### PR TITLE
feat(#15): sub-mcp-manager.js — stdio lifecycle and credential isolation

### DIFF
--- a/sub-mcp-manager.js
+++ b/sub-mcp-manager.js
@@ -1,0 +1,342 @@
+/**
+ * sub-mcp-manager.js — Sub-MCP server child process lifecycle manager
+ *
+ * Manages stdio child processes for each sub-MCP server defined in
+ * passthrough-config.json. Uses the MCP SDK Client + StdioClientTransport
+ * to speak the full MCP protocol over the child process's stdin/stdout.
+ *
+ * Key design decisions (from EPIC_13_ADR.md and EPIC_13_DECOMPOSITION.md):
+ *   - Lazy init: child processes are spawned on first callTool invocation
+ *   - Crash recovery: exponential backoff (1s, 2s, 4s, ... max 30s)
+ *   - Credential isolation: buildSubMcpEnv() strips all credentials and
+ *     adds back only the vars declared in serverConfig.env
+ *   - Sub-MCP crashes NEVER propagate to callers — structured error returned
+ *   - callTool and getSchema always return { error, message } on failure
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { loadConfig } from "./config-loader.js";
+
+// Safe environment variables that are not credentials and are needed for
+// sub-MCP servers to function (e.g., find binaries, write temp files).
+const SAFE_VARS = [
+  "PATH",
+  "HOME",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "NODE_PATH",
+  "npm_config_cache",
+  "SHELL",
+  "TERM",
+  "USER",
+  "LOGNAME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  // npm/npx need these to locate global modules
+  "npm_config_prefix",
+  "npm_config_global_prefix",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_CACHE_HOME",
+];
+
+/**
+ * Build a stripped environment for a sub-MCP server child process.
+ *
+ * Starts from a safe subset of the main process env (only SAFE_VARS),
+ * then adds back only the variables explicitly declared in serverConfig.env.
+ * This ensures that credentials not listed in serverConfig.env are never
+ * passed to the child process — even if they happen to be in the main env.
+ *
+ * @param {{ env?: string[] }} serverConfig - Sub-MCP server config entry
+ * @returns {Record<string, string>} Sanitized environment object
+ */
+export function buildSubMcpEnv(serverConfig) {
+  const stripped = {};
+
+  // Pass through safe (non-credential) vars only
+  for (const key of SAFE_VARS) {
+    if (process.env[key] !== undefined) {
+      stripped[key] = process.env[key];
+    }
+  }
+
+  // Add only the explicitly declared vars for this server
+  for (const varName of (serverConfig.env || [])) {
+    if (process.env[varName] !== undefined) {
+      stripped[varName] = process.env[varName];
+    }
+  }
+
+  return stripped;
+}
+
+// Backoff configuration for crash recovery
+const BACKOFF_INITIAL_MS = 1000;
+const BACKOFF_MULTIPLIER = 2;
+const BACKOFF_MAX_MS = 30000;
+
+/**
+ * Compute the next backoff delay in milliseconds using exponential backoff.
+ *
+ * @param {number} attempt - Zero-based attempt index (0 = first retry)
+ * @returns {number} Delay in milliseconds, capped at BACKOFF_MAX_MS
+ */
+function computeBackoff(attempt) {
+  const delay = BACKOFF_INITIAL_MS * Math.pow(BACKOFF_MULTIPLIER, attempt);
+  return Math.min(delay, BACKOFF_MAX_MS);
+}
+
+/**
+ * SubMcpManager — singleton class for managing sub-MCP server connections.
+ *
+ * Each sub-MCP server is a child process connected via the MCP stdio protocol
+ * (StdioClientTransport). Servers are started lazily on first use and
+ * restarted with exponential backoff on crash.
+ */
+class SubMcpManager {
+  constructor() {
+    // name -> ServerState
+    this._servers = {};
+    this._config = null;
+  }
+
+  /**
+   * Load config lazily (once per manager lifetime).
+   * @returns {{ subMcpServers: Array, interceptRules: Array }}
+   */
+  _getConfig() {
+    if (!this._config) {
+      this._config = loadConfig();
+    }
+    return this._config;
+  }
+
+  /**
+   * Get the config entry for a named sub-MCP server.
+   * @param {string} name
+   * @returns {{ name: string, command: string, args: string[], env: string[] }}
+   * @throws {Error} if the server name is not in the config
+   */
+  _getServerConfig(name) {
+    const server = this._getConfig().subMcpServers.find((s) => s.name === name);
+    if (!server) {
+      throw new Error(`Unknown sub-MCP server: ${name}`);
+    }
+    return server;
+  }
+
+  /**
+   * Get or initialize the server state object for a named server.
+   * @param {string} name
+   * @returns {ServerState}
+   */
+  _getServerState(name) {
+    if (!this._servers[name]) {
+      this._servers[name] = {
+        client: null,
+        transport: null,
+        status: "disconnected", // "disconnected" | "connecting" | "connected" | "crashed"
+        crashCount: 0,
+        connectPromise: null,
+      };
+    }
+    return this._servers[name];
+  }
+
+  /**
+   * Ensure a sub-MCP server is connected, spawning it if necessary.
+   * Uses a per-server connect mutex (connectPromise) to avoid double-init.
+   *
+   * On crash, waits for an exponential backoff delay before reconnecting.
+   *
+   * @param {string} name - Server name from passthrough-config.json
+   * @returns {Promise<void>} Resolves when the client is ready to use
+   * @throws {Error} if connection fails after the attempt
+   */
+  async _ensureConnected(name) {
+    const state = this._getServerState(name);
+
+    // Already connected
+    if (state.status === "connected" && state.client) {
+      return;
+    }
+
+    // Already connecting — wait on the existing promise
+    if (state.status === "connecting" && state.connectPromise) {
+      return state.connectPromise;
+    }
+
+    // Start a new connection attempt
+    state.status = "connecting";
+    state.connectPromise = this._doConnect(name, state);
+
+    try {
+      await state.connectPromise;
+    } finally {
+      state.connectPromise = null;
+    }
+  }
+
+  /**
+   * Internal: perform the actual spawn + MCP handshake.
+   * Called from _ensureConnected when no existing connection is live.
+   *
+   * @param {string} name
+   * @param {ServerState} state
+   */
+  async _doConnect(name, state) {
+    // Exponential backoff on repeated crashes
+    if (state.crashCount > 0) {
+      const delay = computeBackoff(state.crashCount - 1);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+
+    const serverConfig = this._getServerConfig(name);
+    const env = buildSubMcpEnv(serverConfig);
+
+    // Close any existing transport/client before reconnecting
+    if (state.transport) {
+      try {
+        await state.transport.close();
+      } catch {
+        // Ignore close errors on a crashed transport
+      }
+      state.transport = null;
+      state.client = null;
+    }
+
+    const transport = new StdioClientTransport({
+      command: serverConfig.command,
+      args: serverConfig.args,
+      env,
+      stderr: "inherit", // surface sub-MCP stderr for debugging
+    });
+
+    const client = new Client(
+      { name: "onlycodes-passthrough", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    // Detect crashes: when the transport closes unexpectedly, mark as crashed
+    transport.onclose = () => {
+      if (state.status === "connected") {
+        state.status = "crashed";
+        state.crashCount++;
+        state.client = null;
+        state.transport = null;
+      }
+    };
+
+    transport.onerror = (err) => {
+      // Log but don't throw — crash is handled via onclose
+      // (stderr is already inherited, so the error details appear there)
+      void err; // suppress lint warnings; error surfaces through onclose
+    };
+
+    try {
+      await client.connect(transport);
+    } catch (err) {
+      state.status = "crashed";
+      state.crashCount++;
+      state.client = null;
+      state.transport = null;
+      throw new Error(`Failed to connect to sub-MCP server "${name}": ${err.message}`);
+    }
+
+    state.client = client;
+    state.transport = transport;
+    state.status = "connected";
+  }
+
+  /**
+   * Call a tool on a named sub-MCP server.
+   *
+   * Ensures the server is connected (spawning lazily or recovering from crash),
+   * then invokes the tool via the MCP protocol.
+   *
+   * If the server is unavailable or the call fails, returns a structured
+   * error object — NEVER throws to the caller.
+   *
+   * @param {string} serverName - Sub-MCP server name (from passthrough-config.json)
+   * @param {string} toolName - Tool name to invoke
+   * @param {Record<string, unknown>} args - Tool arguments
+   * @returns {Promise<{ error: true, message: string } | unknown>}
+   *   On success: the tool result from the MCP server.
+   *   On failure: { error: true, message: string }
+   */
+  async callTool(serverName, toolName, args) {
+    try {
+      await this._ensureConnected(serverName);
+      const state = this._getServerState(serverName);
+      if (!state.client) {
+        return { error: true, message: `Sub-MCP server "${serverName}" is not available` };
+      }
+      const result = await state.client.callTool({ name: toolName, arguments: args });
+      return result;
+    } catch (err) {
+      return { error: true, message: err.message };
+    }
+  }
+
+  /**
+   * Get the JSON schema for a specific tool on a named sub-MCP server.
+   *
+   * Ensures the server is connected, then calls listTools and finds the
+   * matching entry. Returns the inputSchema from that entry.
+   *
+   * If the server is unavailable or the tool is not found, returns a
+   * structured error object — NEVER throws to the caller.
+   *
+   * @param {string} serverName - Sub-MCP server name
+   * @param {string} toolName - Tool name to look up
+   * @returns {Promise<{ error: true, message: string } | object>}
+   *   On success: the inputSchema object for the tool.
+   *   On failure: { error: true, message: string }
+   */
+  async getSchema(serverName, toolName) {
+    try {
+      await this._ensureConnected(serverName);
+      const state = this._getServerState(serverName);
+      if (!state.client) {
+        return { error: true, message: `Sub-MCP server "${serverName}" is not available` };
+      }
+      const { tools } = await state.client.listTools();
+      const tool = tools.find((t) => t.name === toolName);
+      if (!tool) {
+        return { error: true, message: `Tool "${toolName}" not found on sub-MCP server "${serverName}"` };
+      }
+      return tool.inputSchema || {};
+    } catch (err) {
+      return { error: true, message: err.message };
+    }
+  }
+
+  /**
+   * Close all open sub-MCP connections. Useful for graceful shutdown.
+   * Errors during close are swallowed — callers should not depend on clean
+   * teardown in crash/signal scenarios.
+   */
+  async closeAll() {
+    const closePromises = Object.entries(this._servers).map(async ([, state]) => {
+      if (state.transport) {
+        try {
+          await state.transport.close();
+        } catch {
+          // Swallow — we're shutting down
+        }
+      }
+      state.client = null;
+      state.transport = null;
+      state.status = "disconnected";
+    });
+    await Promise.allSettled(closePromises);
+  }
+}
+
+// Singleton export — one manager per process
+const manager = new SubMcpManager();
+export default manager;

--- a/test/test-sub-mcp-manager.js
+++ b/test/test-sub-mcp-manager.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for sub-mcp-manager.js
+ *
+ * Run: node --test test/test-sub-mcp-manager.js
+ *
+ * These tests do NOT require a live sub-MCP server. They verify:
+ *   1. buildSubMcpEnv() credential isolation (strips non-declared vars)
+ *   2. buildSubMcpEnv() passes through declared vars (e.g. GITHUB_TOKEN)
+ *   3. buildSubMcpEnv() passes through safe system vars (PATH, HOME, etc.)
+ *   4. callTool() returns a structured error for an unknown server
+ *   5. getSchema() returns a structured error for an unknown server
+ *   6. callTool() returns a structured error (never throws) when server is unreachable
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSubMcpEnv } from "../sub-mcp-manager.js";
+import manager from "../sub-mcp-manager.js";
+
+// ---------------------------------------------------------------------------
+// buildSubMcpEnv tests
+// ---------------------------------------------------------------------------
+
+test("buildSubMcpEnv: strips credential vars not in serverConfig.env", () => {
+  // Temporarily set a secret env var that is NOT in serverConfig.env
+  const prev = process.env.SECRET_TOKEN;
+  try {
+    process.env.SECRET_TOKEN = "super-secret-value";
+    const env = buildSubMcpEnv({ env: [] });
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "SECRET_TOKEN"),
+      "SECRET_TOKEN must not appear in stripped env",
+    );
+  } finally {
+    if (prev === undefined) delete process.env.SECRET_TOKEN;
+    else process.env.SECRET_TOKEN = prev;
+  }
+});
+
+test("buildSubMcpEnv: strips GITHUB_TOKEN when not declared in serverConfig.env", () => {
+  const prev = process.env.GITHUB_TOKEN;
+  try {
+    process.env.GITHUB_TOKEN = "gh_test_credential_xyz";
+    const env = buildSubMcpEnv({ env: [] }); // no vars declared
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "GITHUB_TOKEN"),
+      "GITHUB_TOKEN must not appear when not declared in serverConfig.env",
+    );
+  } finally {
+    if (prev === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = prev;
+  }
+});
+
+test("buildSubMcpEnv: passes GITHUB_TOKEN when declared in serverConfig.env", () => {
+  const prev = process.env.GITHUB_TOKEN;
+  try {
+    process.env.GITHUB_TOKEN = "gh_test_token_abc123";
+    const env = buildSubMcpEnv({ env: ["GITHUB_TOKEN"] });
+    assert.equal(
+      env.GITHUB_TOKEN,
+      "gh_test_token_abc123",
+      "GITHUB_TOKEN must appear when declared in serverConfig.env",
+    );
+  } finally {
+    if (prev === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = prev;
+  }
+});
+
+test("buildSubMcpEnv: passes multiple declared vars independently", () => {
+  const prevGithub = process.env.GITHUB_TOKEN;
+  const prevSecret = process.env.SECRET_TOKEN;
+  const prevOther = process.env.OTHER_SAFE_VAR;
+  try {
+    process.env.GITHUB_TOKEN = "gh_token";
+    process.env.SECRET_TOKEN = "secret_value"; // not declared
+    process.env.OTHER_SAFE_VAR = "other_value"; // declared
+    const env = buildSubMcpEnv({ env: ["GITHUB_TOKEN", "OTHER_SAFE_VAR"] });
+    assert.equal(env.GITHUB_TOKEN, "gh_token", "GITHUB_TOKEN included when declared");
+    assert.equal(env.OTHER_SAFE_VAR, "other_value", "OTHER_SAFE_VAR included when declared");
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "SECRET_TOKEN"),
+      "SECRET_TOKEN absent when not declared",
+    );
+  } finally {
+    if (prevGithub === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = prevGithub;
+    if (prevSecret === undefined) delete process.env.SECRET_TOKEN;
+    else process.env.SECRET_TOKEN = prevSecret;
+    if (prevOther === undefined) delete process.env.OTHER_SAFE_VAR;
+    else process.env.OTHER_SAFE_VAR = prevOther;
+  }
+});
+
+test("buildSubMcpEnv: passes through PATH when set in process env", () => {
+  // PATH is a safe var and should always be passed through if present
+  if (process.env.PATH) {
+    const env = buildSubMcpEnv({ env: [] });
+    assert.equal(
+      env.PATH,
+      process.env.PATH,
+      "PATH must be present in stripped env (needed to find binaries)",
+    );
+  }
+});
+
+test("buildSubMcpEnv: passes through HOME when set in process env", () => {
+  if (process.env.HOME) {
+    const env = buildSubMcpEnv({ env: [] });
+    assert.equal(
+      env.HOME,
+      process.env.HOME,
+      "HOME must be present in stripped env",
+    );
+  }
+});
+
+test("buildSubMcpEnv: handles missing serverConfig.env gracefully (defaults to [])", () => {
+  const prev = process.env.GITHUB_TOKEN;
+  try {
+    process.env.GITHUB_TOKEN = "gh_should_not_appear";
+    // serverConfig has no env field at all
+    const env = buildSubMcpEnv({});
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "GITHUB_TOKEN"),
+      "No credential leaks when serverConfig.env is absent",
+    );
+  } finally {
+    if (prev === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = prev;
+  }
+});
+
+test("buildSubMcpEnv: does not include declared var when it is not in process.env", () => {
+  const prev = process.env.NONEXISTENT_VAR_XYZ_ABC;
+  try {
+    delete process.env.NONEXISTENT_VAR_XYZ_ABC;
+    const env = buildSubMcpEnv({ env: ["NONEXISTENT_VAR_XYZ_ABC"] });
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(env, "NONEXISTENT_VAR_XYZ_ABC"),
+      "Declared var absent from process.env must not appear in result",
+    );
+  } finally {
+    if (prev !== undefined) process.env.NONEXISTENT_VAR_XYZ_ABC = prev;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// SubMcpManager error-handling tests (no live server required)
+// ---------------------------------------------------------------------------
+
+test("manager.callTool: returns structured error for unknown server name", async () => {
+  const result = await manager.callTool("nonexistent-server-xyz", "some_tool", {});
+  assert.ok(result !== null && typeof result === "object", "result is an object");
+  assert.equal(result.error, true, "result.error must be true");
+  assert.ok(
+    typeof result.message === "string" && result.message.length > 0,
+    "result.message must be a non-empty string",
+  );
+  assert.match(
+    result.message,
+    /nonexistent-server-xyz/,
+    "error message should mention the server name",
+  );
+});
+
+test("manager.getSchema: returns structured error for unknown server name", async () => {
+  const result = await manager.getSchema("nonexistent-server-xyz", "some_tool");
+  assert.ok(result !== null && typeof result === "object", "result is an object");
+  assert.equal(result.error, true, "result.error must be true");
+  assert.ok(
+    typeof result.message === "string" && result.message.length > 0,
+    "result.message must be a non-empty string",
+  );
+});
+
+test("manager.callTool: never throws — returns structured error for unreachable server", async () => {
+  // Use a server config that points to a non-existent command to simulate
+  // an unreachable server. We test that no exception propagates out.
+  let threw = false;
+  let result;
+  try {
+    // The github server is defined in the config but @github/mcp is not
+    // installed in this test environment, so the spawn will fail.
+    // If it somehow succeeds (CI has the package), that's also fine —
+    // we just check no exception is thrown.
+    result = await manager.callTool("github", "some_tool", {});
+  } catch (err) {
+    threw = true;
+  }
+  assert.equal(threw, false, "callTool must not throw — must return structured error");
+  // result may be { error: true, message: ... } or a real response —
+  // both are acceptable (the server may or may not be installed)
+  if (result && result.error) {
+    assert.ok(
+      typeof result.message === "string",
+      "structured error must have a message string",
+    );
+  }
+});
+
+test("manager.getSchema: never throws — returns structured error for unreachable server", async () => {
+  let threw = false;
+  let result;
+  try {
+    result = await manager.getSchema("github", "some_tool");
+  } catch (err) {
+    threw = true;
+  }
+  assert.equal(threw, false, "getSchema must not throw — must return structured error");
+  if (result && result.error) {
+    assert.ok(
+      typeof result.message === "string",
+      "structured error must have a message string",
+    );
+  }
+});


### PR DESCRIPTION
Closes #15
Part of epic #13

## Changes
- `sub-mcp-manager.js`: lazy-init MCP child processes, `buildSubMcpEnv()`, crash recovery
- `test/test-sub-mcp-manager.js`: credential isolation and error handling tests

## Implementation Details

- **Lazy init**: child processes are spawned on first `callTool` invocation using `StdioClientTransport` from `@modelcontextprotocol/sdk`
- **`buildSubMcpEnv()`**: starts from a safe subset of env vars (PATH, HOME, TMPDIR, etc.) and adds back only the vars explicitly declared in `serverConfig.env` — GITHUB_TOKEN is never present in the execute_code subprocess unless the github sub-MCP server config declares it
- **Crash recovery**: exponential backoff (1s, 2s, 4s, ..., max 30s) on reconnect after child process crash
- **Structured errors**: `callTool()` and `getSchema()` always return `{ error: true, message }` on failure — they never throw to callers, so a sub-MCP crash cannot crash the main MCP server
- **Connect mutex**: per-server `connectPromise` prevents double-init race conditions

## Test Results
All 12 unit tests pass:
- `buildSubMcpEnv` strips credentials not in `serverConfig.env`
- `buildSubMcpEnv` passes through declared vars (GITHUB_TOKEN)
- `buildSubMcpEnv` passes through safe system vars (PATH, HOME)
- Manager returns structured error for unknown server name
- `callTool` / `getSchema` never throw, return `{ error: true, message }` on failure