### PR TITLE
feat: add Stage 3 synthesizer, registry.py, seed patterns.json (#74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ results/
 results_mcp/
 results_requests/
 results_swebench/
+results_swebench/_analysis/
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/patterns.json
+++ b/patterns.json
@@ -1,0 +1,4 @@
+{
+  "patterns": [],
+  "version": 1
+}

--- a/swebench/analyze/registry.py
+++ b/swebench/analyze/registry.py
@@ -1,0 +1,482 @@
+"""Registry I/O, schema validation, and merge helpers for ``patterns.json``.
+
+``patterns.json`` is the canonical pathology vocabulary for epic #62: it
+collects every distinct pathology ``candidate_id`` observed across analysis
+runs along with evidence references, per-arm frequency, and first/last-seen
+run identifiers. This module exposes:
+
+- :func:`load_patterns` — read + validate an existing file.
+- :func:`write_patterns` — atomic write via ``tmp`` + :func:`os.replace`.
+- :func:`validate` — hand-rolled schema validator for the registry file.
+- :func:`merge` — pure merge function (append-merge semantics, ADR Q5).
+- :func:`validate_subagent_output` — strict validator for Stage 2 subagent
+  JSON replies.
+
+All validators return a list of error strings; an empty list means valid.
+This keeps call sites simple (``if errors: refuse(...)``) and lets callers
+aggregate multiple problems in a single error message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Current registry schema version. Incremented only on breaking change.
+SCHEMA_VERSION = 1
+
+#: Cap on ``evidence_refs`` per pattern. See ADR merge rule 1.
+MAX_EVIDENCE_REFS = 20
+
+#: Valid arm names for ``arm_distribution`` and subagent output.
+VALID_ARMS = ("baseline", "onlycode")
+
+#: Valid severity / confidence enum values for subagent findings.
+VALID_SEVERITY = ("low", "medium", "high")
+VALID_CONFIDENCE = ("low", "medium", "high")
+
+#: ``candidate_id`` slug regex: lowercase alnum + hyphen/underscore, 2–64 chars.
+CANDIDATE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{1,63}$")
+
+#: Top-level keys allowed in ``patterns.json``.
+_REGISTRY_TOP_KEYS = {"version", "patterns"}
+
+#: Keys allowed on each pattern entry.
+_PATTERN_KEYS = {
+    "id",
+    "description",
+    "evidence_refs",
+    "frequency",
+    "arm_distribution",
+    "first_seen_run_id",
+    "last_seen_run_id",
+}
+
+#: Keys allowed on each evidence_ref entry in the registry.
+_REGISTRY_EVIDENCE_KEYS = {"log_ref", "run_id", "turn", "excerpt"}
+
+#: Top-level keys allowed in subagent JSON output.
+_SUBAGENT_TOP_KEYS = {"log_ref", "arm", "findings", "notes"}
+
+#: Keys allowed per finding in subagent output.
+_FINDING_KEYS = {
+    "candidate_id",
+    "description",
+    "evidence_refs",
+    "severity",
+    "confidence",
+}
+
+
+# ---------------------------------------------------------------------------
+# Schema validation — registry file
+# ---------------------------------------------------------------------------
+
+
+def validate(data: Any) -> list[str]:
+    """Validate a decoded ``patterns.json`` payload.
+
+    Returns a list of human-readable error strings. An empty list means the
+    payload is a well-formed v1 registry.
+    """
+    errs: list[str] = []
+    if not isinstance(data, dict):
+        return ["top-level value must be an object"]
+
+    unknown = set(data.keys()) - _REGISTRY_TOP_KEYS
+    if unknown:
+        errs.append(f"unknown top-level keys: {sorted(unknown)}")
+
+    if "version" not in data:
+        errs.append("missing key: version")
+    elif data["version"] != SCHEMA_VERSION:
+        errs.append(f"unsupported version: {data['version']} (expected {SCHEMA_VERSION})")
+
+    if "patterns" not in data:
+        errs.append("missing key: patterns")
+    elif not isinstance(data["patterns"], list):
+        errs.append("patterns must be a list")
+    else:
+        for i, pat in enumerate(data["patterns"]):
+            errs.extend(_validate_pattern(pat, i))
+
+    return errs
+
+
+def _validate_pattern(pat: Any, idx: int) -> list[str]:
+    prefix = f"patterns[{idx}]"
+    errs: list[str] = []
+    if not isinstance(pat, dict):
+        return [f"{prefix} must be an object"]
+
+    unknown = set(pat.keys()) - _PATTERN_KEYS
+    if unknown:
+        errs.append(f"{prefix} has unknown keys: {sorted(unknown)}")
+
+    missing = _PATTERN_KEYS - set(pat.keys())
+    if missing:
+        errs.append(f"{prefix} missing keys: {sorted(missing)}")
+        return errs  # further checks would cascade
+
+    pid = pat["id"]
+    if not isinstance(pid, str) or not CANDIDATE_ID_RE.match(pid):
+        errs.append(f"{prefix}.id invalid slug: {pid!r}")
+
+    if not isinstance(pat["description"], str):
+        errs.append(f"{prefix}.description must be a string")
+
+    ev = pat["evidence_refs"]
+    if not isinstance(ev, list):
+        errs.append(f"{prefix}.evidence_refs must be a list")
+    else:
+        if len(ev) > MAX_EVIDENCE_REFS:
+            errs.append(
+                f"{prefix}.evidence_refs exceeds cap {MAX_EVIDENCE_REFS} (got {len(ev)})"
+            )
+        for j, ref in enumerate(ev):
+            errs.extend(_validate_evidence_ref(ref, f"{prefix}.evidence_refs[{j}]"))
+
+    if not isinstance(pat["frequency"], int) or pat["frequency"] < 0:
+        errs.append(f"{prefix}.frequency must be a non-negative int")
+
+    ad = pat["arm_distribution"]
+    if not isinstance(ad, dict):
+        errs.append(f"{prefix}.arm_distribution must be an object")
+    else:
+        ad_unknown = set(ad.keys()) - set(VALID_ARMS)
+        if ad_unknown:
+            errs.append(f"{prefix}.arm_distribution has unknown arms: {sorted(ad_unknown)}")
+        for arm in VALID_ARMS:
+            if arm in ad and (not isinstance(ad[arm], int) or ad[arm] < 0):
+                errs.append(f"{prefix}.arm_distribution.{arm} must be a non-negative int")
+
+    for key in ("first_seen_run_id", "last_seen_run_id"):
+        if not isinstance(pat[key], str) or not pat[key]:
+            errs.append(f"{prefix}.{key} must be a non-empty string")
+
+    return errs
+
+
+def _validate_evidence_ref(ref: Any, prefix: str) -> list[str]:
+    errs: list[str] = []
+    if not isinstance(ref, dict):
+        return [f"{prefix} must be an object"]
+    unknown = set(ref.keys()) - _REGISTRY_EVIDENCE_KEYS
+    if unknown:
+        errs.append(f"{prefix} has unknown keys: {sorted(unknown)}")
+    missing = _REGISTRY_EVIDENCE_KEYS - set(ref.keys())
+    if missing:
+        errs.append(f"{prefix} missing keys: {sorted(missing)}")
+        return errs
+    if not isinstance(ref["log_ref"], str):
+        errs.append(f"{prefix}.log_ref must be a string")
+    if not isinstance(ref["run_id"], str):
+        errs.append(f"{prefix}.run_id must be a string")
+    if not isinstance(ref["turn"], int):
+        errs.append(f"{prefix}.turn must be an int")
+    if not isinstance(ref["excerpt"], str):
+        errs.append(f"{prefix}.excerpt must be a string")
+    elif len(ref["excerpt"]) > 240:
+        errs.append(f"{prefix}.excerpt exceeds 240 chars")
+    return errs
+
+
+# ---------------------------------------------------------------------------
+# File I/O
+# ---------------------------------------------------------------------------
+
+
+def load_patterns(path: Path) -> tuple[dict | None, str | None]:
+    """Load and validate ``patterns.json`` at ``path``.
+
+    Returns ``(data, None)`` on success, or ``(None, reason)`` on any of:
+    file missing, JSON decode failure, schema validation failure.
+    """
+    if not path.exists():
+        return (None, f"{path} does not exist")
+    try:
+        raw = path.read_text()
+    except OSError as exc:
+        return (None, f"read failed: {exc}")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return (None, f"JSON decode failed: {exc}")
+    errs = validate(data)
+    if errs:
+        return (None, "; ".join(errs))
+    return (data, None)
+
+
+def write_patterns(path: Path, data: dict) -> None:
+    """Atomically write ``data`` as formatted JSON to ``path``.
+
+    Writes to a sibling tempfile in the same directory and uses
+    :func:`os.replace` to swap — guaranteeing the destination is either the
+    full prior content or the full new content, never a partial write.
+    Patterns are sorted by ``id`` as a side effect for deterministic output.
+    """
+    if "patterns" in data and isinstance(data["patterns"], list):
+        data = {**data, "patterns": sorted(data["patterns"], key=lambda p: p.get("id", ""))}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Write to sibling tempfile in the same directory so os.replace is atomic
+    # (same filesystem guarantee).
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=".patterns-", suffix=".json.tmp", dir=str(path.parent)
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        # Clean up the tmp file on failure; swallow cleanup errors.
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Subagent output validation
+# ---------------------------------------------------------------------------
+
+
+def validate_subagent_output(data: Any) -> list[str]:
+    """Strict validator for a single subagent's JSON reply.
+
+    See ``swebench/analyze/subagent_prompt.md`` for the expected schema.
+    Returns a list of error strings; empty = valid. Unknown keys at either
+    the top level or inside a finding are rejected.
+    """
+    errs: list[str] = []
+    if not isinstance(data, dict):
+        return ["top-level value must be an object"]
+
+    unknown = set(data.keys()) - _SUBAGENT_TOP_KEYS
+    if unknown:
+        errs.append(f"unknown top-level keys: {sorted(unknown)}")
+
+    for req in ("log_ref", "arm", "findings"):
+        if req not in data:
+            errs.append(f"missing key: {req}")
+
+    if "log_ref" in data and not isinstance(data["log_ref"], str):
+        errs.append("log_ref must be a string")
+    if "arm" in data:
+        if not isinstance(data["arm"], str) or data["arm"] not in VALID_ARMS:
+            errs.append(f"arm must be one of {VALID_ARMS}")
+    if "notes" in data and not isinstance(data["notes"], str):
+        errs.append("notes must be a string if present")
+
+    findings = data.get("findings")
+    if findings is not None:
+        if not isinstance(findings, list):
+            errs.append("findings must be a list")
+        else:
+            for i, f in enumerate(findings):
+                errs.extend(_validate_finding(f, f"findings[{i}]"))
+
+    return errs
+
+
+def _validate_finding(f: Any, prefix: str) -> list[str]:
+    errs: list[str] = []
+    if not isinstance(f, dict):
+        return [f"{prefix} must be an object"]
+
+    unknown = set(f.keys()) - _FINDING_KEYS
+    if unknown:
+        errs.append(f"{prefix} has unknown keys: {sorted(unknown)}")
+    missing = _FINDING_KEYS - set(f.keys())
+    if missing:
+        errs.append(f"{prefix} missing keys: {sorted(missing)}")
+        return errs
+
+    cid = f["candidate_id"]
+    if not isinstance(cid, str) or not CANDIDATE_ID_RE.match(cid):
+        errs.append(f"{prefix}.candidate_id invalid slug: {cid!r}")
+    if not isinstance(f["description"], str):
+        errs.append(f"{prefix}.description must be a string")
+    if not isinstance(f["evidence_refs"], list):
+        errs.append(f"{prefix}.evidence_refs must be a list")
+    else:
+        for j, ref in enumerate(f["evidence_refs"]):
+            if not isinstance(ref, dict):
+                errs.append(f"{prefix}.evidence_refs[{j}] must be an object")
+    if f["severity"] not in VALID_SEVERITY:
+        errs.append(f"{prefix}.severity must be one of {VALID_SEVERITY}")
+    if f["confidence"] not in VALID_CONFIDENCE:
+        errs.append(f"{prefix}.confidence must be one of {VALID_CONFIDENCE}")
+    return errs
+
+
+# ---------------------------------------------------------------------------
+# Merge (pure)
+# ---------------------------------------------------------------------------
+
+
+def _empty_registry() -> dict:
+    return {"version": SCHEMA_VERSION, "patterns": []}
+
+
+def _blank_pattern(cid: str, description: str, run_id: str) -> dict:
+    return {
+        "id": cid,
+        "description": description,
+        "evidence_refs": [],
+        "frequency": 0,
+        "arm_distribution": {arm: 0 for arm in VALID_ARMS},
+        "first_seen_run_id": run_id,
+        "last_seen_run_id": run_id,
+    }
+
+
+def _dedup_key(ref: dict) -> tuple[str, str, int]:
+    return (ref.get("log_ref", ""), ref.get("run_id", ""), int(ref.get("turn", -1)))
+
+
+def merge(existing: dict, findings: list[dict], run_id: str) -> dict:
+    """Merge ``findings`` (subagent output rows) into ``existing`` registry.
+
+    ``findings`` is a flat list of dicts, each of the shape produced by
+    :func:`_flatten_findings` below — i.e. one dict per (subagent_output,
+    finding) pair, carrying ``candidate_id``, ``description``, ``log_ref``,
+    ``arm``, and a list of subagent-level ``evidence_refs``.
+
+    Pure function: does not mutate ``existing`` or ``findings``. Always
+    returns a fresh dict. Patterns in the returned registry are sorted by
+    ``id`` deterministically.
+
+    Merge rules (ADR Q5):
+      - Patterns are keyed by ``id``.
+      - If ``candidate_id`` matches an existing ``id``:
+          * frequency += 1 per new evidence_ref (de-duped by
+            ``(log_ref, run_id, turn)``)
+          * ``arm_distribution[arm]`` += 1 per new evidence_ref
+          * evidence_refs appended, bounded to MAX_EVIDENCE_REFS
+            (most-recent-first; oldest dropped)
+          * ``last_seen_run_id`` = ``run_id``
+          * description is NOT updated (first-writer-wins)
+      - If ``candidate_id`` is new: insert a fresh pattern and increment
+        as above (initial frequency counts from evidence refs).
+    """
+    # Deep-copy existing via JSON round-trip (small data, keeps it pure).
+    if existing is None:
+        merged = _empty_registry()
+    else:
+        merged = json.loads(json.dumps(existing))
+        # Tolerate a missing or incomplete skeleton.
+        merged.setdefault("version", SCHEMA_VERSION)
+        merged.setdefault("patterns", [])
+
+    by_id: dict[str, dict] = {p["id"]: p for p in merged["patterns"]}
+
+    for finding in findings:
+        cid = finding["candidate_id"]
+        description = finding.get("description", "")
+        arm = finding.get("arm", "")
+        log_ref = finding.get("log_ref", "")
+        # The finding carries subagent-level evidence refs (turn/excerpt).
+        # We promote them to registry-level refs by attaching log_ref/run_id.
+        new_refs: list[dict] = []
+        for r in finding.get("evidence_refs", []) or []:
+            new_refs.append(
+                {
+                    "log_ref": log_ref,
+                    "run_id": run_id,
+                    "turn": int(r.get("turn", 0)),
+                    "excerpt": str(r.get("excerpt", ""))[:240],
+                }
+            )
+
+        if cid in by_id:
+            pat = by_id[cid]
+        else:
+            pat = _blank_pattern(cid, description, run_id)
+            by_id[cid] = pat
+            merged["patterns"].append(pat)
+
+        # De-dup against existing refs on this pattern.
+        existing_keys = {_dedup_key(r) for r in pat["evidence_refs"]}
+        added = 0
+        # Prepend new refs most-recent-first (matches the "bounded, most-recent-first" rule).
+        for ref in new_refs:
+            if _dedup_key(ref) in existing_keys:
+                continue
+            pat["evidence_refs"].insert(0, ref)
+            existing_keys.add(_dedup_key(ref))
+            added += 1
+            if arm in pat["arm_distribution"]:
+                pat["arm_distribution"][arm] += 1
+            else:
+                # An unexpected arm slipped through validation — be strict.
+                pat["arm_distribution"][arm] = pat["arm_distribution"].get(arm, 0) + 1
+
+        pat["frequency"] = pat.get("frequency", 0) + added
+        # Stamp last_seen_run_id whenever this finding touched the pattern,
+        # regardless of whether any new evidence ref survived de-dup — the
+        # mere fact that the pattern re-surfaced in this run is meaningful.
+        pat["last_seen_run_id"] = run_id
+
+        # Cap evidence_refs; drop oldest (end of list).
+        if len(pat["evidence_refs"]) > MAX_EVIDENCE_REFS:
+            pat["evidence_refs"] = pat["evidence_refs"][:MAX_EVIDENCE_REFS]
+
+    merged["patterns"] = sorted(merged["patterns"], key=lambda p: p["id"])
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Helper: flatten a list of subagent outputs into merge()-shaped findings.
+# ---------------------------------------------------------------------------
+
+
+def flatten_findings(subagent_outputs: list[dict]) -> list[dict]:
+    """Flatten N validated subagent outputs into a flat list of findings.
+
+    Each output contributes one entry per finding, carrying the parent's
+    ``log_ref`` and ``arm`` so :func:`merge` can write evidence-ref context.
+    """
+    out: list[dict] = []
+    for sub in subagent_outputs:
+        log_ref = sub.get("log_ref", "")
+        arm = sub.get("arm", "")
+        for f in sub.get("findings", []) or []:
+            out.append(
+                {
+                    "candidate_id": f["candidate_id"],
+                    "description": f.get("description", ""),
+                    "evidence_refs": f.get("evidence_refs", []) or [],
+                    "log_ref": log_ref,
+                    "arm": arm,
+                }
+            )
+    return out
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "MAX_EVIDENCE_REFS",
+    "VALID_ARMS",
+    "CANDIDATE_ID_RE",
+    "load_patterns",
+    "write_patterns",
+    "validate",
+    "validate_subagent_output",
+    "merge",
+    "flatten_findings",
+]

--- a/swebench/analyze/run.py
+++ b/swebench/analyze/run.py
@@ -15,7 +15,10 @@ Pipeline overview (epic #62):
   to ``results_swebench/_analysis/<run_id>/subagents/<log_ref>.json``.
   Parallel fan-out follows the ``swebench/add.py`` template: ``_print_lock``
   serialises ``click.echo`` and ``_process_one`` returns ``(id, ok, msg)``.
-- **Stage 3 (synthesize).** Placeholder — implemented in sub-issue #74.
+- **Stage 3 (synthesize).** Read every Stage 2 subagent sidecar, pass the
+  full set plus the current ``patterns.json`` to a single synthesizer
+  ``claude -p`` invocation, then merge its output into the registry via
+  :func:`swebench.analyze.registry.merge` + atomic write.
 
 All stages are idempotent: runs whose sidecar JSON already exists are skipped
 unless ``--force`` is passed. ``--dry-run`` prints the composed commands and
@@ -38,6 +41,7 @@ from typing import Iterable
 import click
 
 from swebench import repo_root
+from swebench.analyze import registry
 from swebench.analyze.compress import compress
 from swebench.analyze.extractor import extract, triage_rank
 from swebench.harness import find_claude_binary, make_isolated_claude_config
@@ -359,15 +363,179 @@ def _stage_subagents(
 
 
 # ---------------------------------------------------------------------------
-# Stage 3: placeholder
+# Stage 3: synthesize
 # ---------------------------------------------------------------------------
 
 
-def _stage_synthesize(*, analysis_root: Path, dry_run: bool) -> None:
-    _echo(
-        "[stage3] Stage 3 (synthesize) not yet implemented — "
-        "will be added in sub-issue #74."
+#: Path to the synthesizer system prompt, shipped alongside this module.
+SYNTHESIZER_PROMPT_PATH = Path(__file__).parent / "synthesizer_prompt.md"
+
+#: Dry-run preview cap on the synthesizer user prompt (characters).
+DRY_RUN_SYNTH_PREVIEW_CHARS = 400
+
+
+def _read_synthesizer_prompt() -> str:
+    """Read and return the Stage 3 synthesizer system prompt."""
+    return SYNTHESIZER_PROMPT_PATH.read_text()
+
+
+def _collect_subagent_outputs(analysis_root: Path) -> list[dict]:
+    """Load every valid subagent sidecar under ``analysis_root/subagents/``.
+
+    Invalid or unparseable sidecars are logged via :func:`_echo` and skipped
+    — one bad subagent reply must not block synthesis of the rest.
+    """
+    sub_dir = analysis_root / "subagents"
+    if not sub_dir.is_dir():
+        return []
+    outputs: list[dict] = []
+    for sc in sorted(sub_dir.glob("*.json")):
+        try:
+            data = json.loads(sc.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            _echo(f"[stage3] skip unreadable sidecar {sc.name}: {exc}", err=True)
+            continue
+        errs = registry.validate_subagent_output(data)
+        if errs:
+            _echo(
+                f"[stage3] skip invalid sidecar {sc.name}: {'; '.join(errs[:3])}",
+                err=True,
+            )
+            continue
+        outputs.append(data)
+    return outputs
+
+
+def _build_synth_user_prompt(
+    existing_registry: dict, subagent_outputs: list[dict]
+) -> str:
+    """Build the user prompt for the synthesizer agent."""
+    return (
+        "## Current patterns.json\n\n"
+        f"```json\n{json.dumps(existing_registry, indent=2, sort_keys=True)}\n```\n\n"
+        "## Per-log subagent outputs\n\n"
+        f"```json\n{json.dumps(subagent_outputs, indent=2, sort_keys=True)}\n```\n"
     )
+
+
+def _compose_synth_cmd(claude_binary: str, user_prompt: str, system_prompt: str) -> list[str]:
+    """Compose the ``claude -p`` command for the Stage 3 synthesizer."""
+    return [
+        claude_binary,
+        "-p", user_prompt,
+        "--system-prompt", system_prompt,
+        "--allowedTools", "Read,Write",
+        "--dangerously-skip-permissions",
+        "--no-session-persistence",
+        "--output-format", "text",
+    ]
+
+
+def _stage_synthesize(
+    *,
+    analysis_root: Path,
+    run_id: str,
+    patterns_path: Path,
+    force: bool,
+    dry_run: bool,
+) -> tuple[bool, str]:
+    """Synthesize per-log findings into ``patterns.json``.
+
+    Returns ``(ok, message)``. Refuses to run on a malformed existing
+    ``patterns.json`` unless ``force`` is set (ADR Q2).
+    """
+    outputs = _collect_subagent_outputs(analysis_root)
+    _echo(f"[stage3] loaded {len(outputs)} subagent sidecar(s) for synthesis")
+
+    # Load existing registry; refuse to run on malformed unless --force.
+    if patterns_path.exists():
+        data, err = registry.load_patterns(patterns_path)
+        if err is not None and not force:
+            msg = (
+                f"patterns.json at {patterns_path} failed schema validation: "
+                f"{err}. Re-run with --force to overwrite, or manually repair."
+            )
+            _echo(f"[stage3] ERROR: {msg}", err=True)
+            return (False, msg)
+        existing = data if data is not None else {"version": registry.SCHEMA_VERSION, "patterns": []}
+    else:
+        existing = {"version": registry.SCHEMA_VERSION, "patterns": []}
+
+    system_prompt = _read_synthesizer_prompt()
+
+    claude_binary: str | None
+    if dry_run:
+        try:
+            claude_binary = find_claude_binary()
+        except FileNotFoundError:
+            claude_binary = None
+    else:
+        claude_binary = find_claude_binary()
+
+    user_prompt = _build_synth_user_prompt(existing, outputs)
+
+    if dry_run:
+        binary_display = claude_binary or "<claude>"
+        cmd = _compose_synth_cmd(binary_display, user_prompt, system_prompt)
+        preview = user_prompt[:DRY_RUN_SYNTH_PREVIEW_CHARS]
+        _echo(
+            f"--- DRY RUN: stage3 synthesizer ---\n"
+            f"patterns_path: {patterns_path}\n"
+            f"run_id: {run_id}\n"
+            f"subagent outputs: {len(outputs)}\n"
+            f"cmd: {' '.join(_shlex_quote(p) for p in cmd[:6])} ...\n"
+            f"user prompt preview (first {DRY_RUN_SYNTH_PREVIEW_CHARS} chars):\n"
+            f"{preview}\n"
+            f"--- /DRY RUN ---"
+        )
+        return (True, "dry-run")
+
+    if not outputs:
+        _echo("[stage3] no subagent outputs — skipping synthesizer call, registry unchanged.")
+        return (True, "no outputs")
+
+    assert claude_binary is not None
+    cmd = _compose_synth_cmd(claude_binary, user_prompt, system_prompt)
+
+    cfg_dir = make_isolated_claude_config()
+    try:
+        import os as _os
+        merged_env = {**_os.environ, "CLAUDE_CONFIG_DIR": cfg_dir}
+        proc = subprocess.run(cmd, capture_output=True, text=True, env=merged_env)
+        if proc.returncode != 0:
+            msg = f"synthesizer exit {proc.returncode}: {proc.stderr.strip()[:500]}"
+            _echo(f"[stage3] ERROR: {msg}", err=True)
+            return (False, msg)
+        try:
+            synth = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            msg = f"synthesizer output not valid JSON: {exc}"
+            _echo(f"[stage3] ERROR: {msg}", err=True)
+            # Persist raw output alongside for debugging.
+            (analysis_root / "synthesizer_raw.txt").write_text(proc.stdout)
+            return (False, msg)
+    finally:
+        shutil.rmtree(cfg_dir, ignore_errors=True)
+
+    findings = synth.get("findings", []) if isinstance(synth, dict) else []
+    if not isinstance(findings, list):
+        msg = "synthesizer output missing 'findings' list"
+        _echo(f"[stage3] ERROR: {msg}", err=True)
+        return (False, msg)
+
+    merged = registry.merge(existing, findings, run_id=run_id)
+    errs = registry.validate(merged)
+    if errs:
+        msg = f"merged registry failed schema validation: {'; '.join(errs[:3])}"
+        _echo(f"[stage3] ERROR: {msg}", err=True)
+        return (False, msg)
+
+    registry.write_patterns(patterns_path, merged)
+    _echo(
+        f"[stage3] wrote {patterns_path} "
+        f"({len(merged['patterns'])} patterns after merge)"
+    )
+    return (True, str(patterns_path))
 
 
 # ---------------------------------------------------------------------------
@@ -486,11 +654,21 @@ def register_pathology_command(analyze_command: click.Group) -> None:
                 sys.exit(1)
 
         if want_stage3:
-            _stage_synthesize(analysis_root=aroot, dry_run=dry_run)
+            patterns_path = repo_root() / "patterns.json"
+            ok, msg = _stage_synthesize(
+                analysis_root=aroot,
+                run_id=rid,
+                patterns_path=patterns_path,
+                force=force,
+                dry_run=dry_run,
+            )
+            if not ok:
+                sys.exit(1)
 
 
 __all__ = [
     "register_pathology_command",
     "SUBAGENT_PROMPT_PATH",
+    "SYNTHESIZER_PROMPT_PATH",
     "STAGE_CHOICES",
 ]

--- a/swebench/analyze/synthesizer_prompt.md
+++ b/swebench/analyze/synthesizer_prompt.md
@@ -1,0 +1,73 @@
+# Log Analysis Synthesizer — Pattern Registry Merger
+
+You are the **synthesizer agent** (Stage 3) in the SWE-bench log analysis
+pipeline (epic #62). Stage 2 spawned a fan-out of per-log subagents, each of
+which produced a JSON report of pathologies it observed in a single run
+transcript. Your job is to read all of those per-log reports at once and
+emit a **single merged JSON object** suitable for folding into the registry
+at `patterns.json`.
+
+You will receive:
+
+1. The **current `patterns.json`** content (the existing pathology
+   vocabulary — may be empty on first run).
+2. A list of **per-log subagent outputs**, each shaped as:
+   ```json
+   {"log_ref": "<stem>", "arm": "baseline|onlycode",
+    "findings": [{"candidate_id": "...", "description": "...",
+                  "evidence_refs": [{"turn": 5, "excerpt": "..."}],
+                  "severity": "low|medium|high",
+                  "confidence": "low|medium|high"}],
+    "notes": "..."}
+   ```
+
+## What to do
+
+1. Read every subagent output. Group findings by `candidate_id`.
+2. **Reuse existing `id`s** from `patterns.json` whenever a new finding
+   matches an existing pattern semantically. Coin new slugs only when no
+   existing one applies. Slugs must match `^[a-z0-9][a-z0-9_-]{1,63}$`.
+3. Prefer the pathology vocabulary listed in the subagent prompt
+   (`monolith_collapse`, `amnesiac_retry`, `error_tunnel_vision`,
+   `state_assumption_drift`, `verification_theater`,
+   `exploration_churn`) before inventing new slugs.
+4. For each distinct `candidate_id`, emit one consolidated finding with:
+   - a single canonical `description` (one paragraph),
+   - all corresponding `evidence_refs` (up to 20, most compelling first).
+
+## Output schema (strict)
+
+Emit **exactly one JSON object**, no prose, no markdown fences:
+
+```json
+{
+  "findings": [
+    {
+      "candidate_id": "amnesiac_retry",
+      "description": "one-paragraph canonical description",
+      "evidence_refs": [
+        {"log_ref": "django__django-11964_onlycode_run1",
+         "arm": "onlycode",
+         "turn": 5,
+         "excerpt": "<=240 chars"}
+      ]
+    }
+  ]
+}
+```
+
+### Rules
+
+- `findings` is a list of merged candidates. Evidence refs must carry
+  `log_ref` (so downstream can trace back to the source) and `arm`.
+- Excerpts are capped at 240 characters; truncate with an ellipsis if longer.
+- Do not include fields outside the schema above.
+- If no pathologies were reported across all subagent outputs, emit
+  `{"findings": []}`.
+
+Your output is consumed by a deterministic merge step that increments
+frequency counts, de-dups evidence refs by `(log_ref, run_id, turn)`, and
+stamps `first_seen_run_id` / `last_seen_run_id`. You do **not** compute
+those fields — the Python caller does.
+
+Emit the JSON object only.

--- a/tests/test_analyze_registry.py
+++ b/tests/test_analyze_registry.py
@@ -1,0 +1,464 @@
+"""Unit tests for ``swebench.analyze.registry``.
+
+All writes go to ``tmp_path``; the autouse guard in ``conftest.py`` asserts
+the repo-root ``patterns.json`` is never touched by the test suite.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from swebench.analyze import registry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_registry() -> dict:
+    return {"version": 1, "patterns": []}
+
+
+def _make_finding(
+    cid: str = "amnesiac_retry",
+    *,
+    log_ref: str = "django__django-11964_onlycode_run1",
+    arm: str = "onlycode",
+    turn: int = 5,
+    excerpt: str = "python -c 'import django'",
+    description: str = "agent re-ran same command repeatedly",
+) -> dict:
+    return {
+        "candidate_id": cid,
+        "description": description,
+        "evidence_refs": [{"turn": turn, "excerpt": excerpt}],
+        "log_ref": log_ref,
+        "arm": arm,
+    }
+
+
+def _make_subagent_output(
+    *,
+    log_ref: str = "django__django-11964_onlycode_run1",
+    arm: str = "onlycode",
+    cid: str = "amnesiac_retry",
+    extras: dict | None = None,
+) -> dict:
+    base = {
+        "log_ref": log_ref,
+        "arm": arm,
+        "findings": [
+            {
+                "candidate_id": cid,
+                "description": "x",
+                "evidence_refs": [{"turn": 1, "excerpt": "code"}],
+                "severity": "high",
+                "confidence": "high",
+            }
+        ],
+    }
+    if extras:
+        base.update(extras)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# load_patterns
+# ---------------------------------------------------------------------------
+
+
+def test_load_patterns_happy(tmp_path: Path) -> None:
+    p = tmp_path / "patterns.json"
+    p.write_text(json.dumps(_seed_registry()))
+    data, err = registry.load_patterns(p)
+    assert err is None
+    assert data == _seed_registry()
+
+
+def test_load_patterns_missing_file(tmp_path: Path) -> None:
+    data, err = registry.load_patterns(tmp_path / "nope.json")
+    assert data is None
+    assert err and "does not exist" in err
+
+
+def test_load_patterns_malformed_json(tmp_path: Path) -> None:
+    p = tmp_path / "patterns.json"
+    p.write_text("not-json{{")
+    data, err = registry.load_patterns(p)
+    assert data is None
+    assert err and "JSON decode" in err
+
+
+def test_load_patterns_schema_fail(tmp_path: Path) -> None:
+    p = tmp_path / "patterns.json"
+    p.write_text(json.dumps({"version": 99, "patterns": []}))
+    data, err = registry.load_patterns(p)
+    assert data is None
+    assert err and "unsupported version" in err
+
+
+def test_load_patterns_unknown_top_key(tmp_path: Path) -> None:
+    p = tmp_path / "patterns.json"
+    p.write_text(json.dumps({"version": 1, "patterns": [], "extra": 1}))
+    data, err = registry.load_patterns(p)
+    assert data is None
+    assert err and "unknown top-level keys" in err
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_empty_ok() -> None:
+    assert registry.validate(_seed_registry()) == []
+
+
+def test_validate_not_dict() -> None:
+    errs = registry.validate([])
+    assert errs and "object" in errs[0]
+
+
+def test_validate_full_pattern_ok() -> None:
+    data = {
+        "version": 1,
+        "patterns": [
+            {
+                "id": "amnesiac_retry",
+                "description": "x",
+                "evidence_refs": [
+                    {"log_ref": "a", "run_id": "r", "turn": 1, "excerpt": "e"}
+                ],
+                "frequency": 1,
+                "arm_distribution": {"baseline": 0, "onlycode": 1},
+                "first_seen_run_id": "r",
+                "last_seen_run_id": "r",
+            }
+        ],
+    }
+    assert registry.validate(data) == []
+
+
+def test_validate_bad_pattern_id() -> None:
+    data = {
+        "version": 1,
+        "patterns": [
+            {
+                "id": "BadID!",
+                "description": "x",
+                "evidence_refs": [],
+                "frequency": 0,
+                "arm_distribution": {"baseline": 0, "onlycode": 0},
+                "first_seen_run_id": "r",
+                "last_seen_run_id": "r",
+            }
+        ],
+    }
+    errs = registry.validate(data)
+    assert any("invalid slug" in e for e in errs)
+
+
+def test_validate_pattern_missing_key() -> None:
+    data = {
+        "version": 1,
+        "patterns": [{"id": "ok_id"}],
+    }
+    errs = registry.validate(data)
+    assert any("missing keys" in e for e in errs)
+
+
+def test_validate_evidence_ref_excerpt_too_long() -> None:
+    data = {
+        "version": 1,
+        "patterns": [
+            {
+                "id": "foo",
+                "description": "x",
+                "evidence_refs": [
+                    {
+                        "log_ref": "a",
+                        "run_id": "r",
+                        "turn": 1,
+                        "excerpt": "x" * 241,
+                    }
+                ],
+                "frequency": 0,
+                "arm_distribution": {"baseline": 0, "onlycode": 0},
+                "first_seen_run_id": "r",
+                "last_seen_run_id": "r",
+            }
+        ],
+    }
+    errs = registry.validate(data)
+    assert any("240" in e for e in errs)
+
+
+# ---------------------------------------------------------------------------
+# validate_subagent_output
+# ---------------------------------------------------------------------------
+
+
+def test_validate_subagent_ok() -> None:
+    assert registry.validate_subagent_output(_make_subagent_output()) == []
+
+
+def test_validate_subagent_unknown_top_key() -> None:
+    data = _make_subagent_output(extras={"extra": 1})
+    errs = registry.validate_subagent_output(data)
+    assert any("unknown top-level keys" in e for e in errs)
+
+
+def test_validate_subagent_bad_arm() -> None:
+    data = _make_subagent_output(arm="control")
+    errs = registry.validate_subagent_output(data)
+    assert any("arm must be" in e for e in errs)
+
+
+def test_validate_subagent_notes_wrong_type() -> None:
+    data = _make_subagent_output(extras={"notes": 42})
+    errs = registry.validate_subagent_output(data)
+    assert any("notes" in e for e in errs)
+
+
+def test_validate_subagent_finding_missing_key() -> None:
+    data = _make_subagent_output()
+    del data["findings"][0]["severity"]
+    errs = registry.validate_subagent_output(data)
+    assert any("missing keys" in e for e in errs)
+
+
+def test_validate_subagent_finding_bad_candidate_id() -> None:
+    data = _make_subagent_output()
+    data["findings"][0]["candidate_id"] = "X"
+    errs = registry.validate_subagent_output(data)
+    assert any("invalid slug" in e for e in errs)
+
+
+def test_validate_subagent_finding_unknown_key() -> None:
+    data = _make_subagent_output()
+    data["findings"][0]["extra"] = 1
+    errs = registry.validate_subagent_output(data)
+    assert any("unknown keys" in e for e in errs)
+
+
+def test_validate_subagent_missing_findings() -> None:
+    data = {"log_ref": "x", "arm": "onlycode"}
+    errs = registry.validate_subagent_output(data)
+    assert any("findings" in e for e in errs)
+
+
+# ---------------------------------------------------------------------------
+# write_patterns (atomic) + deterministic sort
+# ---------------------------------------------------------------------------
+
+
+def test_write_patterns_atomic_and_sorted(tmp_path: Path) -> None:
+    p = tmp_path / "patterns.json"
+    data = {
+        "version": 1,
+        "patterns": [
+            {
+                "id": "zzz",
+                "description": "z",
+                "evidence_refs": [],
+                "frequency": 0,
+                "arm_distribution": {"baseline": 0, "onlycode": 0},
+                "first_seen_run_id": "r",
+                "last_seen_run_id": "r",
+            },
+            {
+                "id": "aaa",
+                "description": "a",
+                "evidence_refs": [],
+                "frequency": 0,
+                "arm_distribution": {"baseline": 0, "onlycode": 0},
+                "first_seen_run_id": "r",
+                "last_seen_run_id": "r",
+            },
+        ],
+    }
+    registry.write_patterns(p, data)
+    written = json.loads(p.read_text())
+    ids = [pat["id"] for pat in written["patterns"]]
+    assert ids == ["aaa", "zzz"]
+    # No stray tempfiles left behind.
+    leftover = [f for f in os.listdir(tmp_path) if f.startswith(".patterns-")]
+    assert leftover == []
+
+
+def test_write_patterns_crash_mid_write_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``os.replace`` fails mid-write, the destination must be untouched."""
+    p = tmp_path / "patterns.json"
+    # Seed with a known-good file first.
+    seed = _seed_registry()
+    registry.write_patterns(p, seed)
+    original = p.read_bytes()
+
+    def _boom(src, dst):  # noqa: ARG001
+        raise OSError("simulated crash")
+
+    monkeypatch.setattr(os, "replace", _boom)
+    with pytest.raises(OSError, match="simulated crash"):
+        registry.write_patterns(p, {"version": 1, "patterns": []})
+
+    # Original file is intact.
+    assert p.read_bytes() == original
+    # Tempfile was cleaned up.
+    leftover = [f for f in os.listdir(tmp_path) if f.startswith(".patterns-")]
+    assert leftover == []
+
+
+def test_write_patterns_creates_parent_dir(tmp_path: Path) -> None:
+    p = tmp_path / "nested" / "dir" / "patterns.json"
+    registry.write_patterns(p, _seed_registry())
+    assert p.exists()
+
+
+# ---------------------------------------------------------------------------
+# merge (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_new_id_insertion() -> None:
+    existing = _seed_registry()
+    out = registry.merge(existing, [_make_finding()], run_id="r1")
+    assert len(out["patterns"]) == 1
+    pat = out["patterns"][0]
+    assert pat["id"] == "amnesiac_retry"
+    assert pat["frequency"] == 1
+    assert pat["arm_distribution"] == {"baseline": 0, "onlycode": 1}
+    assert pat["first_seen_run_id"] == "r1"
+    assert pat["last_seen_run_id"] == "r1"
+    assert existing == _seed_registry()  # pure: not mutated
+
+
+def test_merge_same_id_collision_increments() -> None:
+    existing = _seed_registry()
+    r1 = registry.merge(existing, [_make_finding(turn=1)], run_id="r1")
+    r2 = registry.merge(
+        r1,
+        [_make_finding(turn=2, log_ref="other_onlycode_run1")],
+        run_id="r2",
+    )
+    pat = r2["patterns"][0]
+    assert pat["frequency"] == 2
+    assert pat["arm_distribution"]["onlycode"] == 2
+    assert pat["first_seen_run_id"] == "r1"
+    assert pat["last_seen_run_id"] == "r2"
+    assert len(pat["evidence_refs"]) == 2
+
+
+def test_merge_evidence_dedup_by_tuple() -> None:
+    existing = _seed_registry()
+    r1 = registry.merge(existing, [_make_finding(turn=5)], run_id="r1")
+    # Same (log_ref, run_id, turn) — should be de-duped.
+    r2 = registry.merge(r1, [_make_finding(turn=5)], run_id="r1")
+    pat = r2["patterns"][0]
+    assert pat["frequency"] == 1
+    assert len(pat["evidence_refs"]) == 1
+
+
+def test_merge_evidence_cap_at_20() -> None:
+    existing = _seed_registry()
+    current = existing
+    for turn in range(25):
+        current = registry.merge(
+            current,
+            [_make_finding(turn=turn, log_ref=f"log_{turn}")],
+            run_id="r1",
+        )
+    pat = current["patterns"][0]
+    assert len(pat["evidence_refs"]) == registry.MAX_EVIDENCE_REFS
+    # Most-recent-first: the last added (turn=24) must be present.
+    assert pat["evidence_refs"][0]["turn"] == 24
+    # Oldest (turn=0) must have been dropped.
+    assert all(r["turn"] != 0 for r in pat["evidence_refs"])
+
+
+def test_merge_arm_distribution_sums_both_arms() -> None:
+    existing = _seed_registry()
+    findings = [
+        _make_finding(arm="baseline", log_ref="b1", turn=1),
+        _make_finding(arm="baseline", log_ref="b2", turn=1),
+        _make_finding(arm="onlycode", log_ref="o1", turn=1),
+    ]
+    out = registry.merge(existing, findings, run_id="r1")
+    pat = out["patterns"][0]
+    assert pat["arm_distribution"] == {"baseline": 2, "onlycode": 1}
+    assert pat["frequency"] == 3
+
+
+def test_merge_first_writer_wins_description() -> None:
+    existing = _seed_registry()
+    r1 = registry.merge(
+        existing,
+        [_make_finding(description="first description")],
+        run_id="r1",
+    )
+    r2 = registry.merge(
+        r1,
+        [_make_finding(log_ref="other", turn=9, description="DIFFERENT description")],
+        run_id="r2",
+    )
+    assert r2["patterns"][0]["description"] == "first description"
+
+
+def test_merge_sorts_patterns_by_id() -> None:
+    existing = _seed_registry()
+    findings = [
+        _make_finding(cid="zzz_last", log_ref="a", turn=1),
+        _make_finding(cid="aaa_first", log_ref="b", turn=1),
+        _make_finding(cid="mmm_mid", log_ref="c", turn=1),
+    ]
+    out = registry.merge(existing, findings, run_id="r1")
+    assert [p["id"] for p in out["patterns"]] == ["aaa_first", "mmm_mid", "zzz_last"]
+
+
+def test_merge_is_pure_no_mutation() -> None:
+    existing = _seed_registry()
+    snapshot = json.dumps(existing, sort_keys=True)
+    findings = [_make_finding()]
+    findings_snapshot = json.dumps(findings, sort_keys=True)
+    registry.merge(existing, findings, run_id="r1")
+    assert json.dumps(existing, sort_keys=True) == snapshot
+    assert json.dumps(findings, sort_keys=True) == findings_snapshot
+
+
+def test_merge_accepts_none_existing() -> None:
+    out = registry.merge(None, [_make_finding()], run_id="r1")  # type: ignore[arg-type]
+    assert out["version"] == 1
+    assert len(out["patterns"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# flatten_findings
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_findings_carries_log_ref_and_arm() -> None:
+    outputs = [
+        {
+            "log_ref": "X_onlycode_run1",
+            "arm": "onlycode",
+            "findings": [
+                {
+                    "candidate_id": "cid1",
+                    "description": "d",
+                    "evidence_refs": [{"turn": 1, "excerpt": "e"}],
+                    "severity": "low",
+                    "confidence": "low",
+                }
+            ],
+        }
+    ]
+    flat = registry.flatten_findings(outputs)
+    assert len(flat) == 1
+    assert flat[0]["log_ref"] == "X_onlycode_run1"
+    assert flat[0]["arm"] == "onlycode"

--- a/tests/test_analyze_run.py
+++ b/tests/test_analyze_run.py
@@ -1,7 +1,7 @@
 """Offline tests for ``swebench analyze pathology``.
 
 These cover the ``--dry-run`` path, resume/skip semantics, option surface,
-and that Stage 3 is a recognisable placeholder. They never invoke the
+and Stage 3's composed synthesizer command. They never invoke the
 ``claude`` binary — ``find_claude_binary`` is tolerated via ``--dry-run``.
 """
 
@@ -55,7 +55,8 @@ def test_pathology_dry_run_emits_commands_and_previews(tmp_path: Path) -> None:
     assert "claude" in out  # binary path (or <claude>) appears
     assert "--allowedTools" in out
     assert "compressed preview" in out
-    assert "Stage 3 (synthesize) not yet implemented" in out
+    # Stage 3 synthesizer should also emit its own dry-run banner.
+    assert "stage3 synthesizer" in out
 
     # Dry-run must NOT create sidecars on disk.
     analysis = work / "_analysis" / "test-run"
@@ -138,7 +139,13 @@ def test_pathology_triage_json_written(tmp_path: Path) -> None:
     assert any(entry.get("flagged") for entry in data["ranked"])
 
 
-def test_pathology_stage_synthesize_is_placeholder(tmp_path: Path) -> None:
+def test_pathology_stage_synthesize_dry_run(tmp_path: Path) -> None:
+    """Stage 3 synthesizer prints its composed claude command under --dry-run.
+
+    Runs with ``--stage synthesize`` only (skipping stages 1 and 2), which
+    means the synthesizer sees zero subagent outputs — but should still
+    compose + display its command against the seeded repo-root registry.
+    """
     work = tmp_path / "results"
     work.mkdir()
     for p in FIXTURES_DIR.glob("*.jsonl"):
@@ -151,7 +158,10 @@ def test_pathology_stage_synthesize_is_placeholder(tmp_path: Path) -> None:
         "--dry-run",
     ])
     assert result.exit_code == 0, result.output
-    assert "Stage 3 (synthesize) not yet implemented" in result.output
+    assert "stage3 synthesizer" in result.output
+    assert "--system-prompt" in result.output or "synthesizer_prompt" in result.output
+    # Stage 3 dry-run must not mutate the repo-root patterns.json; the
+    # autouse guard in conftest.py enforces this.
 
 
 def test_pathology_rejects_bad_concurrency(tmp_path: Path) -> None:

--- a/tests/test_analyze_run_integration.py
+++ b/tests/test_analyze_run_integration.py
@@ -1,8 +1,13 @@
 """End-to-end integration test for ``swebench analyze pathology``.
 
-Requires a real ``claude`` binary; otherwise skipped cleanly. Runs the
-pipeline against the committed fixture, and asserts that at least one
-subagent sidecar is produced and parses as JSON.
+Two flavours:
+
+- ``test_pathology_end_to_end_subagents`` — requires a real ``claude``
+  binary; runs stages 1 + 2 against the committed fixture and asserts
+  at least one subagent sidecar parses as JSON.
+- ``test_pathology_full_pipeline_dry_run`` — offline dry-run over all
+  three stages, asserting the synthesizer command appears in output
+  and the registry file at the repo root is not touched.
 """
 
 from __future__ import annotations
@@ -14,6 +19,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from swebench import repo_root
 from swebench.analyze import analyze_command
 
 
@@ -25,7 +31,7 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "analyze" / "both_arms"
     not shutil.which("claude"),
     reason="integration test requires the claude binary on PATH",
 )
-def test_pathology_end_to_end(tmp_path: Path) -> None:
+def test_pathology_end_to_end_subagents(tmp_path: Path) -> None:
     work = tmp_path / "results"
     work.mkdir()
     for p in FIXTURES_DIR.glob("*.jsonl"):
@@ -61,3 +67,44 @@ def test_pathology_end_to_end(tmp_path: Path) -> None:
         except json.JSONDecodeError:
             continue
     assert parsed_any, "no subagent sidecar parsed as JSON"
+
+
+def test_pathology_full_pipeline_dry_run(tmp_path: Path) -> None:
+    """All three stages run end-to-end under ``--dry-run``, offline.
+
+    - Stage 1 mechanical (dry-run computes metrics in memory).
+    - Stage 2 subagents (dry-run prints composed claude commands).
+    - Stage 3 synthesizer (dry-run prints composed claude command,
+      does NOT touch patterns.json).
+
+    The autouse ``_patterns_json_is_immutable`` fixture in conftest.py
+    enforces that the repo-root patterns.json is unchanged after this
+    test completes.
+    """
+    work = tmp_path / "results"
+    work.mkdir()
+    for p in FIXTURES_DIR.glob("*.jsonl"):
+        (work / p.name).write_text(p.read_text())
+
+    runner = CliRunner()
+    result = runner.invoke(
+        analyze_command,
+        [
+            "pathology",
+            "--results-dir", str(work),
+            "--dry-run",
+            "--run-id", "itest-dry",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # Each stage announces itself via a dedicated token in stdout.
+    out = result.output
+    assert "would extract" in out, "stage 1 dry-run banner missing"
+    assert "DRY RUN:" in out, "stage 2 dry-run banner missing"
+    assert "stage3 synthesizer" in out, "stage 3 dry-run banner missing"
+    # Dry-run must not have written anything under _analysis/.
+    assert not (work / "_analysis" / "itest-dry").exists()
+    # And it must not have touched the repo-root registry.
+    root_patterns = repo_root() / "patterns.json"
+    assert root_patterns.exists(), "seed patterns.json missing from repo root"


### PR DESCRIPTION
## Summary

Resolves sub-issue #74 of epic #62.

- Adds `swebench/analyze/registry.py` with `load_patterns`, `write_patterns` (atomic via tmp + `os.replace`), hand-rolled `validate`, `validate_subagent_output` (strict — unknown keys rejected), and a pure `merge()` implementing ADR Q5 append-merge semantics.
- Adds `swebench/analyze/synthesizer_prompt.md` (system prompt) and wires Stage 3 into `swebench/analyze/run.py`, replacing the #73 placeholder with a real single-shot synthesizer `claude -p` call. `--dry-run` composes and previews the command without invoking claude.
- Seeds the canonical `patterns.json` at repo root (`{"version":1,"patterns":[]}`, tracked, not gitignored).
- Adds `results_swebench/_analysis/` to `.gitignore` (documentary — parent dir is already ignored).

## ADR compliance

- **Q2 (crash-recovery):** malformed existing `patterns.json` refuses to run unless `--force`; error message matches the ADR verbatim.
- **Q5 (append-merge):** `merge()` is pure, patterns keyed by `id`, evidence de-duped by `(log_ref, run_id, turn)`, `evidence_refs` capped at 20 (most-recent-first), first-writer-wins description, arm_distribution summed, `last_seen_run_id` stamped on every re-surfacing, deterministic id-sort on write, atomic `tmp` + `os.replace`.

## Test plan

- [x] `python -c "from swebench.analyze.registry import load_patterns, write_patterns, validate"` (imports)
- [x] `pytest tests/test_analyze_registry.py -v` — 32 passed
- [x] `python -m swebench analyze pathology --dry-run --results-dir tests/fixtures/analyze/both_arms` — prints stage 3 synthesizer command
- [x] `python -c "import json; json.load(open('patterns.json'))"` — parses
- [x] `git check-ignore -v patterns.json` — exits nonzero (not ignored)
- [x] `pytest tests/ -m "not integration" -q` — 157 passed
- [x] Coverage on `swebench/analyze/registry.py` is 85% (target met)
- [ ] Integration test `test_pathology_end_to_end_subagents` (requires live `claude` binary) — run manually

## Files

- `swebench/analyze/registry.py` (new)
- `swebench/analyze/synthesizer_prompt.md` (new)
- `swebench/analyze/run.py` (Stage 3 wired in, placeholder removed)
- `patterns.json` (new, tracked)
- `tests/test_analyze_registry.py` (new)
- `tests/test_analyze_run_integration.py` (expanded: full-pipeline dry-run)
- `tests/test_analyze_run.py` (updated: synthesize dry-run banner assertion)
- `.gitignore` (adds `results_swebench/_analysis/`)

Co-authored-by: Claude Code <noreply@anthropic.com>