### PR TITLE
feat(#14): interceptor.js — content-scan and dispatch deny-list

### DIFF
--- a/interceptor.js
+++ b/interceptor.js
@@ -1,0 +1,88 @@
+/**
+ * interceptor.js — Config-driven middleware chain for deny-list enforcement
+ *
+ * Enforces rules on two surfaces:
+ *   1. execute_code content scanning: regex deny-list on bash/python source
+ *   2. sub-MCP dispatch: tool-name deny-list before forwarding to sub-MCP manager
+ *
+ * Rules are loaded from passthrough-config.json via config-loader.js.
+ * Adding or modifying rules requires only a JSON change — no code edits.
+ *
+ * Exports:
+ *   checkContent(code)         Check execute_code source against the deny-list.
+ *                              Returns null if allowed, or { blocked: true, message: string } if denied.
+ *   checkDispatch(toolName)    Check a sub-MCP tool dispatch against the deny-list.
+ *                              Returns null if allowed, or { blocked: true, message: string } if denied.
+ */
+
+import { loadConfig } from "./config-loader.js";
+
+let _rules = null;
+
+/**
+ * Load and cache the interception rules from passthrough-config.json.
+ * On first call, the config is read and validated; subsequent calls use the cache.
+ *
+ * @param {string} [configPath] Optional path override (used by tests).
+ * @returns {Array} The interceptRules array from the config.
+ */
+function getRules(configPath = undefined) {
+  if (!_rules) {
+    const config = configPath ? loadConfig(configPath) : loadConfig();
+    _rules = config.interceptRules;
+  }
+  return _rules;
+}
+
+/**
+ * Reset the cached rules. Exposed for testing so tests can inject a custom
+ * config path on each test without stale state leaking between test cases.
+ */
+export function _resetRulesCache() {
+  _rules = null;
+}
+
+/**
+ * Check execute_code source code against the content-scan deny-list.
+ *
+ * Each rule with surface === 'execute_code' has a `pattern` (regex string).
+ * The rules are checked in order; the first match wins.
+ *
+ * @param {string} code  The script source to check.
+ * @param {string} [configPath]  Optional config path override (for tests).
+ * @returns {null | { blocked: true, message: string }}
+ *   null if the code is allowed; a blocked-result object if a rule fires.
+ */
+export function checkContent(code, configPath = undefined) {
+  const rules = getRules(configPath).filter(
+    (r) => r.surface === "execute_code",
+  );
+  for (const rule of rules) {
+    const regex = new RegExp(rule.pattern);
+    if (regex.test(code)) {
+      return { blocked: true, message: rule.message };
+    }
+  }
+  return null;
+}
+
+/**
+ * Check a sub-MCP tool dispatch against the dispatch deny-list.
+ *
+ * Each rule with surface === 'dispatch' has a `tool` (exact tool name string).
+ * The rules are checked in order; the first match wins.
+ *
+ * @param {string} toolName  The tool name about to be dispatched.
+ * @param {string} [configPath]  Optional config path override (for tests).
+ * @returns {null | { blocked: true, message: string }}
+ *   null if the dispatch is allowed; a blocked-result object if a rule fires.
+ */
+export function checkDispatch(toolName, configPath = undefined) {
+  const rules = getRules(configPath).filter((r) => r.surface === "dispatch");
+  for (const rule of rules) {
+    if (rule.tool === toolName) {
+      return { blocked: true, message: rule.message };
+    }
+  }
+  return null;
+}

--- a/test/test-interceptor.js
+++ b/test/test-interceptor.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for interceptor.js
+ *
+ * Run: node --test test/test-interceptor.js
+ */
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  checkContent,
+  checkDispatch,
+  _resetRulesCache,
+} from "../interceptor.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const SHIPPED_CONFIG = join(REPO_ROOT, "passthrough-config.json");
+
+// Reset cached rules before each test so config-path overrides work cleanly.
+beforeEach(() => {
+  _resetRulesCache();
+});
+
+// --- checkContent: surface = execute_code --------------------------------
+
+test("checkContent: blocks bash code containing 'gh ' (gh followed by space)", () => {
+  const result = checkContent("gh status", SHIPPED_CONFIG);
+  assert.ok(result !== null, "expected a blocked result");
+  assert.equal(result.blocked, true);
+  assert.ok(
+    typeof result.message === "string" && result.message.length > 0,
+    "blocked result has a non-empty message",
+  );
+});
+
+test("checkContent: blocks bash code containing 'gh\\t' (gh followed by tab)", () => {
+  const result = checkContent("gh\tauth status", SHIPPED_CONFIG);
+  assert.ok(result !== null, "expected a blocked result");
+  assert.equal(result.blocked, true);
+});
+
+test("checkContent: blocks bash code where gh is at end of line (word boundary)", () => {
+  const result = checkContent("which gh", SHIPPED_CONFIG);
+  assert.ok(result !== null, "expected a blocked result");
+  assert.equal(result.blocked, true);
+});
+
+test("checkContent: allows bash code that does not contain 'gh'", () => {
+  const result = checkContent("echo hello world", SHIPPED_CONFIG);
+  assert.equal(result, null, "expected null (allowed)");
+});
+
+test("checkContent: allows bash code with 'github' (word boundary — \\bgh\\b must NOT match 'github')", () => {
+  const result = checkContent(
+    "curl https://api.github.com/repos",
+    SHIPPED_CONFIG,
+  );
+  assert.equal(
+    result,
+    null,
+    "expected null (allowed) — 'github' must not trigger the \\bgh\\b rule",
+  );
+});
+
+test("checkContent: allows Python code without 'gh'", () => {
+  const result = checkContent(
+    "import os\nprint(os.getcwd())",
+    SHIPPED_CONFIG,
+  );
+  assert.equal(result, null);
+});
+
+test("checkContent: blocked result contains a message string", () => {
+  const result = checkContent("gh pr list", SHIPPED_CONFIG);
+  assert.ok(result !== null);
+  assert.ok(
+    typeof result.message === "string",
+    "message must be a string",
+  );
+  assert.ok(result.message.length > 0, "message must be non-empty");
+});
+
+// --- checkDispatch: surface = dispatch -----------------------------------
+
+test("checkDispatch: blocks 'delete_repo'", () => {
+  const result = checkDispatch("delete_repo", SHIPPED_CONFIG);
+  assert.ok(result !== null, "expected a blocked result");
+  assert.equal(result.blocked, true);
+  assert.ok(
+    typeof result.message === "string" && result.message.length > 0,
+    "blocked result has a non-empty message",
+  );
+});
+
+test("checkDispatch: allows 'create_pr'", () => {
+  const result = checkDispatch("create_pr", SHIPPED_CONFIG);
+  assert.equal(result, null, "expected null (allowed)");
+});
+
+test("checkDispatch: allows 'list_repos'", () => {
+  const result = checkDispatch("list_repos", SHIPPED_CONFIG);
+  assert.equal(result, null, "expected null (allowed)");
+});
+
+test("checkDispatch: allows unknown tool names (only exact deny-list matches block)", () => {
+  const result = checkDispatch("some_unknown_tool", SHIPPED_CONFIG);
+  assert.equal(result, null);
+});
+
+test("checkDispatch: 'delete_repo' result has blocked=true", () => {
+  const result = checkDispatch("delete_repo", SHIPPED_CONFIG);
+  assert.ok(result !== null);
+  assert.equal(result.blocked, true);
+});
+
+// --- return shape verification -------------------------------------------
+
+test("checkContent: allowed result is exactly null", () => {
+  const result = checkContent("python3 script.py", SHIPPED_CONFIG);
+  assert.strictEqual(result, null);
+});
+
+test("checkDispatch: allowed result is exactly null", () => {
+  const result = checkDispatch("create_issue", SHIPPED_CONFIG);
+  assert.strictEqual(result, null);
+});


### PR DESCRIPTION
Closes #14
Part of epic #13

## Changes
- `interceptor.js`: `checkContent(code)` and `checkDispatch(toolName)` — config-driven deny rules
- `test/test-interceptor.js`: unit tests for both surfaces including word-boundary correctness

## Test Results
All tests pass.