### PR TITLE
feat(logging): Phase 1 — _log.py foundation, --verbose flag, loguru init

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ datasets>=2.18      # HuggingFace streaming fetch (add command only)
 click>=8.1          # CLI
 pyyaml>=6.0         # YAML problem files
 tabulate>=0.9       # analyze output table
+loguru>=0.7         # structured logging (configured in swebench/_log.py)
 pytest>=7.0         # test-only; unit tests under tests/

--- a/swebench/_log.py
+++ b/swebench/_log.py
@@ -1,0 +1,150 @@
+"""Loguru configuration seam for the swebench package.
+
+All loguru configuration lives here. No other module calls
+``logger.add()`` or ``logger.remove()`` directly. Modules that need
+to attach a temporary sink (for example, ``run.py``'s per-arm
+``StringIO`` buffer in parallel mode) MUST go through
+:func:`add_buffer_sink` / :func:`remove_sink`.
+
+Output contract
+---------------
+* Loguru writes diagnostic output to **stderr only**.
+* **stdout** is reserved for user-facing data (currently only
+  ``analyze.py``'s ``tabulate`` table). Reviewers must reject any
+  change that routes machine-readable user data through the logger.
+
+caplog interop
+--------------
+:func:`configure_logging` always installs a ``PropagateHandler`` that
+forwards loguru records into the stdlib ``logging`` tree at the
+configured level. This means pytest's standard ``caplog`` fixture
+works against loguru calls without per-test sink hackery and without
+sniffing ``PYTEST_CURRENT_TEST``.
+
+Verbose semantics
+-----------------
+* ``--log-level INFO`` (default): concise format, INFO and above.
+* ``--verbose`` / ``--log-level DEBUG``: enables DEBUG and adds
+  ``{name}:{function}:{line}`` to every record.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import IO
+
+from loguru import logger
+
+__all__ = [
+    "logger",
+    "configure_logging",
+    "add_buffer_sink",
+    "remove_sink",
+    "PropagateHandler",
+]
+
+
+# Format strings — DEBUG includes file/line origin, INFO+ stays concise.
+_VERBOSE_FORMAT = (
+    "<level>{level: <8}</level> | {name}:{function}:{line} - {message}"
+)
+_DEFAULT_FORMAT = "<level>{level: <8}</level> | {message}"
+
+# Format used by buffer sinks (run.py parallel mode). Always includes
+# file/line so the captured per-arm transcript is self-describing
+# regardless of the global level.
+_BUFFER_FORMAT = (
+    "<level>{level: <8}</level> | {name}:{function}:{line} - {message}"
+)
+
+
+class PropagateHandler(logging.Handler):
+    """Forward loguru records into the stdlib ``logging`` tree.
+
+    Installed unconditionally by :func:`configure_logging` so that
+    pytest's ``caplog`` fixture captures loguru output without any
+    per-test plumbing.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+        logging.getLogger(record.name).handle(record)
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Install the canonical stderr sink and the caplog propagation bridge.
+
+    Always idempotent: removes any previously-registered sinks first so
+    repeated calls (e.g. the ``autouse`` test fixture) do not stack
+    handlers.
+
+    Parameters
+    ----------
+    level:
+        Loguru level name (``"DEBUG"``, ``"INFO"``, ``"WARNING"``,
+        ``"ERROR"``, ``"CRITICAL"``). The format string includes
+        ``{name}:{function}:{line}`` whenever ``level`` is ``"DEBUG"``;
+        otherwise the concise format is used.
+    """
+
+    normalized = (level or "INFO").upper()
+    fmt = _VERBOSE_FORMAT if normalized == "DEBUG" else _DEFAULT_FORMAT
+
+    logger.remove()
+    logger.add(
+        sys.stderr,
+        format=fmt,
+        level=normalized,
+    )
+
+    # caplog interop — always install. The cost is one stdlib handler;
+    # the benefit is that pytest's caplog fixture captures loguru output
+    # in any environment (CI, local, integration) with no conditional
+    # logic.
+    logger.add(
+        PropagateHandler(),
+        format="{message}",
+        level=normalized,
+    )
+
+
+def add_buffer_sink(buf: IO[str], level: str = "DEBUG") -> int:
+    """Attach a loguru sink that writes to ``buf``.
+
+    Used by ``run.py`` parallel mode to capture each arm's transcript
+    into a per-arm ``StringIO`` buffer for atomic flush after the arm
+    completes. ``enqueue=False`` is deliberate — the caller wants
+    synchronous writes so ``_flush_buffer`` sees a complete transcript.
+
+    Parameters
+    ----------
+    buf:
+        Any file-like object supporting ``.write(str)``.
+    level:
+        Minimum loguru level to capture into the buffer. Defaults to
+        ``DEBUG`` so per-arm transcripts retain full detail regardless
+        of the global stderr level.
+
+    Returns
+    -------
+    int
+        The loguru sink id, to be passed back to :func:`remove_sink`.
+    """
+
+    return logger.add(
+        buf,
+        format=_BUFFER_FORMAT,
+        level=(level or "DEBUG").upper(),
+        enqueue=False,
+    )
+
+
+def remove_sink(sink_id: int) -> None:
+    """Remove a previously-added sink.
+
+    The only sanctioned wrapper around ``logger.remove()`` for callers
+    outside this module. Keeps the "no module configures loguru except
+    ``_log.py``" invariant intact.
+    """
+
+    logger.remove(sink_id)

--- a/swebench/cli.py
+++ b/swebench/cli.py
@@ -1,7 +1,12 @@
 """Click CLI dispatcher for swebench commands."""
 
+from __future__ import annotations
+
+import sys
+
 import click
 
+from swebench._log import configure_logging, logger
 from swebench.add import add_command
 from swebench.run import run_command
 from swebench.analyze import analyze_command
@@ -9,8 +14,29 @@ from swebench.cache_cli import cache_group
 
 
 @click.group()
-def cli() -> None:
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Enable DEBUG logging (overrides --log-level).",
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(
+        ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        case_sensitive=False,
+    ),
+    default="INFO",
+    show_default=True,
+    help="Loguru level for the stderr sink (ignored if --verbose is set).",
+)
+def cli(verbose: bool, log_level: str) -> None:
     """SWE-bench evaluation harness: add, run, analyze, and cache instances."""
+
+    effective_level = "DEBUG" if verbose else log_level.upper()
+    configure_logging(level=effective_level)
+    logger.debug(f"swebench CLI started: {sys.argv[1:]}")
 
 
 cli.add_command(add_command, "add")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Shared pytest fixtures for the swebench test suite.
+
+Two fixtures are provided here:
+
+* :func:`reset_loguru` (autouse) — resets the loguru singleton before each
+  test and re-installs the canonical configuration via
+  :func:`swebench._log.configure_logging`. Without this, any test that
+  attaches a sink leaks handlers across the suite, producing duplicate
+  log lines and false-positive ``caplog`` assertions in later tests.
+
+* :func:`propagate_handler` — explicit fixture that installs (or rather,
+  re-confirms) the loguru → stdlib bridge. ``configure_logging`` already
+  installs ``PropagateHandler`` unconditionally, so this fixture's main
+  job is to set the stdlib root logger level low enough that ``caplog``
+  captures DEBUG records too.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from loguru import logger
+
+from swebench._log import PropagateHandler, configure_logging
+
+
+@pytest.fixture(autouse=True)
+def reset_loguru():
+    """Tear down + re-install loguru sinks around every test.
+
+    Marked ``autouse`` because loguru is a process-global singleton and
+    stale sinks would cause cross-test pollution even for tests that
+    never touch logging directly.
+    """
+
+    logger.remove()
+    configure_logging(level="DEBUG")
+    try:
+        yield
+    finally:
+        logger.remove()
+
+
+@pytest.fixture
+def propagate_handler(caplog):
+    """Ensure loguru records reach pytest's ``caplog`` fixture.
+
+    ``configure_logging`` already installs a ``PropagateHandler`` for
+    every test (via ``reset_loguru`` above). This fixture additionally
+    lowers the stdlib root logger to DEBUG so ``caplog`` sees every
+    propagated record, and yields the handler class for tests that want
+    to assert on its behaviour directly.
+    """
+
+    caplog.set_level(logging.DEBUG)
+    yield PropagateHandler

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,71 @@
+"""Foundation tests for ``swebench._log`` (issue #42, epic #37).
+
+Covers the three guarantees the rest of the epic relies on:
+
+1. ``configure_logging`` toggles the stderr level between DEBUG and INFO.
+2. The propagate handler bridges loguru → ``caplog``.
+3. ``add_buffer_sink`` / ``remove_sink`` round-trip through a buffer.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+from loguru import logger
+
+from swebench._log import (
+    add_buffer_sink,
+    configure_logging,
+    remove_sink,
+)
+
+
+def test_configure_logging_info_suppresses_debug(capsys):
+    configure_logging(level="INFO")
+    logger.debug("hidden-debug-line")
+    logger.info("visible-info-line")
+    err = capsys.readouterr().err
+    assert "visible-info-line" in err
+    assert "hidden-debug-line" not in err
+
+
+def test_configure_logging_debug_emits_debug(capsys):
+    configure_logging(level="DEBUG")
+    logger.debug("visible-debug-line")
+    err = capsys.readouterr().err
+    assert "visible-debug-line" in err
+    # Verbose format includes file/function/line origin.
+    assert "test_logging" in err
+
+
+def test_propagate_handler_reaches_caplog(caplog, propagate_handler):
+    caplog.set_level(logging.DEBUG)
+    logger.info("bridged-message")
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("bridged-message" in m for m in messages)
+
+
+def test_add_and_remove_buffer_sink_round_trip():
+    buf = io.StringIO()
+    sink_id = add_buffer_sink(buf, level="DEBUG")
+    try:
+        logger.debug("captured-by-buffer")
+    finally:
+        remove_sink(sink_id)
+
+    assert "captured-by-buffer" in buf.getvalue()
+
+    # After removal, further records should NOT land in the buffer.
+    before = buf.getvalue()
+    logger.debug("post-removal-line")
+    assert buf.getvalue() == before
+
+
+def test_configure_logging_is_idempotent(capsys):
+    configure_logging(level="INFO")
+    configure_logging(level="INFO")
+    logger.info("only-once-please")
+    err = capsys.readouterr().err
+    # Exactly one occurrence — no duplicate sinks stacked up.
+    assert err.count("only-once-please") == 1


### PR DESCRIPTION
Closes #42

## Summary
- Creates `swebench/_log.py` — the single owner of all loguru configuration
- `configure_logging(level)`, `add_buffer_sink(buf) -> int`, `remove_sink(sink_id)`
- Adds `--verbose` / `--log-level` flags to root Click group in `cli.py`
- Wires `configure_logging()` at CLI entry; emits DEBUG entry log
- `tests/conftest.py`: `autouse reset_loguru` fixture + `propagate_handler` for caplog interop
- `tests/test_logging.py`: 5 foundation tests (verbose toggle, caplog bridge, buffer sink round-trip, idempotence)
- Adds `loguru>=0.7` to `requirements.txt`

## Architecture decisions codified
- No module other than `_log.py` may call `logger.add()` or `logger.remove()`
- `add_buffer_sink(buf) -> int` / `remove_sink(id)` for run.py parallel mode
- loguru stderr only; tabulate table stays on stdout (not routed through logger)
- `configure_logging()` always installs PropagateHandler (no PYTEST_CURRENT_TEST sniffing)
- `--verbose` / `-v` switches level INFO→DEBUG and includes file+line in the format

## Validation
- `python -m swebench --help` exits 0 (no DEBUG)
- `python -m swebench --verbose analyze --help` emits DEBUG line on stderr
- `python -m swebench --log-level WARNING analyze --help` suppresses INFO/DEBUG
- `pytest tests/ -m "not integration"` — 22 passed (5 new + 17 pre-existing cache tests)
- The one pre-existing integration test failure (`test_repo_has_no_pycache`) reproduces on the unmodified epic branch — unrelated to this PR

Part of epic #37 (`epic/37-loguru-logging` branch).

🤖 Generated with Claude Code