### PR TITLE
feat(#16): passthrough-config.json schema and config loader

### DIFF
--- a/config-loader.js
+++ b/config-loader.js
@@ -1,0 +1,224 @@
+/**
+ * config-loader.js — Validated loader for passthrough-config.json
+ *
+ * Exports:
+ *   - loadConfig(configPath)      Reads, parses, validates the config file.
+ *                                 Returns a normalized object with { subMcpServers, interceptRules }.
+ *                                 Throws an Error with an actionable message on ANY malformation.
+ *   - getBridgeSocketPath()       Returns the Unix domain socket path for the
+ *                                 mcp_bridge <-> bridge-server link. Honors the
+ *                                 ONLYCODES_BRIDGE_SOCK env var; otherwise falls back
+ *                                 to a per-PID default `/tmp/onlycodes-bridge-${pid}.sock`.
+ *                                 (ADR-001 Decision 2 / EPIC_13_ADR.md Decision 2.)
+ *
+ * The shipped config (`passthrough-config.json` at the repo root) is the source of
+ * truth for sub-MCP server definitions and interception rules. The loader fails
+ * fast on malformed input — consumers (interceptor.js, sub-mcp-manager.js,
+ * bridge-server.js) should NOT attempt to recover from a bad config, because
+ * silently running without interception rules is a security regression.
+ *
+ * UDS framing contract (documented here for cross-reference with mcp_bridge.py
+ * and bridge-server.js):
+ *   - Newline-delimited JSON (NDJSON). One JSON object per line, '\n' terminated.
+ *   - UTF-8 on the wire.
+ *   - Senders use JSON.stringify(obj) + '\n' (or json.dumps(obj) + '\n' in Python).
+ *   - Receivers buffer until '\n', strip it, then parse.
+ *   - Standard JSON encoders guarantee no raw '\n' inside payloads.
+ *   - See EPIC_13_ADR.md Decision 1.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, isAbsolute } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONFIG_PATH = join(__dirname, "passthrough-config.json");
+
+const VALID_SURFACES = new Set(["execute_code", "dispatch"]);
+
+/**
+ * Validate a single sub-MCP server entry. Throws with a descriptive message
+ * including the array index on any problem.
+ */
+function validateSubMcpServer(entry, index) {
+  const label = `subMcpServers[${index}]`;
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(
+      `passthrough-config: ${label} must be an object, got ${Array.isArray(entry) ? "array" : typeof entry}`,
+    );
+  }
+  if (typeof entry.name !== "string" || entry.name.length === 0) {
+    throw new Error(
+      `passthrough-config: ${label}.name must be a non-empty string`,
+    );
+  }
+  if (typeof entry.command !== "string" || entry.command.length === 0) {
+    throw new Error(
+      `passthrough-config: ${label}.command must be a non-empty string (server "${entry.name}")`,
+    );
+  }
+  if (!Array.isArray(entry.args)) {
+    throw new Error(
+      `passthrough-config: ${label}.args must be an array (server "${entry.name}")`,
+    );
+  }
+  for (let i = 0; i < entry.args.length; i++) {
+    if (typeof entry.args[i] !== "string") {
+      throw new Error(
+        `passthrough-config: ${label}.args[${i}] must be a string (server "${entry.name}")`,
+      );
+    }
+  }
+  if (!Array.isArray(entry.env)) {
+    throw new Error(
+      `passthrough-config: ${label}.env must be an array of env var NAMES (server "${entry.name}")`,
+    );
+  }
+  for (let i = 0; i < entry.env.length; i++) {
+    if (typeof entry.env[i] !== "string" || entry.env[i].length === 0) {
+      throw new Error(
+        `passthrough-config: ${label}.env[${i}] must be a non-empty string (server "${entry.name}")`,
+      );
+    }
+  }
+}
+
+/**
+ * Validate a single interception rule entry. Throws with a descriptive message
+ * including the array index on any problem.
+ */
+function validateInterceptRule(rule, index) {
+  const label = `interceptRules[${index}]`;
+  if (rule === null || typeof rule !== "object" || Array.isArray(rule)) {
+    throw new Error(
+      `passthrough-config: ${label} must be an object, got ${Array.isArray(rule) ? "array" : typeof rule}`,
+    );
+  }
+  if (typeof rule.surface !== "string" || !VALID_SURFACES.has(rule.surface)) {
+    throw new Error(
+      `passthrough-config: ${label}.surface must be one of ${[...VALID_SURFACES].join(", ")}, got ${JSON.stringify(rule.surface)}`,
+    );
+  }
+  if (typeof rule.message !== "string" || rule.message.length === 0) {
+    throw new Error(
+      `passthrough-config: ${label}.message must be a non-empty string`,
+    );
+  }
+  if (rule.surface === "execute_code") {
+    if (typeof rule.pattern !== "string" || rule.pattern.length === 0) {
+      throw new Error(
+        `passthrough-config: ${label}.pattern must be a non-empty regex string for surface 'execute_code'`,
+      );
+    }
+    // Compile to catch bad regex at load time rather than at first call.
+    try {
+      new RegExp(rule.pattern);
+    } catch (err) {
+      throw new Error(
+        `passthrough-config: ${label}.pattern is not a valid regex: ${err.message}`,
+      );
+    }
+  } else if (rule.surface === "dispatch") {
+    if (typeof rule.tool !== "string" || rule.tool.length === 0) {
+      throw new Error(
+        `passthrough-config: ${label}.tool must be a non-empty string for surface 'dispatch'`,
+      );
+    }
+  }
+}
+
+/**
+ * Load, parse, and validate passthrough-config.json. Fails fast with a clear
+ * message if the file is missing, not valid JSON, or does not match the schema.
+ *
+ * @param {string} [configPath] Absolute or repo-relative path. Defaults to the
+ *   shipped `passthrough-config.json` next to this module.
+ * @returns {{ subMcpServers: Array, interceptRules: Array }} Normalized config
+ *   (the `_schema` documentation field, if present, is stripped).
+ */
+export function loadConfig(configPath = DEFAULT_CONFIG_PATH) {
+  const resolvedPath = isAbsolute(configPath)
+    ? configPath
+    : join(__dirname, configPath);
+
+  let raw;
+  try {
+    raw = readFileSync(resolvedPath, "utf8");
+  } catch (err) {
+    throw new Error(
+      `passthrough-config: failed to read config at ${resolvedPath}: ${err.message}`,
+    );
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `passthrough-config: ${resolvedPath} is not valid JSON: ${err.message}`,
+    );
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `passthrough-config: top-level value at ${resolvedPath} must be a JSON object`,
+    );
+  }
+
+  if (!Array.isArray(parsed.subMcpServers)) {
+    throw new Error(
+      `passthrough-config: 'subMcpServers' must be an array (at ${resolvedPath})`,
+    );
+  }
+  if (!Array.isArray(parsed.interceptRules)) {
+    throw new Error(
+      `passthrough-config: 'interceptRules' must be an array (at ${resolvedPath})`,
+    );
+  }
+
+  const seenNames = new Set();
+  for (let i = 0; i < parsed.subMcpServers.length; i++) {
+    const entry = parsed.subMcpServers[i];
+    validateSubMcpServer(entry, i);
+    if (seenNames.has(entry.name)) {
+      throw new Error(
+        `passthrough-config: duplicate subMcpServers name "${entry.name}" at index ${i}`,
+      );
+    }
+    seenNames.add(entry.name);
+  }
+
+  for (let i = 0; i < parsed.interceptRules.length; i++) {
+    validateInterceptRule(parsed.interceptRules[i], i);
+  }
+
+  return {
+    subMcpServers: parsed.subMcpServers,
+    interceptRules: parsed.interceptRules,
+  };
+}
+
+/**
+ * Return the Unix domain socket path for the bridge link.
+ *
+ * Precedence:
+ *   1. `ONLYCODES_BRIDGE_SOCK` env var, if set (and non-empty).
+ *   2. Per-PID default `/tmp/onlycodes-bridge-${process.pid}.sock`.
+ *
+ * The per-PID default prevents socket collisions when parallel `swebench run`
+ * instances each spawn their own `exec-server.js`. The env-var override is used
+ * by tests (to get a predictable path), by Docker overlays, and — critically —
+ * by `exec-server.js` to propagate the same path into every `execute_code`
+ * subprocess so `mcp_bridge.py` can connect to the right bridge.
+ *
+ * See EPIC_13_ADR.md Decision 2.
+ *
+ * @returns {string} Absolute socket path.
+ */
+export function getBridgeSocketPath() {
+  const fromEnv = process.env.ONLYCODES_BRIDGE_SOCK;
+  if (typeof fromEnv === "string" && fromEnv.length > 0) {
+    return fromEnv;
+  }
+  return `/tmp/onlycodes-bridge-${process.pid}.sock`;
+}

--- a/passthrough-config.json
+++ b/passthrough-config.json
@@ -1,0 +1,32 @@
+{
+  "_schema": {
+    "description": "Passthrough MCP configuration for the onlycodes exec-server. Defines sub-MCP servers to manage as stdio child processes and interception rules for content-scan (execute_code) and dispatch (tool-call) deny-lists. See EPIC_13_DECOMPOSITION.md and EPIC_13_ADR.md for the full design.",
+    "fields": {
+      "subMcpServers": "Array of sub-MCP server definitions. Each has: name (string, unique key used by mcp_bridge.call), command (string, executable to spawn), args (array of strings), env (array of env var NAMES to pass through from the main process — values pulled from the main process env at spawn time).",
+      "interceptRules": "Array of interception rules. Each has: surface ('execute_code' for content scan or 'dispatch' for tool-call deny), pattern (regex string, only for surface='execute_code'), tool (tool name string, only for surface='dispatch'), message (error string returned to caller when the rule fires). Each rule MUST have a message, and exactly one of pattern (for execute_code) or tool (for dispatch)."
+    },
+    "udsFramingContract": "The Unix domain socket bridge between mcp_bridge.py (Python client in execute_code sandbox) and bridge-server.js (Node server in main MCP process) uses newline-delimited JSON (NDJSON). Each message is a single JSON object serialized by json.dumps / JSON.stringify with a trailing '\\n' terminator. UTF-8 on the wire. Receivers buffer until '\\n', strip it, then parse. Senders MUST NOT emit raw newlines inside payloads — this is guaranteed by the standard JSON encoders. ADR: EPIC_13_ADR.md Decision 1.",
+    "socketPathContract": "The bridge socket path is environmental, NOT a field in this config. exec-server.js computes it as: process.env.ONLYCODES_BRIDGE_SOCK || `/tmp/onlycodes-bridge-${process.pid}.sock`. Per-PID default prevents collisions when swebench run launches parallel exec-server instances. exec-server.js exports ONLYCODES_BRIDGE_SOCK into the env passed to every execute_code subprocess so mcp_bridge.py can find the socket. bridge-server.js reads the same env var. ADR: EPIC_13_ADR.md Decision 2.",
+    "addingRules": "Adding a new interception rule or a new sub-MCP server is a JSON-only change — no code edits required. The loader (config-loader.js) and interceptor (interceptor.js) pull rules dynamically from this file at startup."
+  },
+  "subMcpServers": [
+    {
+      "name": "github",
+      "command": "npx",
+      "args": ["-y", "@github/mcp"],
+      "env": ["GITHUB_TOKEN"]
+    }
+  ],
+  "interceptRules": [
+    {
+      "surface": "execute_code",
+      "pattern": "\\bgh\\b",
+      "message": "Direct use of the 'gh' CLI is not permitted inside execute_code. Use mcp_bridge.call(\"github\", ...) from Python instead. See list_tools for available GitHub sub-MCP tools."
+    },
+    {
+      "surface": "dispatch",
+      "tool": "delete_repo",
+      "message": "The 'delete_repo' tool is blocked by the interception layer. Repository deletion is considered irreversible and is denied at the dispatch boundary."
+    }
+  ]
+}

--- a/test/test-config-loader.js
+++ b/test/test-config-loader.js
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for config-loader.js
+ *
+ * Run: node --test test/test-config-loader.js
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadConfig, getBridgeSocketPath } from "../config-loader.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const SHIPPED_CONFIG = join(REPO_ROOT, "passthrough-config.json");
+
+/**
+ * Create a temp dir with a named config file containing the given JSON.
+ * Returns { dir, path, cleanup }.
+ */
+function mkTempConfig(content) {
+  const dir = mkdtempSync(join(tmpdir(), "onlycodes-config-test-"));
+  const path = join(dir, "passthrough-config.json");
+  writeFileSync(path, content);
+  return {
+    dir,
+    path,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// --- Shipped config ------------------------------------------------------
+
+test("loadConfig: shipped passthrough-config.json loads without error", () => {
+  const cfg = loadConfig(SHIPPED_CONFIG);
+  assert.ok(Array.isArray(cfg.subMcpServers), "subMcpServers is an array");
+  assert.ok(Array.isArray(cfg.interceptRules), "interceptRules is an array");
+});
+
+test("loadConfig: default path (no argument) resolves to shipped config", () => {
+  const cfg = loadConfig();
+  assert.ok(Array.isArray(cfg.subMcpServers));
+  assert.ok(Array.isArray(cfg.interceptRules));
+});
+
+test("shipped config: contains github sub-MCP entry", () => {
+  const cfg = loadConfig(SHIPPED_CONFIG);
+  const github = cfg.subMcpServers.find((s) => s.name === "github");
+  assert.ok(github, "github sub-MCP entry present");
+  assert.equal(typeof github.command, "string");
+  assert.ok(Array.isArray(github.args));
+  assert.ok(Array.isArray(github.env));
+  assert.ok(
+    github.env.includes("GITHUB_TOKEN"),
+    "github entry declares GITHUB_TOKEN in env passthrough list",
+  );
+});
+
+test("shipped config: baseline \\bgh\\b content-scan deny rule present", () => {
+  const cfg = loadConfig(SHIPPED_CONFIG);
+  const ghRule = cfg.interceptRules.find(
+    (r) => r.surface === "execute_code" && r.pattern === "\\bgh\\b",
+  );
+  assert.ok(ghRule, "\\bgh\\b content-scan deny rule present");
+  assert.ok(
+    typeof ghRule.message === "string" && ghRule.message.length > 0,
+    "gh deny rule has a non-empty message",
+  );
+});
+
+test("shipped config: baseline delete_repo dispatch deny rule present", () => {
+  const cfg = loadConfig(SHIPPED_CONFIG);
+  const delRule = cfg.interceptRules.find(
+    (r) => r.surface === "dispatch" && r.tool === "delete_repo",
+  );
+  assert.ok(delRule, "delete_repo dispatch deny rule present");
+  assert.ok(
+    typeof delRule.message === "string" && delRule.message.length > 0,
+    "delete_repo deny rule has a non-empty message",
+  );
+});
+
+// --- Malformed inputs ----------------------------------------------------
+
+test("loadConfig: missing file throws actionable message", () => {
+  assert.throws(
+    () => loadConfig("/tmp/onlycodes-nonexistent-config-xyz.json"),
+    /failed to read config/,
+  );
+});
+
+test("loadConfig: invalid JSON throws with 'not valid JSON'", () => {
+  const t = mkTempConfig("{ this is not json ");
+  try {
+    assert.throws(() => loadConfig(t.path), /not valid JSON/);
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: top-level array is rejected", () => {
+  const t = mkTempConfig("[]");
+  try {
+    assert.throws(() => loadConfig(t.path), /must be a JSON object/);
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: missing subMcpServers throws", () => {
+  const t = mkTempConfig(JSON.stringify({ interceptRules: [] }));
+  try {
+    assert.throws(() => loadConfig(t.path), /'subMcpServers' must be an array/);
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: missing interceptRules throws", () => {
+  const t = mkTempConfig(JSON.stringify({ subMcpServers: [] }));
+  try {
+    assert.throws(
+      () => loadConfig(t.path),
+      /'interceptRules' must be an array/,
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: sub-MCP server missing name throws with field path", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [{ command: "echo", args: [], env: [] }],
+      interceptRules: [],
+    }),
+  );
+  try {
+    assert.throws(
+      () => loadConfig(t.path),
+      /subMcpServers\[0\]\.name must be a non-empty string/,
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: sub-MCP server with non-array args throws", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [
+        { name: "x", command: "echo", args: "not-an-array", env: [] },
+      ],
+      interceptRules: [],
+    }),
+  );
+  try {
+    assert.throws(
+      () => loadConfig(t.path),
+      /subMcpServers\[0\]\.args must be an array/,
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: duplicate sub-MCP server names throws", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [
+        { name: "dup", command: "echo", args: [], env: [] },
+        { name: "dup", command: "echo", args: [], env: [] },
+      ],
+      interceptRules: [],
+    }),
+  );
+  try {
+    assert.throws(
+      () => loadConfig(t.path),
+      /duplicate subMcpServers name "dup"/,
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: intercept rule with bad surface throws", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [],
+      interceptRules: [{ surface: "nope", message: "x", pattern: "y" }],
+    }),
+  );
+  try {
+    assert.throws(() => loadConfig(t.path), /\.surface must be one of/);
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: execute_code rule missing pattern throws", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [],
+      interceptRules: [{ surface: "execute_code", message: "x" }],
+    }),
+  );
+  try {
+    assert.throws(
+      () => loadConfig(t.path),
+      /\.pattern must be a non-empty regex string/,
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: execute_code rule with invalid regex throws", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [],
+      interceptRules: [
+        { surface: "execute_code", pattern: "([unclosed", message: "x" },
+      ],
+    }),
+  );
+  try {
+    assert.throws(() => loadConfig(t.path), /is not a valid regex/);
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: dispatch rule missing tool throws", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [],
+      interceptRules: [{ surface: "dispatch", message: "x" }],
+    }),
+  );
+  try {
+    assert.throws(
+      () => loadConfig(t.path),
+      /\.tool must be a non-empty string/,
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("loadConfig: intercept rule missing message throws", () => {
+  const t = mkTempConfig(
+    JSON.stringify({
+      subMcpServers: [],
+      interceptRules: [{ surface: "dispatch", tool: "x" }],
+    }),
+  );
+  try {
+    assert.throws(
+      () => loadConfig(t.path),
+      /\.message must be a non-empty string/,
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+// --- getBridgeSocketPath -------------------------------------------------
+
+test("getBridgeSocketPath: returns ONLYCODES_BRIDGE_SOCK when set", () => {
+  const prev = process.env.ONLYCODES_BRIDGE_SOCK;
+  try {
+    process.env.ONLYCODES_BRIDGE_SOCK = "/tmp/custom-test.sock";
+    assert.equal(getBridgeSocketPath(), "/tmp/custom-test.sock");
+  } finally {
+    if (prev === undefined) delete process.env.ONLYCODES_BRIDGE_SOCK;
+    else process.env.ONLYCODES_BRIDGE_SOCK = prev;
+  }
+});
+
+test("getBridgeSocketPath: per-PID default when env var unset", () => {
+  const prev = process.env.ONLYCODES_BRIDGE_SOCK;
+  try {
+    delete process.env.ONLYCODES_BRIDGE_SOCK;
+    const expected = `/tmp/onlycodes-bridge-${process.pid}.sock`;
+    assert.equal(getBridgeSocketPath(), expected);
+  } finally {
+    if (prev !== undefined) process.env.ONLYCODES_BRIDGE_SOCK = prev;
+  }
+});
+
+test("getBridgeSocketPath: per-PID default when env var is empty string", () => {
+  const prev = process.env.ONLYCODES_BRIDGE_SOCK;
+  try {
+    process.env.ONLYCODES_BRIDGE_SOCK = "";
+    const expected = `/tmp/onlycodes-bridge-${process.pid}.sock`;
+    assert.equal(getBridgeSocketPath(), expected);
+  } finally {
+    if (prev === undefined) delete process.env.ONLYCODES_BRIDGE_SOCK;
+    else process.env.ONLYCODES_BRIDGE_SOCK = prev;
+  }
+});


### PR DESCRIPTION
Closes #16
Part of epic #13

## Changes
- `passthrough-config.json`: sub-MCP server definitions and interception rules schema, with inline `_schema` documentation covering the UDS framing contract (NDJSON) and the `ONLYCODES_BRIDGE_SOCK` env-var contract
- `config-loader.js`: validated config loader with fast-fail; exports `loadConfig()` and `getBridgeSocketPath()`
- `getBridgeSocketPath()`: returns `ONLYCODES_BRIDGE_SOCK` env var or per-PID default `/tmp/onlycodes-bridge-${pid}.sock` (ADR Decision 2)
- `test/test-config-loader.js`: 21 unit tests covering shipped config, malformed input paths, duplicate names, invalid regex, and socket-path resolution

## ADR Decisions Applied
- Decision 1: UDS framing pinned to newline-delimited JSON — documented in `passthrough-config.json` `_schema.udsFramingContract` and in the `config-loader.js` header
- Decision 2: per-PID socket path via `ONLYCODES_BRIDGE_SOCK` env var — implemented in `getBridgeSocketPath()`

## Test Results
- `node --test test/test-config-loader.js` — 21 pass, 0 fail
- `node test/test-server.js` — 36 pass, 0 fail (existing tests unaffected)