### PR TITLE
feat(#18): bridge-server.js — Unix socket server

### DIFF
--- a/bridge-server.js
+++ b/bridge-server.js
@@ -1,0 +1,157 @@
+/**
+ * bridge-server.js — Unix socket server routing mcp_bridge.py calls
+ *
+ * Listens on a Unix domain socket at getBridgeSocketPath() and serves
+ * NDJSON (newline-delimited JSON) requests from mcp_bridge.py clients.
+ *
+ * Supported request methods:
+ *   - call:       { method: "call", server, tool, args? }
+ *                 Runs through interceptor.checkDispatch() first. If denied,
+ *                 returns { error: true, message }. Otherwise forwards to
+ *                 manager.callTool(server, tool, args).
+ *   - get_schema: { method: "get_schema", server, tool }
+ *                 Forwarded directly to manager.getSchema(server, tool).
+ *
+ * Protocol (ADR Decision 1 — NDJSON):
+ *   Each message is JSON.stringify(obj) + "\n". Receivers buffer until "\n".
+ *
+ * Socket path (ADR Decision 2 — per-PID with env override):
+ *   getBridgeSocketPath() → ONLYCODES_BRIDGE_SOCK env var or
+ *   /tmp/onlycodes-bridge-${pid}.sock
+ *
+ * Exports:
+ *   start()         Starts the server. Returns the net.Server instance.
+ *                   Also exposes server.sockPath for callers that need the path.
+ *   stop(server)    Closes the server and removes the socket file.
+ */
+
+import net from "node:net";
+import fs from "node:fs";
+import { checkDispatch } from "./interceptor.js";
+import manager from "./sub-mcp-manager.js";
+import { getBridgeSocketPath } from "./config-loader.js";
+
+/**
+ * Start the bridge Unix socket server.
+ *
+ * @returns {net.Server} The running server (with .sockPath set).
+ */
+export function start() {
+  const sockPath = getBridgeSocketPath();
+
+  // Remove any stale socket file from a previous run / crash
+  try {
+    fs.unlinkSync(sockPath);
+  } catch {
+    // File didn't exist — that's fine
+  }
+
+  const server = net.createServer((socket) => {
+    let buf = "";
+
+    socket.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      const lines = buf.split("\n");
+      buf = lines.pop(); // keep the (possibly empty) incomplete trailing piece
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        handleRequest(socket, line);
+      }
+    });
+
+    // Silently ignore client disconnects / EPIPE — they are not server errors
+    socket.on("error", () => {});
+  });
+
+  server.listen(sockPath, () => {
+    // Socket is ready; nothing to log here — callers can check server.listening
+  });
+
+  // Expose the path so callers (e.g. exec-server.js, tests) can read it
+  server.sockPath = sockPath;
+
+  // Clean up the socket file on graceful shutdown signals
+  const cleanup = () => {
+    server.close();
+    try {
+      fs.unlinkSync(sockPath);
+    } catch {
+      // Already gone — ignore
+    }
+  };
+
+  process.on("SIGTERM", cleanup);
+  process.on("SIGINT", cleanup);
+
+  return server;
+}
+
+/**
+ * Stop a running bridge server and remove its socket file.
+ *
+ * @param {net.Server} server - The server instance returned by start().
+ */
+export function stop(server) {
+  const sockPath = getBridgeSocketPath();
+  server.close();
+  try {
+    fs.unlinkSync(sockPath);
+  } catch {
+    // Already gone — ignore
+  }
+}
+
+/**
+ * Handle a single NDJSON request line on a connected socket.
+ *
+ * Always writes exactly one NDJSON line back. Never throws.
+ *
+ * @param {net.Socket} socket
+ * @param {string} line - A single (complete) JSON string with no trailing newline.
+ */
+async function handleRequest(socket, line) {
+  let req;
+  try {
+    req = JSON.parse(line);
+  } catch {
+    write(socket, { error: true, message: "Invalid JSON request" });
+    return;
+  }
+
+  try {
+    if (req.method === "call") {
+      const denied = checkDispatch(req.tool);
+      if (denied) {
+        write(socket, { error: true, message: denied.message });
+        return;
+      }
+      const result = await manager.callTool(req.server, req.tool, req.args || {});
+      write(socket, result);
+    } else if (req.method === "get_schema") {
+      const result = await manager.getSchema(req.server, req.tool);
+      write(socket, result);
+    } else {
+      write(socket, {
+        error: true,
+        message: `Unknown method: ${req.method}`,
+      });
+    }
+  } catch (err) {
+    write(socket, { error: true, message: err.message });
+  }
+}
+
+/**
+ * Write a single NDJSON response line to a socket.
+ * Silently ignores write errors (e.g. client already disconnected).
+ *
+ * @param {net.Socket} socket
+ * @param {unknown} obj - Serialisable JS value.
+ */
+function write(socket, obj) {
+  try {
+    socket.write(JSON.stringify(obj) + "\n");
+  } catch {
+    // Client disconnected before the response was sent — ignore
+  }
+}

--- a/test/test-bridge-server.js
+++ b/test/test-bridge-server.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+/**
+ * Integration tests for bridge-server.js
+ *
+ * Run: node --test test/test-bridge-server.js
+ *
+ * Uses a real Unix socket at a test-specific path to exercise:
+ *  1. Dispatch deny-list (delete_repo → blocked)
+ *  2. Allowed call (create_pr → manager fails with structured error, no crash)
+ *  3. get_schema request (forwarded; manager returns structured error, no crash)
+ *  4. Invalid JSON input → { error: true, message: "Invalid JSON request" }
+ *  5. Server shutdown → socket file removed
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import fs from "node:fs";
+
+// ─── Test socket path ───────────────────────────────────────────────────────
+// Use a unique path so parallel test runs don't collide.
+const TEST_SOCK = `/tmp/test-bridge-${process.pid}.sock`;
+process.env.ONLYCODES_BRIDGE_SOCK = TEST_SOCK;
+
+// Import AFTER setting the env var so getBridgeSocketPath() picks it up.
+const { start, stop } = await import("../bridge-server.js");
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Send a single NDJSON request to the bridge server and collect the response.
+ *
+ * @param {object} req - JS object to send as a single NDJSON line.
+ * @returns {Promise<object>} Parsed response object.
+ */
+function sendRequest(req) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(TEST_SOCK, () => {
+      socket.write(JSON.stringify(req) + "\n");
+    });
+
+    let buf = "";
+    socket.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        socket.destroy();
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(new Error(`Failed to parse response: ${line}`));
+        }
+      }
+    });
+
+    socket.on("error", reject);
+  });
+}
+
+// ─── Lifecycle ───────────────────────────────────────────────────────────────
+
+let server;
+
+before(async () => {
+  server = start();
+  // Wait until the socket is actually listening
+  await new Promise((resolve, reject) => {
+    if (server.listening) return resolve();
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+});
+
+after(() => {
+  if (server) {
+    stop(server);
+  }
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test("dispatch deny: delete_repo is blocked before reaching sub-MCP manager", async () => {
+  const resp = await sendRequest({
+    method: "call",
+    server: "github",
+    tool: "delete_repo",
+    args: { repo: "test/test" },
+  });
+
+  assert.equal(resp.error, true, "response should have error: true");
+  assert.ok(
+    typeof resp.message === "string" && resp.message.length > 0,
+    "response should have a non-empty message",
+  );
+  // Confirm it's the deny message, not a sub-MCP error
+  assert.ok(
+    resp.message.includes("delete_repo") ||
+      resp.message.toLowerCase().includes("blocked") ||
+      resp.message.toLowerCase().includes("denied"),
+    `deny message should mention the blocked operation, got: ${resp.message}`,
+  );
+});
+
+test("allowed call: create_pr is not blocked; returns structured error (no real sub-MCP)", async () => {
+  const resp = await sendRequest({
+    method: "call",
+    server: "github",
+    tool: "create_pr",
+    args: { title: "test" },
+  });
+
+  // Manager will fail to connect since there's no real @github/mcp server,
+  // but it must return a structured { error, message } — NOT throw.
+  assert.ok(
+    typeof resp === "object" && resp !== null,
+    "response must be an object",
+  );
+  // Either a successful result OR a structured error — both are valid here.
+  if (resp.error !== undefined) {
+    assert.equal(resp.error, true);
+    assert.ok(
+      typeof resp.message === "string" && resp.message.length > 0,
+      "error response must have a non-empty message",
+    );
+  }
+});
+
+test("get_schema: forwarded to sub-MCP manager; returns structured response", async () => {
+  const resp = await sendRequest({
+    method: "get_schema",
+    server: "github",
+    tool: "create_pr",
+  });
+
+  // No real sub-MCP server → structured error expected, not a crash.
+  assert.ok(
+    typeof resp === "object" && resp !== null,
+    "response must be an object",
+  );
+  if (resp.error !== undefined) {
+    assert.equal(resp.error, true);
+    assert.ok(
+      typeof resp.message === "string" && resp.message.length > 0,
+      "error response must have a non-empty message",
+    );
+  }
+});
+
+test("invalid JSON: returns { error: true, message: 'Invalid JSON request' }", async () => {
+  const resp = await new Promise((resolve, reject) => {
+    const socket = net.createConnection(TEST_SOCK, () => {
+      // Send malformed JSON
+      socket.write("{ this is not valid json }\n");
+    });
+
+    let buf = "";
+    socket.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        socket.destroy();
+        try {
+          resolve(JSON.parse(line));
+        } catch (err) {
+          reject(new Error(`Failed to parse response: ${line}`));
+        }
+      }
+    });
+
+    socket.on("error", reject);
+  });
+
+  assert.equal(resp.error, true);
+  assert.equal(resp.message, "Invalid JSON request");
+});
+
+test("unknown method: returns { error: true, message: ... }", async () => {
+  const resp = await sendRequest({ method: "unknown_method", server: "github", tool: "foo" });
+  assert.equal(resp.error, true);
+  assert.ok(resp.message.includes("unknown_method"), `expected message about unknown method, got: ${resp.message}`);
+});
+
+test("server shutdown: socket file is removed after stop()", async () => {
+  // Socket should exist while server is running
+  assert.ok(fs.existsSync(TEST_SOCK), "socket file should exist while server is running");
+
+  stop(server);
+  server = null;
+
+  // Give the OS a tick to remove the file
+  await new Promise((r) => setTimeout(r, 50));
+
+  assert.ok(!fs.existsSync(TEST_SOCK), "socket file should be cleaned up after stop()");
+});


### PR DESCRIPTION
Closes #18
Part of epic #13

## Changes
- `bridge-server.js`: NDJSON Unix socket server routing `call`/`get_schema` through interceptor → sub-MCP manager
- `test/test-bridge-server.js`: integration tests (dispatch deny, invalid JSON, socket cleanup)

## ADR Decisions Applied
- Decision 1: NDJSON framing
- Decision 2: ONLYCODES_BRIDGE_SOCK / per-PID socket path

## Test Results
All tests pass.