### PR TITLE
fix(#4): SWE-bench evaluation harness for baseline vs. constrained comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 results/
 results_mcp/
 results_requests/
+results_swebench/
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# SWE-bench smoke test: baseline vs. constrained mode comparison
+# Runs selected SWE-bench instances in two arms — baseline (all built-in tools)
+# and constrained (Bash+Write only, one-script-per-turn).
+#
+# Usage:
+#   ./run_swebench.sh [problems_file] [runs_per_arm]
+#
+# Defaults:
+#   problems_file = swebench_problems.txt
+#   runs_per_arm  = 1
+#
+# Architecture is parametric: --problems N and --runs-per-arm N flags support
+# future expansion without structural changes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROBLEMS_FILE="${1:-${SCRIPT_DIR}/swebench_problems.txt}"
+RUNS_PER_ARM="${2:-1}"
+RESULTS_DIR="${SCRIPT_DIR}/results_swebench"
+CLONE_BASE="/tmp/swebench"
+
+mkdir -p "$RESULTS_DIR" "$CLONE_BASE"
+
+# Locate claude binary — same approach as run_prevalidation.sh
+CLAUDE="${CLAUDE:-$(command -v claude 2>/dev/null || echo "")}"
+if [[ -z "$CLAUDE" ]]; then
+  # Try VS Code extension path
+  for ext_dir in /home/vscode/.vscode-server/extensions/anthropic.claude-code-*-linux-x64; do
+    candidate="${ext_dir}/resources/native-binary/claude"
+    if [[ -x "$candidate" ]]; then
+      CLAUDE="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$CLAUDE" || ! -x "$CLAUDE" ]]; then
+  echo "ERROR: claude binary not found. Set CLAUDE= or install Claude Code." >&2
+  exit 1
+fi
+
+echo "=== SWE-bench Evaluation: $(date) ===" | tee "$RESULTS_DIR/run.log"
+echo "Problems file: $PROBLEMS_FILE" | tee -a "$RESULTS_DIR/run.log"
+echo "Runs per arm:  $RUNS_PER_ARM" | tee -a "$RESULTS_DIR/run.log"
+echo "Claude binary: $CLAUDE" | tee -a "$RESULTS_DIR/run.log"
+echo "" | tee -a "$RESULTS_DIR/run.log"
+
+# --------------------------------------------------------------------------
+# Helper: run one arm (baseline or constrained) for one instance
+# --------------------------------------------------------------------------
+run_arm() {
+  local INSTANCE="$1"
+  local ARM="$2"
+  local TOOLS_FLAGS="$3"
+  local SYSTEM_PROMPT="$4"
+  local RUN_IDX="$5"
+  local REPO_DIR="$6"
+  local BASE_COMMIT="$7"
+  local TEST_CMD="$8"
+  local PROBLEM_TEXT="$9"
+
+  echo "  [${ARM} run ${RUN_IDX}] Starting..." | tee -a "$RESULTS_DIR/run.log"
+
+  # Reset repo to base commit before each arm run
+  git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet 2>/dev/null
+  git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
+
+  # Isolated Claude config: only credentials, no settings/skills/memories
+  local EVAL_CFG
+  EVAL_CFG=$(mktemp -d /tmp/claude-eval-XXXXXX)
+  if [[ -f ~/.claude/.credentials.json ]]; then
+    cp ~/.claude/.credentials.json "$EVAL_CFG/"
+  fi
+  if [[ -f ~/.claude/.claude.json ]]; then
+    cp ~/.claude/.claude.json "$EVAL_CFG/"
+  fi
+
+  local RESULT_FILE="${RESULTS_DIR}/${INSTANCE}_${ARM}_run${RUN_IDX}.jsonl"
+
+  # Run claude with timing
+  local START_TIME
+  START_TIME=$(date +%s)
+
+  # Build the full prompt including the problem statement and repo path
+  local FULL_PROMPT
+  FULL_PROMPT="You are working in the repository at: ${REPO_DIR}
+
+Fix the following bug. Make the minimal change needed.
+
+${PROBLEM_TEXT}"
+
+  # shellcheck disable=SC2086
+  CLAUDE_CONFIG_DIR="$EVAL_CFG" \
+    "$CLAUDE" -p "$FULL_PROMPT" \
+    --system-prompt "$SYSTEM_PROMPT" \
+    $TOOLS_FLAGS \
+    --dangerously-skip-permissions \
+    --no-session-persistence \
+    --output-format stream-json \
+    --verbose \
+    > "$RESULT_FILE" 2>&1 || true
+
+  local END_TIME
+  END_TIME=$(date +%s)
+  local WALL_SECS=$(( END_TIME - START_TIME ))
+
+  rm -rf "$EVAL_CFG"
+
+  # Run the test suite to get pass/fail verdict
+  local TEST_RESULT_FILE="${RESULTS_DIR}/${INSTANCE}_${ARM}_run${RUN_IDX}_test.txt"
+
+  echo "  [${ARM} run ${RUN_IDX}] Running test suite..." | tee -a "$RESULTS_DIR/run.log"
+
+  # Run test command from the repo dir using the venv python
+  local VENV_DIR="${REPO_DIR}/.venv"
+  (
+    cd "$REPO_DIR"
+    # TEST_CMD starts with "python ..." — replace with venv python
+    local VENV_TEST_CMD="${TEST_CMD/python/${VENV_DIR}/bin/python}"
+    # shellcheck disable=SC2086
+    if $VENV_TEST_CMD > "$TEST_RESULT_FILE" 2>&1; then
+      echo "PASS" >> "$TEST_RESULT_FILE"
+      echo "  [${ARM} run ${RUN_IDX}] Tests: PASS (${WALL_SECS}s wall)" | tee -a "$RESULTS_DIR/run.log"
+    else
+      echo "FAIL" >> "$TEST_RESULT_FILE"
+      echo "  [${ARM} run ${RUN_IDX}] Tests: FAIL (${WALL_SECS}s wall)" | tee -a "$RESULTS_DIR/run.log"
+    fi
+  )
+
+  # Extract cost and turns from stream-json output
+  local COST TURNS
+  COST=$(grep -o '"total_cost_usd":[0-9.]*' "$RESULT_FILE" 2>/dev/null | tail -1 | cut -d: -f2 || echo "N/A")
+  TURNS=$(grep -o '"num_turns":[0-9]*' "$RESULT_FILE" 2>/dev/null | tail -1 | cut -d: -f2 || echo "N/A")
+
+  echo "  [${ARM} run ${RUN_IDX}] Cost: \$${COST}, Turns: ${TURNS}, Wall: ${WALL_SECS}s" \
+    | tee -a "$RESULTS_DIR/run.log"
+}
+
+# --------------------------------------------------------------------------
+# Main loop: iterate over problems
+# --------------------------------------------------------------------------
+while IFS=$'\t ' read -r INSTANCE BASE_COMMIT REPO_SLUG TEST_CMD_REST || [[ -n "$INSTANCE" ]]; do
+  # Skip comments and blank lines
+  [[ "$INSTANCE" =~ ^#.*$ || -z "$INSTANCE" ]] && continue
+
+  # TEST_CMD_REST may contain spaces — reassemble from the 4th field onward
+  # Re-read the line to get the full test command
+  TEST_CMD="$TEST_CMD_REST"
+
+  echo "--- Instance: $INSTANCE ---" | tee -a "$RESULTS_DIR/run.log"
+  echo "  Repo: $REPO_SLUG" | tee -a "$RESULTS_DIR/run.log"
+  echo "  Base commit: $BASE_COMMIT" | tee -a "$RESULTS_DIR/run.log"
+  echo "  Test cmd: $TEST_CMD" | tee -a "$RESULTS_DIR/run.log"
+
+  REPO_DIR="${CLONE_BASE}/${INSTANCE}"
+
+  # --- Clone repo at base commit ---
+  if [[ ! -d "$REPO_DIR/.git" ]]; then
+    echo "  Cloning ${REPO_SLUG}..." | tee -a "$RESULTS_DIR/run.log"
+    gh repo clone "${REPO_SLUG}" "$REPO_DIR" -- --quiet 2>&1 \
+      | tee -a "$RESULTS_DIR/run.log" || true
+  fi
+
+  git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet
+
+  # --- Set up venv once per instance ---
+  VENV_DIR="${REPO_DIR}/.venv"
+  if [[ ! -d "$VENV_DIR" ]]; then
+    echo "  Setting up venv..." | tee -a "$RESULTS_DIR/run.log"
+    python3.11 -m venv "$VENV_DIR"
+    # Install the project in editable mode
+    "${VENV_DIR}/bin/pip" install --quiet -e "${REPO_DIR}" 2>&1 \
+      | tee -a "$RESULTS_DIR/run.log" || true
+  fi
+
+  # --- Build the problem statement ---
+  # TODO: When scaling to 20 problems, fetch problem_statement from SWE-bench
+  # dataset via: python3 -c "from datasets import load_dataset; ..."
+  # For the smoke test, the problem statement is hardcoded for the single instance.
+  PROBLEM_TEXT="Instance: ${INSTANCE}
+Repository: ${REPO_SLUG} at commit ${BASE_COMMIT}
+
+Bug: FileBasedCache.has_key() is susceptible to race conditions.
+The has_key method checks os.path.exists(fname) then opens the file,
+but between the exists() check and open(), the file can be deleted
+(e.g., by another thread calling _is_expired() which deletes expired files).
+This causes FileNotFoundError.
+
+The fix should wrap the open() call in a try/except FileNotFoundError
+to handle the race condition gracefully (EAFP pattern)."
+
+  # --- Run both arms ---
+  for RUN in $(seq 1 "$RUNS_PER_ARM"); do
+    echo "" | tee -a "$RESULTS_DIR/run.log"
+
+    # Baseline arm: all default tools
+    run_arm "$INSTANCE" "baseline" "" \
+      "You are a helpful assistant." \
+      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT"
+
+    # Reset before constrained arm
+    git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet 2>/dev/null
+    git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
+
+    # Constrained arm: Bash+Write only, one-script-per-turn
+    run_arm "$INSTANCE" "constrained" "--tools Bash,Write" \
+      "You are a helpful assistant. CONSTRAINT: solve each task by writing one complete script per turn." \
+      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT"
+  done
+
+  echo "" | tee -a "$RESULTS_DIR/run.log"
+done < "$PROBLEMS_FILE"
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo "=== Done. Results in ${RESULTS_DIR}/ ===" | tee -a "$RESULTS_DIR/run.log"
+echo ""
+echo "Result files per instance per arm:"
+echo "  *_baseline_run*.jsonl   — stream-json output from baseline arm"
+echo "  *_constrained_run*.jsonl — stream-json output from constrained arm"
+echo "  *_test.txt              — test suite output + PASS/FAIL verdict"
+echo ""
+echo "To generate summary: review *_test.txt files for PASS/FAIL verdicts,"
+echo "and grep for total_cost_usd / num_turns in the .jsonl files."

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -10,14 +10,18 @@
 #   problems_file = swebench_problems.txt
 #   runs_per_arm  = 1
 #
-# Architecture is parametric: --problems N and --runs-per-arm N flags support
-# future expansion without structural changes.
+# Architecture is parametric: positional parameters support future expansion
+# without structural changes.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROBLEMS_FILE="${1:-${SCRIPT_DIR}/swebench_problems.txt}"
 RUNS_PER_ARM="${2:-1}"
+if [[ ! "$RUNS_PER_ARM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: runs_per_arm must be a positive integer, got: '$RUNS_PER_ARM'" >&2
+  exit 1
+fi
 RESULTS_DIR="${SCRIPT_DIR}/results_swebench"
 CLONE_BASE="/tmp/swebench"
 

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -179,6 +179,13 @@ while IFS=$'\t ' read -r INSTANCE BASE_COMMIT REPO_SLUG TEST_CMD_REST || [[ -n "
   # TODO: When scaling to 20 problems, fetch problem_statement from SWE-bench
   # dataset via: python3 -c "from datasets import load_dataset; ..."
   # For the smoke test, the problem statement is hardcoded for the single instance.
+  if [[ "$INSTANCE" != "django__django-16379" ]]; then
+    echo "  WARNING: PROBLEM_TEXT is hardcoded for django__django-16379." >&2
+    echo "           Results for ${INSTANCE} may be invalid." >&2
+    echo "           Implement dynamic problem_statement fetching (see TODO above)." >&2
+    echo "  WARNING: PROBLEM_TEXT hardcoded — ${INSTANCE} results may be invalid" \
+      | tee -a "$RESULTS_DIR/run.log"
+  fi
   PROBLEM_TEXT="Instance: ${INSTANCE}
 Repository: ${REPO_SLUG} at commit ${BASE_COMMIT}
 

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -117,8 +117,8 @@ ${PROBLEM_TEXT}"
   local VENV_DIR="${REPO_DIR}/.venv"
   (
     cd "$REPO_DIR"
-    # TEST_CMD starts with "python ..." — replace with venv python
-    local VENV_TEST_CMD="${TEST_CMD/python/${VENV_DIR}/bin/python}"
+    # TEST_CMD starts with "python ..." — replace leading python with venv python
+    local VENV_TEST_CMD="${TEST_CMD/#python/${VENV_DIR}/bin/python}"
     # shellcheck disable=SC2086
     if $VENV_TEST_CMD > "$TEST_RESULT_FILE" 2>&1; then
       echo "PASS" >> "$TEST_RESULT_FILE"

--- a/swebench_problems.txt
+++ b/swebench_problems.txt
@@ -1,0 +1,10 @@
+# SWE-bench problem list for smoke test
+# Format: instance_id  base_commit  repo  test_cmd
+#
+# Fields are whitespace-separated. The test_cmd is everything after the 3rd field.
+# The harness runs: <venv>/bin/<test_cmd> from within the repo directory.
+#
+# Start with 1 exercise to validate the harness before scaling to 20.
+# Additional instances from the issue can be added once the smoke test passes.
+
+django__django-16379  1d0fa848e084cad62d0bb6bde3b51e4862558e57  django/django  python tests/runtests.py cache.tests.FileBasedCacheTests.test_has_key_race_handling cache.tests.FileBasedCachePathLibTests.test_has_key_race_handling --parallel=1


### PR DESCRIPTION
Closes #4

## What changed

Added a SWE-bench evaluation harness (`run_swebench.sh`) and problem list (`swebench_problems.txt`) that runs SWE-bench instances in both baseline (all built-in tools) and constrained (Bash+Write only, one-script-per-turn) arms. The harness follows the existing `run_prevalidation.sh` pattern and incorporates all decisions from the issue discussion: native clone (no Docker), isolated Claude config for neutral evaluation, and parametric architecture for future expansion.

## Implementation walkthrough

### New files

- **`run_swebench.sh`** -- Main harness script. Accepts `PROBLEMS_FILE` and `RUNS_PER_ARM` parameters (defaults: `swebench_problems.txt`, 1). For each problem instance: clones the repo at the specified base commit, sets up a Python 3.11 venv, then runs both arms sequentially. Each `claude -p` invocation uses a throwaway config directory containing only OAuth credentials (no settings, skills, or memories), ensuring neutral evaluation. After each arm completes, the instance's test suite runs to produce a pass/fail verdict. Metrics captured: wall-clock time, `total_cost_usd`, `num_turns` (from stream-json), and test suite result.

- **`swebench_problems.txt`** -- Whitespace-separated problem list. Format: `instance_id  base_commit  repo  test_cmd`. Ships with one smoke-test instance: `django__django-16379` (FileBasedCache TOCTOU race condition, ~3 lines to fix, fast test suite).

### Default execution path

`./run_swebench.sh` reads `swebench_problems.txt`, clones `django/django` at commit `1d0fa84`, creates a venv, then runs:

1. **Baseline arm**: `claude -p` with all default tools, neutral system prompt
2. **Reset**: `git checkout --force` back to base commit
3. **Constrained arm**: `claude -p` with `--tools Bash,Write` and one-script-per-turn constraint
4. **Test**: `python tests/runtests.py` with the FAIL_TO_PASS test cases for each arm

Results land in `results_swebench/` (gitignored).

### Isolated Claude config (from issue spec)

Each `claude -p` call creates a fresh `mktemp -d` with only `.credentials.json` and `.claude.json` copied from `~/.claude/`. This eliminates `effortLevel: max`, model overrides, custom skills, and memories from evaluation runs. The temp dir is cleaned up after each invocation.

## Tier / approach

Tier 1 -- Planner -> Coder -> Reviewer

## Acceptance criteria

- [x] `swebench_problems.txt` contains correct instance ID, base commit, repo, and test command for `django__django-16379`
- [x] `run_swebench.sh` is executable and follows the Final Implementation Spec
- [x] Harness accepts `PROBLEMS_FILE` and `RUNS_PER_ARM` parameters
- [x] Each `claude -p` invocation uses an isolated config dir
- [x] Both arms (baseline and constrained) run with correct flags
- [x] Test suite results captured per run
- [x] `results_swebench/` is gitignored

## Outstanding items

- Problem statement is hardcoded for the single smoke-test instance (`django__django-16379`). When scaling to the full 20-problem suite, the harness should fetch `problem_statement` from the SWE-bench dataset dynamically (marked with TODO in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)