### PR TITLE
fix(#4): switch constrained arm to onlycode (MCP execute_code), adopt SWE-bench test-patch methodology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 results/
 results_mcp/
 results_requests/
+results_swebench/
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/patches/django__django-16379_tests.patch
+++ b/patches/django__django-16379_tests.patch
@@ -1,0 +1,17 @@
+diff --git a/tests/cache/tests.py b/tests/cache/tests.py
+index 937a55acc5..c4d4522514 100644
+--- a/tests/cache/tests.py
++++ b/tests/cache/tests.py
+@@ -1762,6 +1762,12 @@ class FileBasedCacheTests(BaseCacheTests, TestCase):
+         with open(cache_file, "rb") as fh:
+             self.assertIs(cache._is_expired(fh), True)
+ 
++    def test_has_key_race_handling(self):
++        self.assertIs(cache.add("key", "value"), True)
++        with mock.patch("builtins.open", side_effect=FileNotFoundError) as mocked_open:
++            self.assertIs(cache.has_key("key"), False)
++            mocked_open.assert_called_once()
++
+ 
+ @unittest.skipUnless(RedisCache_params, "Redis backend not configured")
+ @override_settings(

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# SWE-bench smoke test: baseline vs. constrained mode comparison
+# Runs selected SWE-bench instances in two arms — baseline (all built-in tools)
+# and constrained (Bash+Write only, one-script-per-turn).
+#
+# Usage:
+#   ./run_swebench.sh [problems_file] [runs_per_arm]
+#
+# Defaults:
+#   problems_file = swebench_problems.txt
+#   runs_per_arm  = 1
+#
+# Architecture is parametric: --problems N and --runs-per-arm N flags support
+# future expansion without structural changes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROBLEMS_FILE="${1:-${SCRIPT_DIR}/swebench_problems.txt}"
+RUNS_PER_ARM="${2:-1}"
+RESULTS_DIR="${SCRIPT_DIR}/results_swebench"
+CLONE_BASE="/tmp/swebench"
+
+mkdir -p "$RESULTS_DIR" "$CLONE_BASE"
+
+# Locate claude binary — same approach as run_prevalidation.sh
+CLAUDE="${CLAUDE:-$(command -v claude 2>/dev/null || echo "")}"
+if [[ -z "$CLAUDE" ]]; then
+  # Try VS Code extension path
+  for ext_dir in /home/vscode/.vscode-server/extensions/anthropic.claude-code-*-linux-x64; do
+    candidate="${ext_dir}/resources/native-binary/claude"
+    if [[ -x "$candidate" ]]; then
+      CLAUDE="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$CLAUDE" || ! -x "$CLAUDE" ]]; then
+  echo "ERROR: claude binary not found. Set CLAUDE= or install Claude Code." >&2
+  exit 1
+fi
+
+echo "=== SWE-bench Evaluation: $(date) ===" | tee "$RESULTS_DIR/run.log"
+echo "Problems file: $PROBLEMS_FILE" | tee -a "$RESULTS_DIR/run.log"
+echo "Runs per arm:  $RUNS_PER_ARM" | tee -a "$RESULTS_DIR/run.log"
+echo "Claude binary: $CLAUDE" | tee -a "$RESULTS_DIR/run.log"
+echo "" | tee -a "$RESULTS_DIR/run.log"
+
+# --------------------------------------------------------------------------
+# Helper: run one arm (baseline or constrained) for one instance
+# --------------------------------------------------------------------------
+run_arm() {
+  local INSTANCE="$1"
+  local ARM="$2"
+  local TOOLS_FLAGS="$3"
+  local SYSTEM_PROMPT="$4"
+  local RUN_IDX="$5"
+  local REPO_DIR="$6"
+  local BASE_COMMIT="$7"
+  local TEST_CMD="$8"
+  local PROBLEM_TEXT="$9"
+
+  echo "  [${ARM} run ${RUN_IDX}] Starting..." | tee -a "$RESULTS_DIR/run.log"
+
+  # Reset repo to base commit before each arm run
+  git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet 2>/dev/null
+  git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
+
+  # Isolated Claude config: only credentials, no settings/skills/memories
+  local EVAL_CFG
+  EVAL_CFG=$(mktemp -d /tmp/claude-eval-XXXXXX)
+  if [[ -f ~/.claude/.credentials.json ]]; then
+    cp ~/.claude/.credentials.json "$EVAL_CFG/"
+  fi
+  if [[ -f ~/.claude/.claude.json ]]; then
+    cp ~/.claude/.claude.json "$EVAL_CFG/"
+  fi
+
+  local RESULT_FILE="${RESULTS_DIR}/${INSTANCE}_${ARM}_run${RUN_IDX}.jsonl"
+
+  # Run claude with timing
+  local START_TIME
+  START_TIME=$(date +%s)
+
+  # Build the full prompt including the problem statement and repo path
+  local FULL_PROMPT
+  FULL_PROMPT="You are working in the repository at: ${REPO_DIR}
+
+Fix the following bug. Make the minimal change needed.
+
+${PROBLEM_TEXT}"
+
+  # shellcheck disable=SC2086
+  CLAUDE_CONFIG_DIR="$EVAL_CFG" \
+    "$CLAUDE" -p "$FULL_PROMPT" \
+    --system-prompt "$SYSTEM_PROMPT" \
+    $TOOLS_FLAGS \
+    --dangerously-skip-permissions \
+    --no-session-persistence \
+    --output-format stream-json \
+    --verbose \
+    > "$RESULT_FILE" 2>&1 || true
+
+  local END_TIME
+  END_TIME=$(date +%s)
+  local WALL_SECS=$(( END_TIME - START_TIME ))
+
+  rm -rf "$EVAL_CFG"
+
+  # Run the test suite to get pass/fail verdict
+  local TEST_RESULT_FILE="${RESULTS_DIR}/${INSTANCE}_${ARM}_run${RUN_IDX}_test.txt"
+
+  echo "  [${ARM} run ${RUN_IDX}] Running test suite..." | tee -a "$RESULTS_DIR/run.log"
+
+  # Run test command from the repo dir using the venv python
+  local VENV_DIR="${REPO_DIR}/.venv"
+  (
+    cd "$REPO_DIR"
+    # TEST_CMD starts with "python ..." — replace with venv python
+    local VENV_TEST_CMD="${TEST_CMD/python/${VENV_DIR}/bin/python}"
+    # shellcheck disable=SC2086
+    if $VENV_TEST_CMD > "$TEST_RESULT_FILE" 2>&1; then
+      echo "PASS" >> "$TEST_RESULT_FILE"
+      echo "  [${ARM} run ${RUN_IDX}] Tests: PASS (${WALL_SECS}s wall)" | tee -a "$RESULTS_DIR/run.log"
+    else
+      echo "FAIL" >> "$TEST_RESULT_FILE"
+      echo "  [${ARM} run ${RUN_IDX}] Tests: FAIL (${WALL_SECS}s wall)" | tee -a "$RESULTS_DIR/run.log"
+    fi
+  )
+
+  # Extract cost and turns from stream-json output
+  local COST TURNS
+  COST=$(grep -o '"total_cost_usd":[0-9.]*' "$RESULT_FILE" 2>/dev/null | tail -1 | cut -d: -f2 || echo "N/A")
+  TURNS=$(grep -o '"num_turns":[0-9]*' "$RESULT_FILE" 2>/dev/null | tail -1 | cut -d: -f2 || echo "N/A")
+
+  echo "  [${ARM} run ${RUN_IDX}] Cost: \$${COST}, Turns: ${TURNS}, Wall: ${WALL_SECS}s" \
+    | tee -a "$RESULTS_DIR/run.log"
+}
+
+# --------------------------------------------------------------------------
+# Main loop: iterate over problems
+# --------------------------------------------------------------------------
+while IFS=$'\t ' read -r INSTANCE BASE_COMMIT REPO_SLUG TEST_CMD_REST || [[ -n "$INSTANCE" ]]; do
+  # Skip comments and blank lines
+  [[ "$INSTANCE" =~ ^#.*$ || -z "$INSTANCE" ]] && continue
+
+  # TEST_CMD_REST may contain spaces — reassemble from the 4th field onward
+  # Re-read the line to get the full test command
+  TEST_CMD="$TEST_CMD_REST"
+
+  echo "--- Instance: $INSTANCE ---" | tee -a "$RESULTS_DIR/run.log"
+  echo "  Repo: $REPO_SLUG" | tee -a "$RESULTS_DIR/run.log"
+  echo "  Base commit: $BASE_COMMIT" | tee -a "$RESULTS_DIR/run.log"
+  echo "  Test cmd: $TEST_CMD" | tee -a "$RESULTS_DIR/run.log"
+
+  REPO_DIR="${CLONE_BASE}/${INSTANCE}"
+
+  # --- Clone repo at base commit ---
+  if [[ ! -d "$REPO_DIR/.git" ]]; then
+    echo "  Cloning ${REPO_SLUG}..." | tee -a "$RESULTS_DIR/run.log"
+    gh repo clone "${REPO_SLUG}" "$REPO_DIR" -- --quiet 2>&1 \
+      | tee -a "$RESULTS_DIR/run.log" || true
+  fi
+
+  git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet
+
+  # --- Set up venv once per instance ---
+  VENV_DIR="${REPO_DIR}/.venv"
+  if [[ ! -d "$VENV_DIR" ]]; then
+    echo "  Setting up venv..." | tee -a "$RESULTS_DIR/run.log"
+    python3.11 -m venv "$VENV_DIR"
+    # Install the project in editable mode
+    "${VENV_DIR}/bin/pip" install --quiet -e "${REPO_DIR}" 2>&1 \
+      | tee -a "$RESULTS_DIR/run.log" || true
+  fi
+
+  # --- Build the problem statement ---
+  # TODO: When scaling to 20 problems, fetch problem_statement from SWE-bench
+  # dataset via: python3 -c "from datasets import load_dataset; ..."
+  # For the smoke test, the problem statement is hardcoded for the single instance.
+  PROBLEM_TEXT="Instance: ${INSTANCE}
+Repository: ${REPO_SLUG} at commit ${BASE_COMMIT}
+
+Bug: FileBasedCache.has_key() is susceptible to race conditions.
+The has_key method checks os.path.exists(fname) then opens the file,
+but between the exists() check and open(), the file can be deleted
+(e.g., by another thread calling _is_expired() which deletes expired files).
+This causes FileNotFoundError.
+
+The fix should wrap the open() call in a try/except FileNotFoundError
+to handle the race condition gracefully (EAFP pattern)."
+
+  # --- Run both arms ---
+  for RUN in $(seq 1 "$RUNS_PER_ARM"); do
+    echo "" | tee -a "$RESULTS_DIR/run.log"
+
+    # Baseline arm: all default tools
+    run_arm "$INSTANCE" "baseline" "" \
+      "You are a helpful assistant." \
+      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT"
+
+    # Reset before constrained arm
+    git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet 2>/dev/null
+    git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
+
+    # Constrained arm: Bash+Write only, one-script-per-turn
+    run_arm "$INSTANCE" "constrained" "--tools Bash,Write" \
+      "You are a helpful assistant. CONSTRAINT: solve each task by writing one complete script per turn." \
+      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT"
+  done
+
+  echo "" | tee -a "$RESULTS_DIR/run.log"
+done < "$PROBLEMS_FILE"
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo "=== Done. Results in ${RESULTS_DIR}/ ===" | tee -a "$RESULTS_DIR/run.log"
+echo ""
+echo "Result files per instance per arm:"
+echo "  *_baseline_run*.jsonl   — stream-json output from baseline arm"
+echo "  *_constrained_run*.jsonl — stream-json output from constrained arm"
+echo "  *_test.txt              — test suite output + PASS/FAIL verdict"
+echo ""
+echo "To generate summary: review *_test.txt files for PASS/FAIL verdicts,"
+echo "and grep for total_cost_usd / num_turns in the .jsonl files."

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -219,6 +219,11 @@ Fix the source code so these tests pass. Do not modify the test files."
 
     # Onlycode arm: MCP execute_code tool only, no built-in tools
     # run_arm() resets the repo to BASE_COMMIT as its first action — no explicit reset needed here.
+    #
+    # NOTE: mcp-config.json sets cwd=/workspaces/hub_1/onlycodes (the harness dir),
+    # not the target repo. The onlycode agent must use absolute paths to work on
+    # REPO_DIR. This is a known evaluation asymmetry; fix by generating per-instance
+    # MCP configs when scaling beyond the smoke test.
     run_arm "$INSTANCE" "onlycode" "--mcp-config ${MCP_CONFIG} --strict-mcp-config --tools mcp__codebox__execute_code" \
       "You are a helpful assistant." \
       "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT" "$VENV_DIR"

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -53,7 +53,7 @@ echo "Claude binary: $CLAUDE" | tee -a "$RESULTS_DIR/run.log"
 echo "" | tee -a "$RESULTS_DIR/run.log"
 
 # --------------------------------------------------------------------------
-# Helper: run one arm (baseline or constrained) for one instance
+# Helper: run one arm (baseline or onlycode) for one instance
 # --------------------------------------------------------------------------
 run_arm() {
   local INSTANCE="$1"
@@ -200,7 +200,7 @@ while IFS=$'\t ' read -r INSTANCE BASE_COMMIT REPO_SLUG TEST_CMD_REST || [[ -n "
     echo "  WARNING: PROBLEM_TEXT hardcoded — ${INSTANCE} results may be invalid" \
       | tee -a "$RESULTS_DIR/run.log"
   fi
-  PROBLEM_TEXT="The following tests are failing in the repository at ${REPO_DIR}:
+  PROBLEM_TEXT="The following tests are failing:
 
   cache.tests.FileBasedCacheTests.test_has_key_race_handling
   cache.tests.FileBasedCachePathLibTests.test_has_key_race_handling
@@ -216,11 +216,8 @@ Fix the source code so these tests pass. Do not modify the test files."
       "You are a helpful assistant." \
       "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT" "$VENV_DIR"
 
-    # Reset before onlycode arm
-    git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet 2>/dev/null
-    git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
-
     # Onlycode arm: MCP execute_code tool only, no built-in tools
+    # run_arm() resets the repo to BASE_COMMIT as its first action — no explicit reset needed here.
     run_arm "$INSTANCE" "onlycode" "--mcp-config ${MCP_CONFIG} --strict-mcp-config --tools mcp__codebox__execute_code" \
       "You are a helpful assistant." \
       "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT" "$VENV_DIR"

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -10,14 +10,18 @@
 #   problems_file = swebench_problems.txt
 #   runs_per_arm  = 1
 #
-# Architecture is parametric: --problems N and --runs-per-arm N flags support
-# future expansion without structural changes.
+# Architecture is parametric: positional parameters support future expansion
+# without structural changes.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROBLEMS_FILE="${1:-${SCRIPT_DIR}/swebench_problems.txt}"
 RUNS_PER_ARM="${2:-1}"
+if [[ ! "$RUNS_PER_ARM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: runs_per_arm must be a positive integer, got: '$RUNS_PER_ARM'" >&2
+  exit 1
+fi
 RESULTS_DIR="${SCRIPT_DIR}/results_swebench"
 CLONE_BASE="/tmp/swebench"
 

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -93,6 +93,15 @@ run_arm() {
 
   local RESULT_FILE="${RESULTS_DIR}/${INSTANCE}_${ARM}_run${RUN_IDX}.jsonl"
 
+  # Generate per-run MCP config with cwd set to the target repo
+  local EFFECTIVE_MCP_CONFIG="$MCP_CONFIG"
+  if [[ -f "$MCP_CONFIG" ]]; then
+    EFFECTIVE_MCP_CONFIG=$(mktemp /tmp/mcp-config-XXXXXX.json)
+    jq --arg cwd "$REPO_DIR" '.mcpServers.codebox.cwd = $cwd' "$MCP_CONFIG" > "$EFFECTIVE_MCP_CONFIG"
+  fi
+  # Replace MCP_CONFIG path in TOOLS_FLAGS with the per-run config
+  local EFFECTIVE_TOOLS_FLAGS="${TOOLS_FLAGS//${MCP_CONFIG}/${EFFECTIVE_MCP_CONFIG}}"
+
   # Run claude with timing
   local START_TIME
   START_TIME=$(date +%s)
@@ -111,7 +120,7 @@ ${PROBLEM_TEXT}"
     --model claude-sonnet-4-6 \
     --cwd "$REPO_DIR" \
     --system-prompt "$SYSTEM_PROMPT" \
-    $TOOLS_FLAGS \
+    $EFFECTIVE_TOOLS_FLAGS \
     --dangerously-skip-permissions \
     --no-session-persistence \
     --output-format stream-json \
@@ -123,6 +132,9 @@ ${PROBLEM_TEXT}"
   local WALL_SECS=$(( END_TIME - START_TIME ))
 
   rm -rf "$EVAL_CFG"
+  if [[ "$EFFECTIVE_MCP_CONFIG" != "$MCP_CONFIG" ]]; then
+    rm -f "$EFFECTIVE_MCP_CONFIG"
+  fi
 
   # Run the test suite to get pass/fail verdict
   local TEST_RESULT_FILE="${RESULTS_DIR}/${INSTANCE}_${ARM}_run${RUN_IDX}_test.txt"
@@ -219,11 +231,8 @@ Fix the source code so these tests pass. Do not modify the test files."
 
     # Onlycode arm: MCP execute_code tool only, no built-in tools
     # run_arm() resets the repo to BASE_COMMIT as its first action — no explicit reset needed here.
-    #
-    # NOTE: mcp-config.json sets cwd=/workspaces/hub_1/onlycodes (the harness dir),
-    # not the target repo. The onlycode agent must use absolute paths to work on
-    # REPO_DIR. This is a known evaluation asymmetry; fix by generating per-instance
-    # MCP configs when scaling beyond the smoke test.
+    # run_arm() generates a per-instance MCP config with cwd=$REPO_DIR so the MCP server
+    # runs in the target repo, matching the baseline arm's working directory.
     run_arm "$INSTANCE" "onlycode" "--mcp-config ${MCP_CONFIG} --strict-mcp-config --tools mcp__codebox__execute_code" \
       "You are a helpful assistant." \
       "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT" "$VENV_DIR"

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# SWE-bench smoke test: baseline vs. constrained mode comparison
+# SWE-bench smoke test: baseline vs. onlycode comparison
 # Runs selected SWE-bench instances in two arms — baseline (all built-in tools)
-# and constrained (Bash+Write only, one-script-per-turn).
+# and onlycode (MCP execute_code tool only, no built-ins).
 #
 # Usage:
 #   ./run_swebench.sh [problems_file] [runs_per_arm]
@@ -24,6 +24,7 @@ if [[ ! "$RUNS_PER_ARM" =~ ^[1-9][0-9]*$ ]]; then
 fi
 RESULTS_DIR="${SCRIPT_DIR}/results_swebench"
 CLONE_BASE="/tmp/swebench"
+MCP_CONFIG="${SCRIPT_DIR}/mcp-config.json"
 
 mkdir -p "$RESULTS_DIR" "$CLONE_BASE"
 
@@ -64,12 +65,21 @@ run_arm() {
   local BASE_COMMIT="$7"
   local TEST_CMD="$8"
   local PROBLEM_TEXT="$9"
+  local VENV_DIR="${10}"
 
   echo "  [${ARM} run ${RUN_IDX}] Starting..." | tee -a "$RESULTS_DIR/run.log"
 
   # Reset repo to base commit before each arm run
   git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet 2>/dev/null
   git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
+
+  # Apply test-only patch (SWE-bench style: agent sees failing tests, must fix implementation)
+  local TEST_PATCH="${SCRIPT_DIR}/patches/${INSTANCE}_tests.patch"
+  if [[ -f "$TEST_PATCH" ]]; then
+    git -C "$REPO_DIR" apply "$TEST_PATCH" 2>/dev/null \
+      && echo "  [${ARM} run ${RUN_IDX}] Applied test patch." | tee -a "$RESULTS_DIR/run.log" \
+      || echo "  [${ARM} run ${RUN_IDX}] WARNING: test patch failed to apply." | tee -a "$RESULTS_DIR/run.log"
+  fi
 
   # Isolated Claude config: only credentials, no settings/skills/memories
   local EVAL_CFG
@@ -98,6 +108,7 @@ ${PROBLEM_TEXT}"
   # shellcheck disable=SC2086
   CLAUDE_CONFIG_DIR="$EVAL_CFG" \
     "$CLAUDE" -p "$FULL_PROMPT" \
+    --model claude-sonnet-4-6 \
     --system-prompt "$SYSTEM_PROMPT" \
     $TOOLS_FLAGS \
     --dangerously-skip-permissions \
@@ -118,7 +129,6 @@ ${PROBLEM_TEXT}"
   echo "  [${ARM} run ${RUN_IDX}] Running test suite..." | tee -a "$RESULTS_DIR/run.log"
 
   # Run test command from the repo dir using the venv python
-  local VENV_DIR="${REPO_DIR}/.venv"
   (
     cd "$REPO_DIR"
     # TEST_CMD starts with "python ..." — replace leading python with venv python
@@ -169,8 +179,8 @@ while IFS=$'\t ' read -r INSTANCE BASE_COMMIT REPO_SLUG TEST_CMD_REST || [[ -n "
 
   git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet
 
-  # --- Set up venv once per instance ---
-  VENV_DIR="${REPO_DIR}/.venv"
+  # --- Set up venv once per instance (outside REPO_DIR so git clean -fd doesn't wipe it) ---
+  VENV_DIR="${CLONE_BASE}/venvs/${INSTANCE}"
   if [[ ! -d "$VENV_DIR" ]]; then
     echo "  Setting up venv..." | tee -a "$RESULTS_DIR/run.log"
     python3.11 -m venv "$VENV_DIR"
@@ -190,17 +200,12 @@ while IFS=$'\t ' read -r INSTANCE BASE_COMMIT REPO_SLUG TEST_CMD_REST || [[ -n "
     echo "  WARNING: PROBLEM_TEXT hardcoded — ${INSTANCE} results may be invalid" \
       | tee -a "$RESULTS_DIR/run.log"
   fi
-  PROBLEM_TEXT="Instance: ${INSTANCE}
-Repository: ${REPO_SLUG} at commit ${BASE_COMMIT}
+  PROBLEM_TEXT="The following tests are failing in the repository at ${REPO_DIR}:
 
-Bug: FileBasedCache.has_key() is susceptible to race conditions.
-The has_key method checks os.path.exists(fname) then opens the file,
-but between the exists() check and open(), the file can be deleted
-(e.g., by another thread calling _is_expired() which deletes expired files).
-This causes FileNotFoundError.
+  cache.tests.FileBasedCacheTests.test_has_key_race_handling
+  cache.tests.FileBasedCachePathLibTests.test_has_key_race_handling
 
-The fix should wrap the open() call in a try/except FileNotFoundError
-to handle the race condition gracefully (EAFP pattern)."
+Fix the source code so these tests pass. Do not modify the test files."
 
   # --- Run both arms ---
   for RUN in $(seq 1 "$RUNS_PER_ARM"); do
@@ -209,16 +214,16 @@ to handle the race condition gracefully (EAFP pattern)."
     # Baseline arm: all default tools
     run_arm "$INSTANCE" "baseline" "" \
       "You are a helpful assistant." \
-      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT"
+      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT" "$VENV_DIR"
 
-    # Reset before constrained arm
+    # Reset before onlycode arm
     git -C "$REPO_DIR" checkout "$BASE_COMMIT" --force --quiet 2>/dev/null
     git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
 
-    # Constrained arm: Bash+Write only, one-script-per-turn
-    run_arm "$INSTANCE" "constrained" "--tools Bash,Write" \
-      "You are a helpful assistant. CONSTRAINT: solve each task by writing one complete script per turn." \
-      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT"
+    # Onlycode arm: MCP execute_code tool only, no built-in tools
+    run_arm "$INSTANCE" "onlycode" "--mcp-config ${MCP_CONFIG} --strict-mcp-config --tools mcp__codebox__execute_code" \
+      "You are a helpful assistant." \
+      "$RUN" "$REPO_DIR" "$BASE_COMMIT" "$TEST_CMD" "$PROBLEM_TEXT" "$VENV_DIR"
   done
 
   echo "" | tee -a "$RESULTS_DIR/run.log"
@@ -231,7 +236,7 @@ echo "=== Done. Results in ${RESULTS_DIR}/ ===" | tee -a "$RESULTS_DIR/run.log"
 echo ""
 echo "Result files per instance per arm:"
 echo "  *_baseline_run*.jsonl   — stream-json output from baseline arm"
-echo "  *_constrained_run*.jsonl — stream-json output from constrained arm"
+echo "  *_onlycode_run*.jsonl   — stream-json output from onlycode arm"
 echo "  *_test.txt              — test suite output + PASS/FAIL verdict"
 echo ""
 echo "To generate summary: review *_test.txt files for PASS/FAIL verdicts,"

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -179,6 +179,13 @@ while IFS=$'\t ' read -r INSTANCE BASE_COMMIT REPO_SLUG TEST_CMD_REST || [[ -n "
   # TODO: When scaling to 20 problems, fetch problem_statement from SWE-bench
   # dataset via: python3 -c "from datasets import load_dataset; ..."
   # For the smoke test, the problem statement is hardcoded for the single instance.
+  if [[ "$INSTANCE" != "django__django-16379" ]]; then
+    echo "  WARNING: PROBLEM_TEXT is hardcoded for django__django-16379." >&2
+    echo "           Results for ${INSTANCE} may be invalid." >&2
+    echo "           Implement dynamic problem_statement fetching (see TODO above)." >&2
+    echo "  WARNING: PROBLEM_TEXT hardcoded — ${INSTANCE} results may be invalid" \
+      | tee -a "$RESULTS_DIR/run.log"
+  fi
   PROBLEM_TEXT="Instance: ${INSTANCE}
 Repository: ${REPO_SLUG} at commit ${BASE_COMMIT}
 

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -109,6 +109,7 @@ ${PROBLEM_TEXT}"
   CLAUDE_CONFIG_DIR="$EVAL_CFG" \
     "$CLAUDE" -p "$FULL_PROMPT" \
     --model claude-sonnet-4-6 \
+    --cwd "$REPO_DIR" \
     --system-prompt "$SYSTEM_PROMPT" \
     $TOOLS_FLAGS \
     --dangerously-skip-permissions \

--- a/run_swebench.sh
+++ b/run_swebench.sh
@@ -117,8 +117,8 @@ ${PROBLEM_TEXT}"
   local VENV_DIR="${REPO_DIR}/.venv"
   (
     cd "$REPO_DIR"
-    # TEST_CMD starts with "python ..." — replace with venv python
-    local VENV_TEST_CMD="${TEST_CMD/python/${VENV_DIR}/bin/python}"
+    # TEST_CMD starts with "python ..." — replace leading python with venv python
+    local VENV_TEST_CMD="${TEST_CMD/#python/${VENV_DIR}/bin/python}"
     # shellcheck disable=SC2086
     if $VENV_TEST_CMD > "$TEST_RESULT_FILE" 2>&1; then
       echo "PASS" >> "$TEST_RESULT_FILE"

--- a/swebench_problems.txt
+++ b/swebench_problems.txt
@@ -6,5 +6,7 @@
 #
 # Start with 1 exercise to validate the harness before scaling to 20.
 # Additional instances from the issue can be added once the smoke test passes.
+#
+# --parallel=1: disables Django's parallel test runner for deterministic evaluation results.
 
 django__django-16379  1d0fa848e084cad62d0bb6bde3b51e4862558e57  django/django  python tests/runtests.py cache.tests.FileBasedCacheTests.test_has_key_race_handling cache.tests.FileBasedCachePathLibTests.test_has_key_race_handling --parallel=1

--- a/swebench_problems.txt
+++ b/swebench_problems.txt
@@ -1,0 +1,10 @@
+# SWE-bench problem list for smoke test
+# Format: instance_id  base_commit  repo  test_cmd
+#
+# Fields are whitespace-separated. The test_cmd is everything after the 3rd field.
+# The harness runs: <venv>/bin/<test_cmd> from within the repo directory.
+#
+# Start with 1 exercise to validate the harness before scaling to 20.
+# Additional instances from the issue can be added once the smoke test passes.
+
+django__django-16379  1d0fa848e084cad62d0bb6bde3b51e4862558e57  django/django  python tests/runtests.py cache.tests.FileBasedCacheTests.test_has_key_race_handling cache.tests.FileBasedCachePathLibTests.test_has_key_race_handling --parallel=1


### PR DESCRIPTION
## Summary

- Replaces the constrained arm (Bash+Write tools only, one-script-per-turn) with an **onlycode arm** that uses only the MCP `execute_code` tool (`--strict-mcp-config`, no built-ins) — a more realistic comparison of code-execution-only vs. full Claude Code
- Adopts **real SWE-bench evaluation methodology**: a test-only patch is applied before each arm so the agent sees failing tests and must fix the implementation (rather than being given a prose description of the bug)
- Fixes a venv-wiping bug: venv is now created outside the repo dir so `git clean -fd` doesn't destroy it between arms
- Adds `--model claude-sonnet-4-6` for consistent, cost-effective evaluation
- Adds `patches/django__django-16379_tests.patch` (test-only portion of the gold patch commit)

## Smoke test results (run 4)

| Arm | Result | Turns | Cost | Wall |
|-----|--------|-------|------|------|
| baseline | PASS | 7 | $0.103 | 28s |
| onlycode | PASS | 8 | $0.121 | 50s |

Both arms solved `django__django-16379` (FileBasedCache TOCTOU race, LBYL→EAFP fix). Onlycode's extra cost was attributed to test-suite verification runs (~$0.018, ~16% of total).

## Test plan

- [x] Smoke test run with single instance (`django__django-16379`) — both arms PASS
- [x] Venv persistence confirmed across arms (no `git clean` wipe)
- [x] Test patch applies cleanly at base commit
- [x] `--model claude-sonnet-4-6` confirmed in invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)