### PR TITLE
feat: add Stage 2b runner, subagent prompt, analyze pathology CLI (#73)

### DIFF
--- a/swebench/analyze/__init__.py
+++ b/swebench/analyze/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import click
 
+from swebench.analyze.run import register_pathology_command
 from swebench.analyze.summary import _register
 
 
@@ -13,5 +14,6 @@ def analyze_command() -> None:
 
 
 _register(analyze_command)
+register_pathology_command(analyze_command)
 
 __all__ = ["analyze_command"]

--- a/swebench/analyze/run.py
+++ b/swebench/analyze/run.py
@@ -1,0 +1,496 @@
+"""Stage 2b runner — fan out per-log subagents over compressed transcripts.
+
+Pipeline overview (epic #62):
+
+- **Stage 1 (mechanical).** For every ``*_run*.jsonl`` under ``--results-dir``,
+  call :func:`swebench.analyze.extractor.extract` and persist the result as a
+  sidecar JSON under ``results_swebench/_analysis/<run_id>/mechanical/``.
+  Produce a ``triage.json`` listing the top ``TRIAGE_TOP_PERCENTILE`` of runs
+  (via :func:`swebench.analyze.extractor.triage_rank`) — those are the ones
+  fed to Stage 2.
+- **Stage 2 (subagents).** For each log flagged by triage, compose a
+  ``claude -p`` command using :func:`swebench.harness.find_claude_binary` and
+  :func:`swebench.harness.make_isolated_claude_config`, compressed log body +
+  the system prompt at ``subagent_prompt.md``. Write the subagent's JSON reply
+  to ``results_swebench/_analysis/<run_id>/subagents/<log_ref>.json``.
+  Parallel fan-out follows the ``swebench/add.py`` template: ``_print_lock``
+  serialises ``click.echo`` and ``_process_one`` returns ``(id, ok, msg)``.
+- **Stage 3 (synthesize).** Placeholder — implemented in sub-issue #74.
+
+All stages are idempotent: runs whose sidecar JSON already exists are skipped
+unless ``--force`` is passed. ``--dry-run`` prints the composed commands and
+prompts without invoking ``claude`` (fully offline-testable).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import click
+
+from swebench import repo_root
+from swebench.analyze.compress import compress
+from swebench.analyze.extractor import extract, triage_rank
+from swebench.harness import find_claude_binary, make_isolated_claude_config
+
+
+# ---------------------------------------------------------------------------
+# Concurrency primitives (mirror swebench/add.py)
+# ---------------------------------------------------------------------------
+
+
+_print_lock = threading.Lock()
+
+
+def _echo(msg: str, *, err: bool = False) -> None:
+    with _print_lock:
+        click.echo(msg, err=err)
+
+
+# ---------------------------------------------------------------------------
+# Path + naming helpers
+# ---------------------------------------------------------------------------
+
+
+#: Regex to split a run filename stem into (instance_id, arm, run_idx).
+_RUN_STEM_RE = re.compile(r"^(?P<instance>.+)_(?P<arm>baseline|onlycode)_run(?P<run>\d+)$")
+
+
+def _default_run_id() -> str:
+    """Return a compact UTC timestamp ``YYYYMMDDTHHMMSSZ`` for this invocation."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _discover_logs(results_dir: Path) -> list[Path]:
+    """Return sorted ``*_run*.jsonl`` files under ``results_dir`` (non-recursive)."""
+    return sorted(results_dir.glob("*_run*.jsonl"))
+
+
+def _parse_log_ref(jsonl_path: Path) -> tuple[str, str, int] | None:
+    """Return ``(instance_id, arm, run_idx)`` for a run JSONL, or None if unparseable."""
+    m = _RUN_STEM_RE.match(jsonl_path.stem)
+    if not m:
+        return None
+    return m.group("instance"), m.group("arm"), int(m.group("run"))
+
+
+def _analysis_root(results_dir: Path, run_id: str) -> Path:
+    """Return ``<results_dir>/_analysis/<run_id>/`` (created lazily by callers)."""
+    return results_dir / "_analysis" / run_id
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: mechanical
+# ---------------------------------------------------------------------------
+
+
+def _stage_mechanical(
+    *,
+    logs: list[Path],
+    analysis_root: Path,
+    force: bool,
+    dry_run: bool,
+) -> list[dict]:
+    """Run the mechanical extractor on every log, write sidecars, return metrics.
+
+    Returns a list of per-log metric dicts (extended with ``task_id``, ``arm``,
+    ``run``, and ``log_ref`` for downstream consumers). In ``--dry-run`` mode
+    nothing is written to disk; the metrics are still computed in-memory so
+    triage can run.
+    """
+    mech_dir = analysis_root / "mechanical"
+    if not dry_run:
+        mech_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics: list[dict] = []
+    for jsonl in logs:
+        sidecar = mech_dir / f"{jsonl.stem}.json"
+        parsed = _parse_log_ref(jsonl)
+
+        if sidecar.exists() and not force and not dry_run:
+            try:
+                data = json.loads(sidecar.read_text())
+                _echo(f"[stage1] skip (cached): {jsonl.name}")
+            except (OSError, json.JSONDecodeError):
+                data = extract(jsonl)
+                sidecar.write_text(json.dumps(data, indent=2, sort_keys=True))
+                _echo(f"[stage1] re-extracted (bad cache): {jsonl.name}")
+        else:
+            data = extract(jsonl)
+            if not dry_run:
+                sidecar.write_text(json.dumps(data, indent=2, sort_keys=True))
+                _echo(f"[stage1] extracted: {jsonl.name}")
+            else:
+                _echo(f"[stage1] would extract: {jsonl.name}")
+
+        if parsed is not None:
+            instance, arm, run = parsed
+            data["task_id"] = instance
+            data["arm"] = arm
+            data["run"] = run
+            data["log_ref"] = jsonl.stem
+        data["jsonl_path"] = str(jsonl)
+        metrics.append(data)
+    return metrics
+
+
+def _write_triage(
+    *,
+    metrics: list[dict],
+    analysis_root: Path,
+    dry_run: bool,
+) -> list[dict]:
+    """Run :func:`triage_rank` and persist ``triage.json``; return flagged subset.
+
+    The "flagged subset" is the top :data:`TRIAGE_TOP_PERCENTILE` of ranked runs
+    — i.e. everything whose priority tuple ranks it in the first bucket. For
+    simplicity we slice the ranked list at ``ceil(len * TRIAGE_TOP_PERCENTILE)``,
+    matching the docstring guarantee of "top 20% flagged".
+    """
+    from swebench.analyze.extractor import TRIAGE_TOP_PERCENTILE
+
+    ranked = triage_rank(metrics)
+    cutoff = max(1, int(round(len(ranked) * TRIAGE_TOP_PERCENTILE))) if ranked else 0
+    flagged = ranked[:cutoff]
+
+    payload = {
+        "ranked": [
+            {
+                "log_ref": m.get("log_ref"),
+                "task_id": m.get("task_id"),
+                "arm": m.get("arm"),
+                "run": m.get("run"),
+                "turns": m.get("turns"),
+                "total_cost_usd": m.get("total_cost_usd"),
+                "mechanical_flags": m.get("mechanical_flags", []),
+                "flagged": i < cutoff,
+            }
+            for i, m in enumerate(ranked)
+        ],
+        "cutoff_count": cutoff,
+        "top_percentile": TRIAGE_TOP_PERCENTILE,
+    }
+    if not dry_run:
+        (analysis_root / "triage.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True)
+        )
+        _echo(f"[triage] flagged {cutoff}/{len(ranked)} runs")
+    else:
+        _echo(f"[triage] would flag {cutoff}/{len(ranked)} runs")
+    return flagged
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: subagents
+# ---------------------------------------------------------------------------
+
+
+#: Path to the subagent system prompt, shipped alongside this module.
+SUBAGENT_PROMPT_PATH = Path(__file__).parent / "subagent_prompt.md"
+
+#: Dry-run preview cap on compressed log body (characters).
+DRY_RUN_LOG_PREVIEW_CHARS = 200
+
+
+def _read_subagent_prompt() -> str:
+    """Read and return the subagent system prompt."""
+    return SUBAGENT_PROMPT_PATH.read_text()
+
+
+def _compose_claude_cmd(claude_binary: str, user_prompt: str, system_prompt: str) -> list[str]:
+    """Compose the ``claude -p`` command for a single subagent invocation.
+
+    We restrict the subagent to ``Read,Write`` (it doesn't need a shell); the
+    system prompt is responsible for telling it to emit JSON only.
+    """
+    return [
+        claude_binary,
+        "-p", user_prompt,
+        "--system-prompt", system_prompt,
+        "--allowedTools", "Read,Write",
+        "--dangerously-skip-permissions",
+        "--no-session-persistence",
+        "--output-format", "text",
+    ]
+
+
+def _build_user_prompt(log_ref: str, arm: str, compressed: str) -> str:
+    """Build the user-facing prompt for one subagent."""
+    return (
+        f"log_ref: {log_ref}\n"
+        f"arm: {arm}\n\n"
+        f"## Compressed transcript\n\n"
+        f"{compressed}\n"
+    )
+
+
+def _process_one(
+    *,
+    metric: dict,
+    out_dir: Path,
+    claude_binary: str | None,
+    system_prompt: str,
+    force: bool,
+    dry_run: bool,
+) -> tuple[str, bool, str]:
+    """Run a single subagent end-to-end. Returns ``(log_ref, ok, message)``."""
+    log_ref = metric.get("log_ref") or Path(metric["jsonl_path"]).stem
+    sidecar = out_dir / f"{log_ref}.json"
+
+    if sidecar.exists() and not force and not dry_run:
+        return (log_ref, True, "skipped (cached)")
+
+    try:
+        compressed = compress(metric["jsonl_path"])
+    except Exception as exc:  # noqa: BLE001 — compression surface is broad
+        return (log_ref, False, f"compress failed: {type(exc).__name__}: {exc}")
+
+    arm = metric.get("arm") or "unknown"
+    user_prompt = _build_user_prompt(log_ref, arm, compressed)
+
+    if dry_run:
+        binary_display = claude_binary or "<claude>"
+        cmd = _compose_claude_cmd(binary_display, user_prompt, system_prompt)
+        preview = compressed[:DRY_RUN_LOG_PREVIEW_CHARS]
+        _echo(
+            f"--- DRY RUN: {log_ref} ---\n"
+            f"sidecar: {sidecar}\n"
+            f"cmd: {' '.join(_shlex_quote(p) for p in cmd[:6])} ...\n"
+            f"compressed preview (first {DRY_RUN_LOG_PREVIEW_CHARS} chars):\n"
+            f"{preview}\n"
+            f"--- /DRY RUN ---"
+        )
+        return (log_ref, True, "dry-run")
+
+    assert claude_binary is not None  # narrowed by caller
+    cmd = _compose_claude_cmd(claude_binary, user_prompt, system_prompt)
+
+    cfg_dir = make_isolated_claude_config()
+    try:
+        env = {"CLAUDE_CONFIG_DIR": cfg_dir}
+        import os
+        merged = {**os.environ, **env}
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=merged,
+        )
+        if proc.returncode != 0:
+            return (
+                log_ref,
+                False,
+                f"claude exit {proc.returncode}: {proc.stderr.strip()[:500]}",
+            )
+        sidecar.write_text(proc.stdout)
+        return (log_ref, True, str(sidecar))
+    finally:
+        shutil.rmtree(cfg_dir, ignore_errors=True)
+
+
+def _shlex_quote(part: str) -> str:
+    """Quote a single arg for display (shlex.quote without importing twice)."""
+    import shlex
+    return shlex.quote(part)
+
+
+def _stage_subagents(
+    *,
+    flagged: list[dict],
+    analysis_root: Path,
+    concurrency: int,
+    force: bool,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Fan out subagents. Returns ``(succeeded, failed)`` counts."""
+    if not flagged:
+        _echo("[stage2] no flagged runs; nothing to do.")
+        return (0, 0)
+
+    out_dir = analysis_root / "subagents"
+    if not dry_run:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    system_prompt = _read_subagent_prompt()
+    claude_binary: str | None
+    if dry_run:
+        # In dry-run we prefer to show the real path when available but do not
+        # require the binary to be installed.
+        try:
+            claude_binary = find_claude_binary()
+        except FileNotFoundError:
+            claude_binary = None
+    else:
+        claude_binary = find_claude_binary()
+
+    succ = 0
+    fail = 0
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futs = {
+            pool.submit(
+                _process_one,
+                metric=m,
+                out_dir=out_dir,
+                claude_binary=claude_binary,
+                system_prompt=system_prompt,
+                force=force,
+                dry_run=dry_run,
+            ): m
+            for m in flagged
+        }
+        for fut in as_completed(futs):
+            log_ref, ok, msg = fut.result()
+            if ok:
+                succ += 1
+                _echo(f"[stage2] OK   {log_ref}: {msg}")
+            else:
+                fail += 1
+                _echo(f"[stage2] FAIL {log_ref}: {msg}", err=True)
+    return (succ, fail)
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: placeholder
+# ---------------------------------------------------------------------------
+
+
+def _stage_synthesize(*, analysis_root: Path, dry_run: bool) -> None:
+    _echo(
+        "[stage3] Stage 3 (synthesize) not yet implemented — "
+        "will be added in sub-issue #74."
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+STAGE_CHOICES = ("mechanical", "subagents", "synthesize", "all")
+
+
+def register_pathology_command(analyze_command: click.Group) -> None:
+    """Attach the ``pathology`` subcommand to the parent ``analyze`` group."""
+
+    @analyze_command.command("pathology")
+    @click.option(
+        "--results-dir",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        default=None,
+        help="Path to results directory (default: auto-detect results_swebench/).",
+    )
+    @click.option(
+        "--concurrency",
+        type=int,
+        default=8,
+        show_default=True,
+        help="Max parallel subagent invocations.",
+    )
+    @click.option(
+        "--force",
+        is_flag=True,
+        default=False,
+        help="Re-run stages even if sidecar JSON already exists.",
+    )
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        default=False,
+        help="Print composed commands/prompts without invoking claude.",
+    )
+    @click.option(
+        "--stage",
+        type=click.Choice(STAGE_CHOICES),
+        default="all",
+        show_default=True,
+        help="Which stage(s) to run.",
+    )
+    @click.option(
+        "--run-id",
+        "run_id",
+        default=None,
+        help="Identifier for this analysis run (default: UTC timestamp).",
+    )
+    def pathology_command(
+        results_dir: Path | None,
+        concurrency: int,
+        force: bool,
+        dry_run: bool,
+        stage: str,
+        run_id: str | None,
+    ) -> None:
+        """Run the log-analysis pipeline (stages 1, 2, and 3)."""
+        if concurrency < 1:
+            raise click.UsageError("--concurrency must be >= 1.")
+
+        rdir = Path(results_dir) if results_dir else (repo_root() / "results_swebench")
+        if not rdir.is_dir():
+            _echo(f"ERROR: results directory not found: {rdir}", err=True)
+            sys.exit(1)
+
+        rid = run_id or _default_run_id()
+        aroot = _analysis_root(rdir, rid)
+        if not dry_run:
+            aroot.mkdir(parents=True, exist_ok=True)
+
+        _echo(f"[pathology] results_dir={rdir}")
+        _echo(f"[pathology] run_id={rid}")
+        _echo(f"[pathology] analysis_root={aroot}")
+        _echo(f"[pathology] stage={stage} concurrency={concurrency} "
+              f"force={force} dry_run={dry_run}")
+
+        logs = _discover_logs(rdir)
+        if not logs:
+            _echo(f"[pathology] no *_run*.jsonl files found under {rdir}")
+            return
+
+        want_stage1 = stage in ("mechanical", "all")
+        want_stage2 = stage in ("subagents", "all")
+        want_stage3 = stage in ("synthesize", "all")
+
+        metrics: list[dict] = []
+        flagged: list[dict] = []
+
+        if want_stage1 or want_stage2:
+            metrics = _stage_mechanical(
+                logs=logs,
+                analysis_root=aroot,
+                force=force,
+                dry_run=dry_run,
+            )
+            flagged = _write_triage(
+                metrics=metrics,
+                analysis_root=aroot,
+                dry_run=dry_run,
+            )
+
+        if want_stage2:
+            succ, fail = _stage_subagents(
+                flagged=flagged,
+                analysis_root=aroot,
+                concurrency=concurrency,
+                force=force,
+                dry_run=dry_run,
+            )
+            _echo(f"[stage2] summary: ok={succ} fail={fail}")
+            if fail:
+                sys.exit(1)
+
+        if want_stage3:
+            _stage_synthesize(analysis_root=aroot, dry_run=dry_run)
+
+
+__all__ = [
+    "register_pathology_command",
+    "SUBAGENT_PROMPT_PATH",
+    "STAGE_CHOICES",
+]

--- a/swebench/analyze/subagent_prompt.md
+++ b/swebench/analyze/subagent_prompt.md
@@ -1,0 +1,83 @@
+# Log Analysis Subagent — Pathology Finder
+
+You are a **log analysis subagent** embedded in the SWE-bench log analysis
+pipeline (epic #62). You receive one compressed run transcript at a time and
+return a structured JSON report of pathologies observed in that single run.
+
+## Your job
+
+Read the compressed transcript provided in the user message carefully, then emit
+**one JSON object** describing any pathologies you observe. Do not narrate, do
+not wrap the JSON in markdown code fences, and do not emit anything other than
+the JSON object. Downstream tooling parses your output with a strict JSON
+validator — extra prose will cause your report to be discarded.
+
+## Pathology vocabulary
+
+Prefer these `candidate_id` slugs when a finding matches. You may coin a new
+slug (lowercase, hyphen/underscore-separated) for pathologies that don't fit,
+but only when none of the predefined categories apply:
+
+- **`monolith_collapse`** — the agent writes one enormous code block that
+  conflates exploration, editing, and verification into a single tool call.
+- **`amnesiac_retry`** — the agent re-runs near-identical code across turns
+  without incorporating prior output (high Jaccard, no learning).
+- **`error_tunnel_vision`** — the agent fixates on a stack trace from early
+  in the run and keeps poking at the same frame even after evidence points
+  elsewhere.
+- **`state_assumption_drift`** — the agent assumes filesystem, venv, or
+  module state that was never verified (and the assumption is wrong).
+- **`verification_theater`** — the agent runs commands that *look* like a
+  test but don't actually exercise the change (e.g. imports a module to
+  "verify" a fix, skipping the failing test).
+- **`exploration_churn`** — the agent spends many turns listing/reading
+  without ever attempting an edit.
+
+## Output schema (strict)
+
+```json
+{
+  "log_ref": "django__django-11964_onlycode_run1",
+  "arm": "onlycode",
+  "findings": [
+    {
+      "candidate_id": "slug-like-string",
+      "description": "one-paragraph human description",
+      "evidence_refs": [
+        {"turn": 5, "block_index": 0, "excerpt": "<=240 chars quoted code"}
+      ],
+      "severity": "low|medium|high",
+      "confidence": "low|medium|high"
+    }
+  ],
+  "notes": "optional free-form prose <=2000 chars"
+}
+```
+
+### Validator rules
+
+1. `log_ref: str` (matches the source transcript filename stem, as given in
+   the user message), `arm: str` must be one of `{"baseline", "onlycode"}`,
+   `findings: list[dict]`. `notes` is optional but must be a string if
+   present.
+2. Each finding must provide: `candidate_id` matching the regex
+   `^[a-z0-9][a-z0-9_-]{1,63}$`, `description: str`, `evidence_refs:
+   list[dict]` (may be empty), `severity` and `confidence` ∈
+   `{"low", "medium", "high"}`.
+3. **Unknown keys are rejected.** Do not add extra top-level keys or
+   extra keys inside findings. Stick to the schema above.
+4. If you observe no pathologies, emit an empty `findings` list — do not
+   omit the key.
+
+## Worked example
+
+Given a hypothetical compressed transcript for
+`django__django-11964_onlycode_run1` where the agent re-ran the same
+failing import 12 times in a row and never edited a file, a valid report
+is:
+
+```json
+{"log_ref":"django__django-11964_onlycode_run1","arm":"onlycode","findings":[{"candidate_id":"amnesiac_retry","description":"The agent ran essentially the same `python -c 'from django.db.models import Choices'` import 12 times across turns 3-14, each time observing the identical ImportError without modifying any source file or adjusting the import path.","evidence_refs":[{"turn":3,"block_index":0,"excerpt":"python -c 'from django.db.models import Choices'"},{"turn":9,"block_index":0,"excerpt":"python -c 'from django.db.models import Choices'"}],"severity":"high","confidence":"high"},{"candidate_id":"exploration_churn","description":"Turns 15-22 consist entirely of `ls`/`cat` calls against django/db/models/ with no edits attempted; the agent appears to be stalling rather than converging on a fix.","evidence_refs":[{"turn":18,"block_index":0,"excerpt":"ls django/db/models/"}],"severity":"medium","confidence":"medium"}],"notes":"Run terminates at turn 42 without ever touching django/db/models/enums.py."}
+```
+
+Emit the JSON object only. No prose, no fences.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Shared pytest fixtures for the onlycodes test suite.
+
+The primary fixture here is an autouse guard that asserts the repo-root
+``patterns.json`` file (the canonical pathology vocabulary, written by
+sub-issue #74) is not mutated by any test. Even before that file exists,
+the guard detects accidental creation.
+
+Rationale: ``patterns.json`` is a shared, version-controlled artefact used
+across the analysis pipeline. A test that writes to it would silently leak
+state into every subsequent run of the suite and into the developer's
+working tree. Failing loudly is the only acceptable behaviour.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from swebench import repo_root
+
+
+def _snapshot(path: Path) -> tuple[bool, str | None]:
+    """Return ``(exists, sha256-hex-or-None)`` for ``path``."""
+    if not path.exists():
+        return (False, None)
+    return (True, hashlib.sha256(path.read_bytes()).hexdigest())
+
+
+@pytest.fixture(autouse=True)
+def _patterns_json_is_immutable() -> None:
+    """Fail any test that writes to or deletes the repo-root ``patterns.json``.
+
+    The fixture snapshots existence + content hash before the test runs,
+    then re-snapshots after and asserts equality. It is autouse so every
+    test in the suite is protected without opt-in.
+    """
+    patterns_path = repo_root() / "patterns.json"
+    before = _snapshot(patterns_path)
+    yield
+    after = _snapshot(patterns_path)
+    assert before == after, (
+        f"Test illegally mutated {patterns_path}: "
+        f"before={before} after={after}. patterns.json is the canonical "
+        "pathology vocabulary and must never be modified by the test suite."
+    )

--- a/tests/test_analyze_run.py
+++ b/tests/test_analyze_run.py
@@ -1,0 +1,167 @@
+"""Offline tests for ``swebench analyze pathology``.
+
+These cover the ``--dry-run`` path, resume/skip semantics, option surface,
+and that Stage 3 is a recognisable placeholder. They never invoke the
+``claude`` binary — ``find_claude_binary`` is tolerated via ``--dry-run``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from swebench.analyze import analyze_command
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "analyze" / "both_arms"
+
+
+def _run(args: list[str]):
+    runner = CliRunner()
+    return runner.invoke(analyze_command, args, catch_exceptions=False)
+
+
+def test_pathology_help_lists_all_options() -> None:
+    result = _run(["pathology", "--help"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    for opt in ("--results-dir", "--concurrency", "--force", "--dry-run",
+                "--stage", "--run-id"):
+        assert opt in out, f"missing {opt} in help output:\n{out}"
+
+
+def test_pathology_dry_run_emits_commands_and_previews(tmp_path: Path) -> None:
+    # Copy fixture jsonls into an isolated dir so we don't write _analysis/ to
+    # the repo tree (even in dry-run we only read, but tmp_path keeps it tidy).
+    work = tmp_path / "results"
+    work.mkdir()
+    for p in FIXTURES_DIR.glob("*.jsonl"):
+        (work / p.name).write_text(p.read_text())
+
+    result = _run([
+        "pathology",
+        "--results-dir", str(work),
+        "--dry-run",
+        "--run-id", "test-run",
+    ])
+    assert result.exit_code == 0, result.output
+    out = result.output
+
+    # Dry-run must surface composed cmd + preview but not actually invoke.
+    assert "DRY RUN" in out
+    assert "claude" in out  # binary path (or <claude>) appears
+    assert "--allowedTools" in out
+    assert "compressed preview" in out
+    assert "Stage 3 (synthesize) not yet implemented" in out
+
+    # Dry-run must NOT create sidecars on disk.
+    analysis = work / "_analysis" / "test-run"
+    assert not analysis.exists(), (
+        f"dry-run unexpectedly created {analysis}"
+    )
+
+
+def test_pathology_resume_skip_on_second_run(tmp_path: Path) -> None:
+    work = tmp_path / "results"
+    work.mkdir()
+    for p in FIXTURES_DIR.glob("*.jsonl"):
+        (work / p.name).write_text(p.read_text())
+
+    args = [
+        "pathology",
+        "--results-dir", str(work),
+        "--stage", "mechanical",
+        "--run-id", "resume-test",
+    ]
+    first = _run(args)
+    assert first.exit_code == 0, first.output
+    assert "[stage1] extracted" in first.output
+
+    mech_dir = work / "_analysis" / "resume-test" / "mechanical"
+    sidecars = sorted(mech_dir.glob("*.json"))
+    assert sidecars, "stage 1 produced no sidecars"
+
+    # Snapshot mtimes; the second run must not rewrite them.
+    mtimes_before = {p: p.stat().st_mtime_ns for p in sidecars}
+
+    second = _run(args)
+    assert second.exit_code == 0, second.output
+    assert "[stage1] skip (cached)" in second.output
+    assert "[stage1] extracted" not in second.output
+
+    mtimes_after = {p: p.stat().st_mtime_ns for p in sidecars}
+    assert mtimes_before == mtimes_after, (
+        "resume should be a no-op but sidecars were rewritten"
+    )
+
+
+def test_pathology_force_rewrites_sidecars(tmp_path: Path) -> None:
+    work = tmp_path / "results"
+    work.mkdir()
+    for p in FIXTURES_DIR.glob("*.jsonl"):
+        (work / p.name).write_text(p.read_text())
+
+    base_args = [
+        "pathology",
+        "--results-dir", str(work),
+        "--stage", "mechanical",
+        "--run-id", "force-test",
+    ]
+    assert _run(base_args).exit_code == 0
+    forced = _run(base_args + ["--force"])
+    assert forced.exit_code == 0
+    assert "[stage1] extracted" in forced.output
+    assert "skip (cached)" not in forced.output
+
+
+def test_pathology_triage_json_written(tmp_path: Path) -> None:
+    work = tmp_path / "results"
+    work.mkdir()
+    for p in FIXTURES_DIR.glob("*.jsonl"):
+        (work / p.name).write_text(p.read_text())
+
+    result = _run([
+        "pathology",
+        "--results-dir", str(work),
+        "--stage", "mechanical",
+        "--run-id", "triage-test",
+    ])
+    assert result.exit_code == 0, result.output
+    triage_path = work / "_analysis" / "triage-test" / "triage.json"
+    assert triage_path.exists()
+    data = json.loads(triage_path.read_text())
+    assert "ranked" in data
+    assert data["cutoff_count"] >= 1
+    assert any(entry.get("flagged") for entry in data["ranked"])
+
+
+def test_pathology_stage_synthesize_is_placeholder(tmp_path: Path) -> None:
+    work = tmp_path / "results"
+    work.mkdir()
+    for p in FIXTURES_DIR.glob("*.jsonl"):
+        (work / p.name).write_text(p.read_text())
+    result = _run([
+        "pathology",
+        "--results-dir", str(work),
+        "--stage", "synthesize",
+        "--run-id", "synth-test",
+        "--dry-run",
+    ])
+    assert result.exit_code == 0, result.output
+    assert "Stage 3 (synthesize) not yet implemented" in result.output
+
+
+def test_pathology_rejects_bad_concurrency(tmp_path: Path) -> None:
+    work = tmp_path / "results"
+    work.mkdir()
+    (work / "noop_onlycode_run1.jsonl").write_text("")
+    result = _run([
+        "pathology",
+        "--results-dir", str(work),
+        "--concurrency", "0",
+    ])
+    assert result.exit_code != 0
+    assert "concurrency" in result.output.lower()

--- a/tests/test_analyze_run_integration.py
+++ b/tests/test_analyze_run_integration.py
@@ -1,0 +1,63 @@
+"""End-to-end integration test for ``swebench analyze pathology``.
+
+Requires a real ``claude`` binary; otherwise skipped cleanly. Runs the
+pipeline against the committed fixture, and asserts that at least one
+subagent sidecar is produced and parses as JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from swebench.analyze import analyze_command
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "analyze" / "both_arms"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not shutil.which("claude"),
+    reason="integration test requires the claude binary on PATH",
+)
+def test_pathology_end_to_end(tmp_path: Path) -> None:
+    work = tmp_path / "results"
+    work.mkdir()
+    for p in FIXTURES_DIR.glob("*.jsonl"):
+        (work / p.name).write_text(p.read_text())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        analyze_command,
+        [
+            "pathology",
+            "--results-dir", str(work),
+            "--stage", "subagents",
+            "--concurrency", "2",
+            "--run-id", "itest",
+        ],
+        catch_exceptions=False,
+    )
+    # Subagents may error, but the pipeline must not crash outright.
+    assert result.exit_code in (0, 1), result.output
+
+    sub_dir = work / "_analysis" / "itest" / "subagents"
+    assert sub_dir.exists(), "subagents output directory missing"
+    sidecars = list(sub_dir.glob("*.json"))
+    assert sidecars, "no subagent sidecars were produced"
+
+    # At least one sidecar should parse as JSON (the subagent prompt demands JSON).
+    parsed_any = False
+    for sc in sidecars:
+        try:
+            json.loads(sc.read_text())
+            parsed_any = True
+            break
+        except json.JSONDecodeError:
+            continue
+    assert parsed_any, "no subagent sidecar parsed as JSON"


### PR DESCRIPTION
## Summary

Implements sub-issue #73 of epic #62 (log analysis pipeline). Adds the Stage 2b runner that fans subagents out over compressed run transcripts, wires it up as a new `python -m swebench analyze pathology` CLI, and lands the system prompt / JSON schema the subagents are held to.

- New `swebench/analyze/run.py` — three-stage pipeline (mechanical extract -> triage -> per-log subagent fan-out), reusing `harness.find_claude_binary` + `harness.make_isolated_claude_config` and following the `swebench/add.py` threading template (`_print_lock`, `_process_one` returning `(id, ok, msg)`).
- New `swebench/analyze/subagent_prompt.md` — system prompt carrying the predefined pathology vocabulary, the strict JSON schema, validator rules, and a worked example.
- `swebench/analyze/__init__.py` — registers `pathology` on the existing `analyze` Click group.
- Sidecars laid out per ADR Q4: `results_swebench/_analysis/<run_id>/{mechanical,subagents}/`.
- `--dry-run` prints composed `claude -p` cmd + compressed preview without shelling out; `--force` re-runs; resume is idempotent by default.
- Stage 3 (`synthesize`) is a placeholder until #74.

## Test plan

- [x] `python -m swebench analyze pathology --help` lists all required options
- [x] `python -m swebench analyze pathology --dry-run --results-dir tests/fixtures/analyze/both_arms` surfaces the composed command + compressed preview, no sidecar files written
- [x] `pytest tests/test_analyze_run.py -v` — 7 offline tests pass (dry-run, resume, force, triage, synthesize placeholder, option surface, bad concurrency)
- [x] `pytest tests/ -m "not integration"` — 124 passed, 16 deselected
- [x] Integration test skips cleanly when `claude` binary is absent
- [x] `tests/conftest.py` autouse fixture guards the repo-root `patterns.json` against mutation

Depends on #72 (Stage 2a compressor, already merged into the epic branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)