### PR TITLE
fix(#40): add --output-dir flag and resume-by-default for incomplete runs

### DIFF
--- a/swebench/run.py
+++ b/swebench/run.py
@@ -53,6 +53,53 @@ class _ArmTask(NamedTuple):
     needs_editable_reinstall: bool = False
 
 
+def _is_triple_complete(
+    results_dir: str | os.PathLike,
+    instance_id: str,
+    arm: str,
+    run_idx: int,
+) -> str | None:
+    """Return the recorded verdict if a (instance_id, arm, run_idx) triple is
+    already complete, else ``None``.
+
+    A triple is considered complete iff:
+
+    - ``<results_dir>/<instance_id>_<arm>_run<N>.jsonl`` exists, AND
+    - ``<results_dir>/<instance_id>_<arm>_run<N>_test.txt`` exists, AND
+    - the test file's last non-empty line (stripped of trailing whitespace) is
+      exactly ``PASS`` or ``FAIL``.
+
+    If any of those conditions fail (missing file, no verdict, empty file,
+    mid-run kill leaving partial output), the triple is **incomplete** and the
+    caller must re-run it. Returning ``None`` signals "re-run"; returning the
+    verdict string signals "skip".
+    """
+    results_dir = str(results_dir)
+    jsonl_path = os.path.join(results_dir, f"{instance_id}_{arm}_run{run_idx}.jsonl")
+    test_path = os.path.join(results_dir, f"{instance_id}_{arm}_run{run_idx}_test.txt")
+
+    if not os.path.isfile(jsonl_path) or not os.path.isfile(test_path):
+        return None
+
+    try:
+        with open(test_path) as f:
+            lines = f.readlines()
+    except OSError:
+        return None
+
+    # Walk backward for the last non-empty (stripped) line.
+    for raw in reversed(lines):
+        line = raw.strip()
+        if not line:
+            continue
+        if line == "PASS" or line == "FAIL":
+            return line
+        return None
+
+    # File was empty or whitespace-only.
+    return None
+
+
 def _run_arm(
     *,
     problem: Problem,
@@ -394,6 +441,25 @@ def _cleanup_stale_overlays(
     show_default=True,
     help="Randomize arm execution order per problem per run (default: on). Disable to always run baseline before onlycode.",
 )
+@click.option(
+    "--output-dir",
+    "output_dir",
+    type=click.Path(file_okay=False, dir_okay=True, resolve_path=False),
+    default=None,
+    help="Directory for result files [default: <repo>/results_swebench/]. Created if it does not exist.",
+)
+@click.option(
+    "--resume/--no-resume",
+    "resume",
+    default=True,
+    show_default=True,
+    help=(
+        "Skip (instance, arm, run) triples that already have a completed "
+        "result in --output-dir. A triple is complete when both its .jsonl "
+        "and _test.txt exist and the test file's last non-empty line is "
+        "PASS or FAIL; otherwise it is re-run."
+    ),
+)
 def run_command(
     filter_ids: str | None,
     arms: str,
@@ -402,6 +468,8 @@ def run_command(
     fail_fast: bool,
     use_cache: bool,
     shuffle_arms: bool,
+    output_dir: str | None,
+    resume: bool,
 ) -> None:
     """Run SWE-bench evaluation arms on problem instances."""
     if parallel < 1:
@@ -410,7 +478,7 @@ def run_command(
 
     root = repo_root()
     problems_dir = root / "problems"
-    results_dir = root / "results_swebench"
+    results_dir = Path(output_dir) if output_dir else root / "results_swebench"
     mcp_config_path = str(root / "mcp-config.json")
     clone_base = "/tmp/swebench"
 
@@ -455,6 +523,8 @@ def run_command(
     click.echo(f"Parallel: {parallel}")
     click.echo(f"Fail-fast: {fail_fast}")
     click.echo(f"Use cache: {use_cache}")
+    click.echo(f"Resume: {resume}")
+    click.echo(f"Output dir: {results_dir}")
     click.echo(f"Claude binary: {claude_binary}")
     click.echo()
 
@@ -558,6 +628,11 @@ def run_command(
 
     # Build arm tasks grouped by problem.  Each problem's arms must run
     # serially because they share one repo_dir (git working tree).
+    #
+    # When --resume is on, any (instance, arm, run) triple whose result files
+    # already indicate a PASS/FAIL verdict is skipped at task-build time. This
+    # keeps the skip decision in one place, so serial and parallel execution
+    # paths see the exact same filtered task list.
     problem_tasks: dict[str, list[_ArmTask]] = {}
     for problem in problems:
         repo_dir, venv_dir = setup_map[problem.instance_id]
@@ -571,6 +646,16 @@ def run_command(
             if shuffle_arms and len(run_arms) > 1:
                 random.shuffle(run_arms)
             for arm in run_arms:
+                if resume:
+                    verdict = _is_triple_complete(
+                        str(results_dir), problem.instance_id, arm, run_idx
+                    )
+                    if verdict is not None:
+                        click.echo(
+                            f"  [{problem.instance_id} {arm} run {run_idx}] "
+                            f"Skipping — already complete ({verdict})"
+                        )
+                        continue
                 tasks.append(_ArmTask(
                     problem=problem,
                     arm=arm,
@@ -701,6 +786,7 @@ def run_command(
                 futures = {
                     pool.submit(_run_problem_tasks, tasks): pid
                     for pid, tasks in problem_tasks.items()
+                    if tasks  # every task was skipped by --resume; nothing to run
                 }
 
                 had_failure = False

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,140 @@
+"""Unit tests for swebench.run.
+
+Only the offline helpers are covered here. End-to-end CLI behaviour is
+exercised by the larger integration suites — this file intentionally stays
+fast and hermetic (no subprocess, no network, no real repos).
+"""
+
+from __future__ import annotations
+
+from swebench.run import _is_triple_complete
+
+
+INSTANCE = "django__django-16379"
+ARM = "baseline"
+RUN_IDX = 1
+
+
+def _write(path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _paths(tmp_path):
+    jsonl = tmp_path / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
+    test_txt = tmp_path / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
+    return jsonl, test_txt
+
+
+# --- missing files ----------------------------------------------------------
+
+
+def test_is_triple_complete_missing_jsonl(tmp_path):
+    """Test file has a verdict but the jsonl is absent → incomplete."""
+    _, test_txt = _paths(tmp_path)
+    _write(test_txt, "PASS\n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+def test_is_triple_complete_missing_test_file(tmp_path):
+    """jsonl exists but the test file is absent → incomplete."""
+    jsonl, _ = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+def test_is_triple_complete_both_missing(tmp_path):
+    """Neither file exists → incomplete."""
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+# --- verdict parsing --------------------------------------------------------
+
+
+def test_is_triple_complete_no_verdict(tmp_path):
+    """Both files present, but the test file has no PASS/FAIL line → incomplete."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "ran 12 tests\nsome warnings\n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+def test_is_triple_complete_pass_verdict(tmp_path):
+    """Last non-empty line is PASS → complete (returns 'PASS')."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "ran 12 tests\nPASS\n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) == "PASS"
+
+
+def test_is_triple_complete_fail_verdict(tmp_path):
+    """Last non-empty line is FAIL → complete (returns 'FAIL')."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "ran 12 tests\nFAIL\n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) == "FAIL"
+
+
+def test_is_triple_complete_trailing_blank_lines(tmp_path):
+    """Verdict followed by blank lines still counts — we take the last *non-empty* line."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "ran 12 tests\nPASS\n\n\n   \n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) == "PASS"
+
+
+def test_is_triple_complete_mixed_content_noise_after(tmp_path):
+    """PASS appears mid-file but trailing non-empty noise wins → incomplete."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    # 'PASS' is somewhere in the middle, but the last non-empty line is
+    # unrelated — that is what --resume must treat as incomplete, so the
+    # triple gets re-run.
+    _write(test_txt, "ran 12 tests\nPASS\ntraceback follows\nsome error\n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+def test_is_triple_complete_empty_test_file(tmp_path):
+    """Empty test file → incomplete (killed mid-run before first write)."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+def test_is_triple_complete_whitespace_only_test_file(tmp_path):
+    """Test file with only whitespace/blank lines → incomplete."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "\n\n   \n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+def test_is_triple_complete_pass_without_trailing_newline(tmp_path):
+    """Test file that ends with 'PASS' (no trailing newline) → complete."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "ran 12 tests\nPASS")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) == "PASS"
+
+
+def test_is_triple_complete_accepts_path_object(tmp_path):
+    """Helper should accept both str and Path objects for results_dir."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"foo": "bar"}\n')
+    _write(test_txt, "PASS\n")
+
+    # Path object
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) == "PASS"
+    # str form
+    assert _is_triple_complete(str(tmp_path), INSTANCE, ARM, RUN_IDX) == "PASS"


### PR DESCRIPTION
Closes #40

## What changed

Two related CLI improvements to `python -m swebench run` that make long batch runs resumable. Previously the `results_dir` was hardcoded to `<repo>/results_swebench/` and every invocation re-did every `(instance_id, arm, run_idx)` triple even if prior results already existed on disk. This PR adds `--output-dir PATH` to direct results anywhere the caller wants, and `--resume / --no-resume` (default `--resume`) to skip triples that are already complete. A single helper encapsulates the "is this triple complete?" predicate so serial and parallel execution paths both see the exact same filtered task list.

## Implementation walkthrough

### New / modified functions

- **`_is_triple_complete(results_dir, instance_id, arm, run_idx) -> str | None` in `swebench/run.py`** — the completeness predicate. It joins `results_dir` with `<instance_id>_<arm>_run<N>.jsonl` and `<instance_id>_<arm>_run<N>_test.txt`, requires both to exist, then walks the test file's lines in reverse for the last non-empty (stripped) line. The helper returns that line when it is exactly `PASS` or `FAIL`; otherwise (missing file, no verdict, empty file, mid-run kill that left noise, permission error) it returns `None`. The return is `Optional[str]` rather than `bool` so callers can log the recorded verdict without re-reading the file.

- **`run_command` in `swebench/run.py`** — gained two Click options:
  - `--output-dir DIRECTORY` typed as `click.Path(file_okay=False, dir_okay=True, resolve_path=False)`, defaulting to `None`. When `None` (falsy) the original `root / "results_swebench"` path is used; otherwise `Path(output_dir)` replaces it. The existing `results_dir.mkdir(parents=True, exist_ok=True)` call is unchanged, so the custom directory is auto-created.
  - `--resume / --no-resume` boolean flag, default `True`. It guards the call to `_is_triple_complete` during task-list construction.

  The banner now echoes both `Resume: <bool>` and `Output dir: <path>` so batch-run logs record exactly which directory and mode were active.

### How components interact

The skip decision is made once, inside the `problem_tasks` build loop, before either the serial or the parallel execution path consumes the list. This matters: `--resume` is a pure filter on `_ArmTask` creation, so the downstream execution code needs no changes and both modes see identical input.

```mermaid
graph TD
    A[run_command] --> B[Load problems]
    B --> C[Phase 1 setup]
    C --> D[Build task list loop]
    D --> E{Resume gate}
    E -->|complete| F[Log skip line]
    E -->|incomplete or no-resume| G[Append ArmTask]
    F --> D
    G --> D
    D --> H[Phase 2 execute]
    H --> I[Serial path]
    H --> J[Parallel ThreadPoolExecutor]
```

### Default execution path

**Before**: `load problems --> setup clones/venvs --> for each problem, for each run, for each arm: append _ArmTask --> execute all tasks`.

**After**: `load problems --> setup clones/venvs --> for each problem, for each run, for each arm: [if --resume AND _is_triple_complete returns verdict → log skip and continue] else append _ArmTask --> execute remaining tasks`.

The filter happens at task-build time rather than inside the execution loop, which has two benefits: (a) the serial and parallel paths share the exact same filtered task list, no divergence possible; (b) the "skipping" log lines appear together at startup so the operator sees at a glance how much work a resumed run has left to do.

In the parallel path, the `ThreadPoolExecutor` dispatch now also filters `if tasks` so problems whose every triple is already complete don't spawn a no-op worker.

### Edge cases and error handling

- **Missing `.jsonl`**: treated as incomplete (re-run).
- **Missing `_test.txt`**: treated as incomplete (re-run).
- **Test file exists but has no `PASS`/`FAIL` line** (e.g. killed mid-run): treated as incomplete (re-run).
- **Test file ends with `PASS\n\n\n`** (trailing blank lines): complete. The helper strips whitespace and walks past empty lines.
- **Test file has `PASS` mid-file but noise after**: treated as incomplete — the predicate checks the *last non-empty line*, not "contains PASS". This is the desired behaviour for a killed run that started to print a verdict and then crashed afterward.
- **Permission error on `open(test_path)`**: caught as `OSError`, treated as incomplete (re-run).
- **`--no-resume`**: bypasses the helper entirely, so even already-complete triples are re-run. This matches the issue's requirement that `--no-resume` "disables skip logic entirely".

### What was intentionally not changed

The `.jsonl` file is not parsed for content or verdict — only its existence is checked. The issue's completeness table uses only the test file for the verdict, so parsing the jsonl would add risk (JSON errors, partial writes) for no benefit.

## Tier / approach

Tier 1 — Planner → Coder → Reviewer. Single-area CLI change, ~90 lines of production code plus 130 lines of tests, requirements fully specified in the issue.

## Acceptance criteria

- [x] `--output-dir PATH` accepted by `run` subcommand; default preserves existing behaviour
- [x] `--resume` is the default; `--no-resume` disables skip logic entirely
- [x] Incomplete triples (missing files or no verdict) are always re-run even with `--resume`
- [x] Skipped triples are logged clearly (`  [<instance> <arm> run <N>] Skipping — already complete (<verdict>)`)
- [x] Existing tests pass (17/17 cache tests)
- [x] New unit tests for the "is complete?" helper pass (12/12)

## Outstanding items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)