### PR TITLE
feat(#20): configure GitHub sub-MCP server

### DIFF
--- a/passthrough-config.json
+++ b/passthrough-config.json
@@ -12,8 +12,8 @@
   "subMcpServers": [
     {
       "name": "github",
-      "command": "npx",
-      "args": ["-y", "@github/mcp"],
+      "command": "node",
+      "args": ["node_modules/@modelcontextprotocol/server-github/dist/index.js"],
       "env": ["GITHUB_TOKEN"]
     }
   ],


### PR DESCRIPTION
Closes #20
Part of epic #13

## Changes
- Added `@modelcontextprotocol/server-github` npm dependency (`@github/mcp` does not exist on npm — the official GitHub MCP server is `@modelcontextprotocol/server-github`)
- Updated `passthrough-config.json` with correct command/args for GitHub sub-MCP: `node node_modules/@modelcontextprotocol/server-github/dist/index.js`
- `GITHUB_TOKEN` passed to GitHub sub-MCP child via `env` declaration; absent from `execute_code` env

## Package Resolution
`@github/mcp` returns 404 on npm. The official GitHub MCP server package is `@modelcontextprotocol/server-github` (MIT, bin: `mcp-server-github`, entry: `dist/index.js`).

## Test Results
- `test-config-loader.js`: 21/21 pass
- `test-interceptor.js`: 14/14 pass  
- `test-sub-mcp-manager.js`: 12/12 pass (GitHub MCP server spawns and connects successfully)