### PR TITLE
feat(#94): artifact-mode harness (loader, materializer, grader, CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ results_mcp/
 results_requests/
 results_swebench/
 results_swebench/_analysis/
+results_artifact/
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/docs/adr-0001-artifact-mode.md
+++ b/docs/adr-0001-artifact-mode.md
@@ -1,6 +1,6 @@
 # ADR-0001: Artifact-Graded Benchmark Mode — CLI Surface and Sandbox Wiring
 
-**Status:** STUB — to be filled by epic #92 harness slice (#2).
+**Status:** Accepted (filled by harness slice #94).
 
 **Context:** Epic #92 ships a second benchmark mode ("artifact-graded") alongside SWE-bench mode. The on-disk schema for tasks is frozen in [`docs/SCHEMA_ARTIFACT.md`](SCHEMA_ARTIFACT.md). This ADR records the remaining implementation-level decisions that the harness slice must pin before seed tasks land. They are deliberately deferred from the schema doc because they are operational, not structural.
 
@@ -17,9 +17,16 @@ Options under consideration:
 - **Option A:** A new top-level subcommand, e.g. `python -m swebench artifact run`.
 - **Option B:** A mode flag on the existing `run` subcommand, e.g. `python -m swebench run --mode artifact`.
 
-**Decision:** *(to be filled by #2)*
+**Decision:** Option A. A new `artifact` Click group wired into `swebench/cli.py`
+with subcommands `run` (full) and `verify` (placeholder for #96).
 
-**Rationale:** *(to be filled by #2)*
+**Rationale:** Additive-only preserves byte-identical behaviour of the existing
+`python -m swebench run` command (a hard slice invariant). The two modes have
+disjoint primitives — artifact mode uses `Task` / `GradeResult`, SWE-bench mode
+uses `Problem` / test patches — so sharing a single `run` entrypoint would
+require option-gated branching that is hard to reason about. The two groups
+share infrastructure (`harness.run_claude`, `find_claude_binary`) by import,
+not by flag plumbing.
 
 ---
 
@@ -34,9 +41,19 @@ Options:
 - **Option A:** Copy-on-setup of `workspace/` only into a fresh scratch dir; sandbox cwd is the scratch dir; `grader/` lives outside the scratch dir entirely.
 - **Option B:** Materialize the full task dir into scratch then delete `grader/` + `task.yaml` + `reference_output.*`.
 
-**Decision:** *(to be filled by #2)*
+**Decision:** Option A. The harness calls `shutil.copytree(task_dir /
+"workspace", scratch_dir)` and never references `task_dir / "grader"` during
+materialization. The agent subprocess is launched with `cwd=scratch_dir` and
+no PYTHONPATH injection of the repo root. `swebench.artifact_materialize`
+enforces the invariant with a post-copy scan that fails loudly if any file
+named `hidden.py` or `reference_output*` is present in the scratch tree.
 
-**Rationale:** *(to be filled by #2)*
+**Rationale:** Copy-then-delete (Option B) is strictly more error-prone — a
+bug in the deletion step silently leaks the golden answer into the agent
+sandbox. Copy-only means the leak invariant is a property of the code that
+was never written, not of a post-hoc scrub step. The runtime scan exists
+only as a tripwire for future misconfiguration (e.g. a task author
+accidentally putting `reference_output` inside `workspace/`).
 
 ---
 
@@ -46,9 +63,18 @@ Options:
 
 The existing OverlayFS cache (`/workspaces/.swebench-cache/`) is structured around git clones and venvs. Artifact-graded tasks have in-repo, local-directory workspaces, which may not need the same caching treatment.
 
-**Decision:** *(to be filled by #2)*
+**Decision:** Artifact mode does NOT use the OverlayFS cache. No artifact-mode
+module imports `swebench.cache`. Each run creates a fresh scratch dir with
+`shutil.copytree`; the previous run's scratch is left intact on disk (supports
+`--resume` and post-run inspection).
 
-**Rationale:** *(to be filled by #2)*
+**Rationale:** The cache pays for itself only when setup is expensive (cloning
+a large repo, building a venv). Artifact workspaces are self-contained trees
+of hand-curated input files — typically kilobytes, always sub-50MB per the
+schema's cap. Copying them per-run costs less than the overlay mount/unmount
+cycle. Skipping the cache also removes an entire class of bugs (leaked pip
+installs, stale lockfiles, fuse-overlayfs fallbacks) from the artifact-mode
+critical path.
 
 ---
 

--- a/sets/seed-v1.txt
+++ b/sets/seed-v1.txt
@@ -1,0 +1,3 @@
+# Curated artifact task set — seed-v1.
+# One instance_id per line. Blank lines and # comments are ignored.
+# Append-only: this file is populated by the seed-task slices (#95 onward).

--- a/swebench/_artifact_grade_runner.py
+++ b/swebench/_artifact_grade_runner.py
@@ -1,0 +1,76 @@
+"""Internal grader-runner subprocess entrypoint.
+
+Invoked by ``swebench.artifact_grade.invoke_grader`` as:
+
+    python -m swebench._artifact_grade_runner <grader_dir> <scratch_dir>
+
+Imports ``hidden`` from ``<grader_dir>`` (prepended to ``sys.path``), calls
+``hidden.grade(Path(scratch_dir))``, and serialises the result as a single
+JSON object to stdout.
+
+The grader is expected to return an object with ``passed: bool``, ``score:
+float``, ``detail: str`` attributes (structural typing — see SCHEMA §3.1).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import traceback
+from pathlib import Path
+
+
+def _serialize_exception(exc: BaseException) -> dict:
+    return {
+        "_error": True,
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "traceback": traceback.format_exc(),
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(
+            json.dumps({
+                "_error": True,
+                "type": "UsageError",
+                "message": "usage: _artifact_grade_runner <grader_dir> <scratch_dir>",
+                "traceback": "",
+            })
+        )
+        return 2
+
+    grader_dir = Path(argv[1]).resolve()
+    scratch_dir = Path(argv[2]).resolve()
+
+    sys.path.insert(0, str(grader_dir))
+    try:
+        # Drop any cached version from a prior subprocess (defensive; subprocess
+        # starts with a fresh import cache anyway).
+        sys.modules.pop("hidden", None)
+        mod = importlib.import_module("hidden")
+        grade_fn = getattr(mod, "grade", None)
+        if grade_fn is None:
+            raise AttributeError(
+                f"{grader_dir / 'hidden.py'} does not define grade()"
+            )
+        result = grade_fn(scratch_dir)
+        # Structural typing: accept anything with passed/score/detail attrs.
+        payload = {
+            "passed": bool(getattr(result, "passed")),
+            "score": float(getattr(result, "score")),
+            "detail": str(getattr(result, "detail")),
+        }
+        sys.stdout.write(json.dumps(payload))
+        sys.stdout.flush()
+        return 0
+    except Exception as exc:  # noqa: BLE001 — surface everything to parent
+        sys.stdout.write(json.dumps(_serialize_exception(exc)))
+        sys.stdout.flush()
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/swebench/artifact_cli.py
+++ b/swebench/artifact_cli.py
@@ -1,0 +1,185 @@
+"""Click CLI group for ``python -m swebench artifact <subcommand>``.
+
+Additive-only: does not touch the existing ``run`` / ``add`` / ``analyze`` /
+``cache`` groups. Wired into the dispatcher in ``swebench.cli``.
+
+Subcommands:
+
+- ``artifact run``    — execute code_only / tool_rich arms against artifact tasks.
+- ``artifact verify`` — placeholder for the ``tools/verify_graders.py``
+  functionality shipped in a later slice (#96). Declared here so the command
+  namespace exists; invoking it prints a pointer message and exits 2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from swebench import repo_root
+from swebench.artifact_loader import load_tasks
+from swebench.artifact_run import (
+    ARMS,
+    is_run_complete,
+    run_artifact_arm,
+    run_dir_for,
+)
+from swebench.harness import find_claude_binary
+
+
+@click.group()
+def artifact_group() -> None:
+    """Artifact-graded benchmark: run tasks, verify graders (future)."""
+
+
+@artifact_group.command("run")
+@click.option(
+    "--filter",
+    "filter_ids",
+    default=None,
+    help="Comma-separated instance IDs to run (default: all in tasks/).",
+)
+@click.option(
+    "--arms",
+    type=click.Choice(["code_only", "tool_rich", "both"]),
+    default="both",
+    show_default=True,
+    help="Which arms to run.",
+)
+@click.option(
+    "--runs",
+    "num_runs",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Number of runs per arm per task.",
+)
+@click.option(
+    "--output-dir",
+    "output_dir",
+    type=click.Path(file_okay=False, dir_okay=True, resolve_path=False),
+    default=None,
+    help="Directory for result files [default: <repo>/results_artifact/].",
+)
+@click.option(
+    "--resume/--no-resume",
+    "resume",
+    default=True,
+    show_default=True,
+    help=(
+        "Skip (task, arm, run) triples with an existing result.json whose "
+        "verdict is PASS or FAIL."
+    ),
+)
+@click.option(
+    "--tasks-dir",
+    "tasks_dir",
+    type=click.Path(file_okay=False, dir_okay=True, resolve_path=False),
+    default=None,
+    help="Directory containing <category>/<slug>/task.yaml [default: <repo>/tasks/].",
+)
+@click.option(
+    "--mcp-config",
+    "mcp_config",
+    type=click.Path(file_okay=True, dir_okay=False, resolve_path=False),
+    default=None,
+    help="MCP config path for the code_only arm [default: <repo>/mcp-config.json if present].",
+)
+def artifact_run_command(
+    filter_ids: str | None,
+    arms: str,
+    num_runs: int,
+    output_dir: str | None,
+    resume: bool,
+    tasks_dir: str | None,
+    mcp_config: str | None,
+) -> None:
+    """Run artifact-graded benchmark arms on one or more tasks."""
+    if num_runs < 1:
+        click.echo("ERROR: --runs must be >= 1", err=True)
+        raise SystemExit(1)
+
+    root = repo_root()
+    tasks_root = Path(tasks_dir) if tasks_dir else (root / "tasks")
+    results_dir = Path(output_dir) if output_dir else (root / "results_artifact")
+
+    filter_set: set[str] | None = None
+    if filter_ids:
+        filter_set = {s.strip() for s in filter_ids.split(",") if s.strip()}
+
+    try:
+        tasks = load_tasks(tasks_root, filter_ids=filter_set)
+    except ValueError as exc:
+        click.echo(f"ERROR: {exc}", err=True)
+        raise SystemExit(1)
+
+    if not tasks:
+        click.echo(
+            f"ERROR: No tasks found under {tasks_root}. "
+            "Add a task at tasks/<category>/<slug>/task.yaml.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    try:
+        claude_binary = find_claude_binary()
+    except FileNotFoundError as exc:
+        click.echo(f"ERROR: {exc}", err=True)
+        raise SystemExit(1)
+
+    arm_list: list[str]
+    if arms == "both":
+        arm_list = list(ARMS)
+    else:
+        arm_list = [arms]
+
+    mcp_path = mcp_config
+    if mcp_path is None:
+        candidate = root / "mcp-config.json"
+        if candidate.is_file():
+            mcp_path = str(candidate)
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    click.echo(
+        f"Loaded {len(tasks)} task(s); arms={arm_list}; runs={num_runs}; "
+        f"results_dir={results_dir}"
+    )
+
+    for task in tasks:
+        click.echo(f"\n== {task.instance_id} ({task.category}/{task.difficulty}) ==")
+        for arm in arm_list:
+            for run_idx in range(1, num_runs + 1):
+                run_dir = run_dir_for(results_dir, task.instance_id, arm, run_idx)
+                if resume and is_run_complete(run_dir):
+                    click.echo(
+                        f"  [{task.instance_id} {arm} run{run_idx}] "
+                        "Skipping — already complete (resume on)."
+                    )
+                    continue
+                run_artifact_arm(
+                    task,
+                    arm,
+                    run_idx,
+                    results_dir=results_dir,
+                    claude_binary=claude_binary,
+                    mcp_config_path=mcp_path,
+                    echo=click.echo,
+                )
+
+
+@artifact_group.command("verify")
+def artifact_verify_command() -> None:
+    """Placeholder for the grader verification tool (future slice #96).
+
+    The full implementation lives in ``tools/verify_graders.py`` and will be
+    wired to this subcommand by a later child issue. Declared here so the
+    command namespace exists.
+    """
+    click.echo(
+        "artifact verify is a placeholder — the grader verification tool "
+        "(tools/verify_graders.py) lands in a future slice.",
+        err=True,
+    )
+    raise SystemExit(2)

--- a/swebench/artifact_grade.py
+++ b/swebench/artifact_grade.py
@@ -1,0 +1,124 @@
+"""Grader invocation for artifact-graded benchmark tasks.
+
+Runs the task's ``grader/hidden.py:grade(scratch_dir)`` in a fresh Python
+subprocess so the grader has no shared state with the agent process and no
+accidental access to agent sandbox leftovers. See refined spec Q7.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from swebench.artifact_models import GradeResult, Task
+
+
+class GraderInvocationError(RuntimeError):
+    """Raised when the grader subprocess fails with an infrastructure error.
+
+    This is distinct from a grader returning ``passed=False`` — that is a
+    task failure, not a harness failure. This exception is raised only when
+    the grader itself could not be run (missing module, raised an exception,
+    produced malformed output).
+    """
+
+
+def _grader_dir_for(task: Task) -> Path:
+    """Resolve the absolute path to the task's grader/ directory."""
+    if task.task_dir is None:
+        raise ValueError(f"Task {task.instance_id!r} has no task_dir attached")
+    grader_rel = task.hidden_grader  # e.g. "grader/hidden.py"
+    return (task.task_dir / grader_rel).parent.resolve()
+
+
+def invoke_grader(
+    task: Task,
+    scratch_dir: Path,
+    *,
+    timeout_seconds: float | None = 120.0,
+    python_executable: str | None = None,
+) -> GradeResult:
+    """Invoke the task's grader on ``scratch_dir`` via a subprocess.
+
+    Returns the parsed ``GradeResult``.
+
+    Raises:
+        GraderInvocationError: if the grader module is missing, raises an
+            exception, or returns malformed output.
+    """
+    grader_dir = _grader_dir_for(task)
+    if not (grader_dir / "hidden.py").is_file():
+        raise GraderInvocationError(
+            f"grader/hidden.py not found for task {task.instance_id} "
+            f"(expected at {grader_dir / 'hidden.py'})"
+        )
+
+    python = python_executable or sys.executable
+
+    # The grader subprocess is invoked as `python -m swebench._artifact_grade_runner`.
+    # To make that import resolvable, we pass PYTHONPATH pointing at the repo
+    # root (the parent of swebench/). This does NOT affect the agent — the
+    # agent runs in a separate subprocess earlier, with a different cwd and
+    # no `swebench.*` on its path.
+    repo_root = Path(__file__).resolve().parent.parent
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{repo_root}{os.pathsep}{existing}" if existing else str(repo_root)
+    )
+    # Offline hint to discourage accidental network I/O in graders. Not a
+    # sandbox — just a signal. (Seed-stage: no kernel isolation required.)
+    env.setdefault("NO_NETWORK", "1")
+
+    cmd = [
+        python,
+        "-m", "swebench._artifact_grade_runner",
+        str(grader_dir),
+        str(scratch_dir),
+    ]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=env,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GraderInvocationError(
+            f"Grader timed out after {timeout_seconds}s for {task.instance_id}"
+        ) from exc
+
+    stdout = (proc.stdout or "").strip()
+    if not stdout:
+        raise GraderInvocationError(
+            f"Grader produced no output (rc={proc.returncode}) for "
+            f"{task.instance_id}. stderr:\n{proc.stderr}"
+        )
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise GraderInvocationError(
+            f"Grader stdout was not valid JSON for {task.instance_id}: "
+            f"{stdout!r}"
+        ) from exc
+
+    if payload.get("_error"):
+        raise GraderInvocationError(
+            f"Grader raised {payload.get('type')} for {task.instance_id}: "
+            f"{payload.get('message')}\n{payload.get('traceback', '')}"
+        )
+
+    try:
+        return GradeResult.from_dict(payload)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise GraderInvocationError(
+            f"Grader output missing required fields for {task.instance_id}: "
+            f"{payload!r}"
+        ) from exc

--- a/swebench/artifact_loader.py
+++ b/swebench/artifact_loader.py
@@ -1,0 +1,172 @@
+"""Task loader for artifact-graded benchmark mode.
+
+Walks ``tasks/<category>/<slug>/task.yaml`` and parses each manifest per the
+frozen SCHEMA in docs/SCHEMA_ARTIFACT.md.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from swebench.artifact_models import ExecutionBudget, Task
+
+_INSTANCE_ID_RE = re.compile(r"^[a-z][a-z0-9_]*__[a-z0-9_]+$")
+
+_CATEGORIES = frozenset({
+    "data_processing",
+    "algorithmic",
+    "verification_heavy",
+    "enumeration",
+    "stateful_reasoning",
+    "iterative_numerical",
+    # Test-only category used by the fixture task in the test suite. Kept
+    # permissive so synthetic fixtures don't require real task content.
+    "test_fixture",
+})
+
+_DIFFICULTIES = frozenset({"easy", "medium"})
+
+_REQUIRED_FIELDS = frozenset({
+    "instance_id",
+    "category",
+    "difficulty",
+    "problem_statement",
+    "workspace_dir",
+    "output_artifact",
+    "hidden_grader",
+    "reference_output",
+    "execution_budget",
+})
+
+_OPTIONAL_FIELDS = frozenset({
+    "structural_verifier",
+    "tags",
+})
+
+_ALLOWED_FIELDS = _REQUIRED_FIELDS | _OPTIONAL_FIELDS
+
+
+def _parse_task_yaml(path: Path) -> Task:
+    """Parse a single task.yaml into a Task. Raises ValueError on schema violation."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: task.yaml must be a mapping")
+
+    keys = set(data.keys())
+    unknown = keys - _ALLOWED_FIELDS
+    if unknown:
+        raise ValueError(f"{path}: unknown field(s) in task.yaml: {sorted(unknown)}")
+    missing = _REQUIRED_FIELDS - keys
+    if missing:
+        raise ValueError(f"{path}: missing required field(s): {sorted(missing)}")
+
+    instance_id = str(data["instance_id"])
+    if not _INSTANCE_ID_RE.match(instance_id):
+        raise ValueError(
+            f"{path}: instance_id {instance_id!r} does not match "
+            f"{_INSTANCE_ID_RE.pattern}"
+        )
+
+    category = str(data["category"])
+    if category not in _CATEGORIES:
+        raise ValueError(f"{path}: unknown category {category!r}")
+    if not instance_id.startswith(f"{category}__"):
+        raise ValueError(
+            f"{path}: instance_id {instance_id!r} does not start with "
+            f"'{category}__' (category prefix mismatch)"
+        )
+
+    difficulty = str(data["difficulty"])
+    if difficulty not in _DIFFICULTIES:
+        raise ValueError(
+            f"{path}: difficulty must be one of {sorted(_DIFFICULTIES)}, "
+            f"got {difficulty!r}"
+        )
+
+    budget_raw = data["execution_budget"]
+    if not isinstance(budget_raw, dict):
+        raise ValueError(f"{path}: execution_budget must be a mapping")
+    for k in ("max_code_runs", "max_wall_seconds"):
+        if k not in budget_raw:
+            raise ValueError(f"{path}: execution_budget missing {k}")
+        v = budget_raw[k]
+        if not isinstance(v, int) or v < 0:
+            raise ValueError(
+                f"{path}: execution_budget.{k} must be int >= 0, got {v!r}"
+            )
+    budget = ExecutionBudget(
+        max_code_runs=int(budget_raw["max_code_runs"]),
+        max_wall_seconds=int(budget_raw["max_wall_seconds"]),
+    )
+
+    tags_raw = data.get("tags", []) or []
+    if not isinstance(tags_raw, list) or not all(isinstance(t, str) for t in tags_raw):
+        raise ValueError(f"{path}: tags must be list[str]")
+
+    structural_verifier = data.get("structural_verifier")
+    if structural_verifier is not None and not isinstance(structural_verifier, str):
+        raise ValueError(f"{path}: structural_verifier must be a string path")
+
+    return Task(
+        instance_id=instance_id,
+        category=category,
+        difficulty=difficulty,
+        problem_statement=str(data["problem_statement"]),
+        workspace_dir=str(data["workspace_dir"]),
+        output_artifact=str(data["output_artifact"]),
+        hidden_grader=str(data["hidden_grader"]),
+        reference_output=str(data["reference_output"]),
+        execution_budget=budget,
+        structural_verifier=structural_verifier,
+        tags=list(tags_raw),
+        task_dir=path.parent.resolve(),
+    )
+
+
+def discover_task_manifests(tasks_dir: Path) -> list[Path]:
+    """Return sorted list of task.yaml paths under tasks_dir. Empty if none."""
+    if not tasks_dir.is_dir():
+        return []
+    # Glob at depth 2: tasks/<category>/<slug>/task.yaml
+    return sorted(tasks_dir.glob("*/*/task.yaml"))
+
+
+def load_tasks(
+    tasks_dir: Path,
+    filter_ids: Iterable[str] | None = None,
+) -> list[Task]:
+    """Load every task under ``tasks_dir``, optionally filtered by exact instance_id.
+
+    Args:
+        tasks_dir: root directory containing ``<category>/<slug>/task.yaml`` entries.
+        filter_ids: if provided, only tasks whose ``instance_id`` is in this set
+            are returned. Passing an empty iterable explicitly is treated like
+            ``None`` (no filter) — callers pass ``None`` if they mean "all".
+
+    Returns:
+        List of Task in instance_id-sorted order.
+
+    Raises:
+        ValueError: if any task.yaml fails to parse, or if filter_ids is set
+            but no tasks match.
+    """
+    manifests = discover_task_manifests(tasks_dir)
+    tasks = [_parse_task_yaml(m) for m in manifests]
+    tasks.sort(key=lambda t: t.instance_id)
+
+    if filter_ids:
+        wanted = {s.strip() for s in filter_ids if s and s.strip()}
+        if wanted:
+            selected = [t for t in tasks if t.instance_id in wanted]
+            if not selected:
+                raise ValueError(
+                    f"No matching tasks for filter: {sorted(wanted)}"
+                )
+            return selected
+    return tasks

--- a/swebench/artifact_materialize.py
+++ b/swebench/artifact_materialize.py
@@ -1,0 +1,76 @@
+"""Workspace materialization for artifact-graded benchmark tasks.
+
+ABSOLUTE invariant (see SCHEMA §5 and refined spec Q3): the agent's scratch
+dir contains ONLY the contents of ``workspace/`` (plus whatever the agent
+writes at run time). ``grader/`` and ``reference_output.*`` MUST NEVER be
+copied in. A post-copy scan enforces this invariant.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from swebench.artifact_models import Task
+
+
+class MaterializationError(RuntimeError):
+    """Raised when the no-leak invariant is violated after copytree."""
+
+
+def scratch_dir_for(
+    results_dir: Path,
+    instance_id: str,
+    arm: str,
+    run_idx: int,
+) -> Path:
+    """Return the canonical scratch-dir path (not created)."""
+    return results_dir / instance_id / arm / f"run{run_idx}" / "scratch"
+
+
+def materialize(task: Task, scratch_dir: Path) -> Path:
+    """Copy ``task.workspace_dir`` into ``scratch_dir``.
+
+    - Uses ``shutil.copytree(..., dirs_exist_ok=True)``.
+    - Never copies ``task_dir/grader/`` or any ``reference_output*`` file.
+    - Raises ``MaterializationError`` if a post-copy scan finds a grader leak.
+
+    Returns the absolute path to the populated scratch dir.
+    """
+    if task.task_dir is None:
+        raise ValueError(f"Task {task.instance_id!r} has no task_dir attached")
+
+    workspace_src = task.task_dir / task.workspace_dir
+    if not workspace_src.is_dir():
+        raise FileNotFoundError(
+            f"workspace_dir does not exist: {workspace_src}"
+        )
+
+    scratch_dir = scratch_dir.resolve()
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+
+    # We only copy workspace/. grader/ is left behind by construction.
+    shutil.copytree(workspace_src, scratch_dir, dirs_exist_ok=True, symlinks=False)
+
+    _assert_no_grader_leak(scratch_dir)
+    return scratch_dir
+
+
+def _assert_no_grader_leak(scratch_dir: Path) -> None:
+    """Fail loudly if any grader artifact leaked into the agent's scratch dir."""
+    # "hidden.py" is the grader's module filename; reference_output.* is the
+    # golden artifact. Either appearing inside the scratch dir is a bug.
+    leaks: list[Path] = []
+    for path in scratch_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        name = path.name
+        if name == "hidden.py":
+            leaks.append(path)
+        elif name.startswith("reference_output"):
+            leaks.append(path)
+    if leaks:
+        rels = [str(p.relative_to(scratch_dir)) for p in leaks]
+        raise MaterializationError(
+            f"No-leak invariant violated in {scratch_dir}: {rels}"
+        )

--- a/swebench/artifact_models.py
+++ b/swebench/artifact_models.py
@@ -1,0 +1,103 @@
+"""Data models for artifact-graded benchmark tasks and results.
+
+Kept deliberately separate from ``swebench/models.py`` so artifact mode does
+not entangle with SWE-bench mode. See docs/SCHEMA_ARTIFACT.md for the frozen
+on-disk schema this module mirrors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ExecutionBudget:
+    """Execution budget fields from task.yaml. 0 means unlimited (see SCHEMA §2.3)."""
+
+    max_code_runs: int
+    max_wall_seconds: int
+
+    @property
+    def enforcement(self) -> str:
+        """Always 'OFF' for seed-v1 — no hard caps enforced yet."""
+        return "OFF"
+
+    @property
+    def is_unlimited(self) -> bool:
+        return self.max_code_runs == 0 and self.max_wall_seconds == 0
+
+
+@dataclass(frozen=True)
+class Task:
+    """A single artifact-graded task.
+
+    This is NOT an extension of ``swebench.models.Problem``. Artifact mode and
+    SWE-bench mode use disjoint in-memory types.
+    """
+
+    instance_id: str
+    category: str
+    difficulty: str
+    problem_statement: str      # relative path to prompt.md
+    workspace_dir: str          # relative path, typically "workspace/"
+    output_artifact: str        # relative to scratch dir
+    hidden_grader: str          # relative path, typically "grader/hidden.py"
+    reference_output: str       # relative path under grader/
+    execution_budget: ExecutionBudget
+    structural_verifier: str | None = None  # optional
+    tags: list[str] = field(default_factory=list)
+    task_dir: Path | None = None  # populated by loader; absolute path
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    """Result of invoking ``grader/hidden.py:grade(scratch_dir)``.
+
+    Canonical import path for grader modules: ``from swebench.artifact_models
+    import GradeResult``. The harness also accepts any object with matching
+    ``passed: bool``, ``score: float``, ``detail: str`` attributes (structural
+    typing — see SCHEMA §3.1).
+    """
+
+    passed: bool
+    score: float
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"passed": self.passed, "score": self.score, "detail": self.detail}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GradeResult":
+        return cls(
+            passed=bool(data["passed"]),
+            score=float(data["score"]),
+            detail=str(data["detail"]),
+        )
+
+
+@dataclass
+class ArtifactArmResult:
+    """Result of running one artifact-mode arm on one task.
+
+    Parallels ``swebench.models.ArmResult`` but with artifact-specific fields.
+    ``verdict`` follows the same "PASS" | "FAIL" | "ERROR" convention.
+    """
+
+    instance_id: str
+    arm: str            # "code_only" | "tool_rich"
+    run_idx: int
+    verdict: str        # "PASS" | "FAIL" | "ERROR"
+    grade_result: GradeResult | None
+    budget: dict[str, Any]
+    wall_secs: int
+    cost_usd: float | None
+    num_turns: int | None
+    claude_version: str | None
+    agent_jsonl_path: str
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["grade_result"] = self.grade_result.to_dict() if self.grade_result else None
+        return d

--- a/swebench/artifact_run.py
+++ b/swebench/artifact_run.py
@@ -1,0 +1,244 @@
+"""Arm executor for artifact-graded benchmark tasks.
+
+Orchestrates a single (task, arm, run) triple end-to-end:
+
+1. Materialise workspace into scratch dir (no-leak invariant enforced).
+2. Build prompt from ``prompt.md``.
+3. Run Claude via ``harness.run_claude`` with cwd=scratch_dir.
+4. Invoke the grader on the populated scratch dir.
+5. Write ``result.json`` + ``agent.jsonl``.
+
+Mirrors the matched-arm pattern from ``swebench.run._run_arm`` (lines 135–329)
+but with artifact primitives. Does NOT import ``swebench.cache``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Callable
+
+from swebench.artifact_grade import GraderInvocationError, invoke_grader
+from swebench.artifact_materialize import materialize, scratch_dir_for
+from swebench.artifact_models import ArtifactArmResult, GradeResult, Task
+from swebench.harness import get_claude_version, run_claude
+
+# Matched verbatim with ``run.py:_BLOCKED_BUILTINS`` (lines 248–256). Duplication
+# is intentional: refined spec §3 calls for no shared state between SWE-bench
+# and artifact modes. If the SWE-bench list drifts, the artifact arm stays pinned
+# to the version that was validated against the artifact-mode invariants.
+_BLOCKED_BUILTINS = (
+    "Agent,AskUserQuestion,Bash,CronCreate,CronDelete,CronList,"
+    "Edit,EnterPlanMode,EnterWorktree,ExitPlanMode,ExitWorktree,"
+    "Glob,Grep,ListMcpResourcesTool,LSP,Monitor,NotebookEdit,"
+    "PowerShell,PushNotification,Read,ReadMcpResourceTool,"
+    "RemoteTrigger,SendMessage,Skill,"
+    "TaskCreate,TaskGet,TaskList,TaskOutput,TaskStop,TaskUpdate,"
+    "TeamCreate,TeamDelete,TodoWrite,ToolSearch,WebFetch,WebSearch,Write"
+)
+
+ARMS = ("code_only", "tool_rich")
+
+
+def run_dir_for(results_dir: Path, instance_id: str, arm: str, run_idx: int) -> Path:
+    """Canonical directory for a single (instance, arm, run) triple."""
+    return results_dir / instance_id / arm / f"run{run_idx}"
+
+
+def _build_prompt(task: Task, scratch_dir: Path, arm: str) -> str:
+    """Compose the agent prompt from ``prompt.md`` plus scratch-dir context."""
+    if task.task_dir is None:
+        raise ValueError(f"Task {task.instance_id!r} has no task_dir attached")
+    prompt_path = task.task_dir / task.problem_statement
+    if not prompt_path.is_file():
+        raise FileNotFoundError(f"problem_statement not found: {prompt_path}")
+    prompt_body = prompt_path.read_text()
+
+    parts = [
+        f"You are working in the directory: {scratch_dir}",
+        f"Write your output artifact to the relative path: {task.output_artifact}",
+        "",
+        prompt_body,
+    ]
+    return "\n".join(parts)
+
+
+def _build_tools_flags(arm: str, mcp_config_path: str | None) -> list[str]:
+    """Construct ``--tools`` / ``--disallowedTools`` flags for the chosen arm.
+
+    ``code_only`` mirrors the ``onlycode`` arm (restricts to two MCP tools).
+    ``tool_rich`` mirrors ``baseline`` (no restriction).
+    """
+    if arm == "tool_rich":
+        return []
+    if arm == "code_only":
+        flags = []
+        if mcp_config_path:
+            flags.extend([
+                "--mcp-config", mcp_config_path,
+                "--strict-mcp-config",
+            ])
+        flags.extend([
+            "--tools", "mcp__codebox__execute_code,mcp__codebox__list_tools",
+            "--disallowedTools", _BLOCKED_BUILTINS,
+        ])
+        return flags
+    raise ValueError(f"Unknown arm: {arm!r}")
+
+
+def _log_budget(task: Task, echo: Callable[[str], None]) -> None:
+    b = task.execution_budget
+    if b.is_unlimited:
+        echo(
+            f"  [{task.instance_id}] budget enforcement OFF (0 = unlimited)"
+        )
+    else:
+        echo(
+            f"  [{task.instance_id}] budget declared: "
+            f"max_code_runs={b.max_code_runs}, "
+            f"max_wall_seconds={b.max_wall_seconds} "
+            f"(enforcement OFF — future epic)"
+        )
+
+
+def _extract_cost_and_turns(jsonl_path: Path) -> tuple[float | None, int | None]:
+    """Parse the last ``total_cost_usd`` / ``num_turns`` values from a stream-json log."""
+    try:
+        content = jsonl_path.read_text()
+    except OSError:
+        return (None, None)
+    cost: float | None = None
+    turns: int | None = None
+    cost_match = re.findall(r'"total_cost_usd":\s*([\d.]+)', content)
+    if cost_match:
+        try:
+            cost = float(cost_match[-1])
+        except ValueError:
+            cost = None
+    turns_match = re.findall(r'"num_turns":\s*(\d+)', content)
+    if turns_match:
+        try:
+            turns = int(turns_match[-1])
+        except ValueError:
+            turns = None
+    return (cost, turns)
+
+
+def is_run_complete(run_dir: Path) -> bool:
+    """Return True if ``run_dir/result.json`` exists with a valid verdict."""
+    result_path = run_dir / "result.json"
+    if not result_path.is_file():
+        return False
+    try:
+        data = json.loads(result_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return data.get("verdict") in ("PASS", "FAIL")
+
+
+def run_artifact_arm(
+    task: Task,
+    arm: str,
+    run_idx: int,
+    *,
+    results_dir: Path,
+    claude_binary: str,
+    mcp_config_path: str | None = None,
+    echo: Callable[[str], None] | None = None,
+) -> ArtifactArmResult:
+    """Run one (task, arm, run_idx) triple and write result.json + agent.jsonl.
+
+    Returns the ``ArtifactArmResult`` (also serialised to disk).
+    """
+    if arm not in ARMS:
+        raise ValueError(f"arm must be one of {ARMS}, got {arm!r}")
+    if echo is None:
+        echo = print
+
+    run_dir = run_dir_for(results_dir, task.instance_id, arm, run_idx)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    scratch_dir = scratch_dir_for(results_dir, task.instance_id, arm, run_idx)
+
+    agent_jsonl = run_dir / "agent.jsonl"
+    result_json = run_dir / "result.json"
+
+    echo(f"  [{task.instance_id} {arm} run{run_idx}] Materializing workspace...")
+    materialize(task, scratch_dir)
+    _log_budget(task, echo)
+
+    # Seed the agent.jsonl with a self-describing meta record — mirrors
+    # run.py lines 274–284 so analysis tooling can reuse the same shape.
+    claude_version = get_claude_version(claude_binary)
+    with open(agent_jsonl, "w") as f:
+        f.write(json.dumps({
+            "type": "meta",
+            "mode": "artifact",
+            "instance_id": task.instance_id,
+            "arm": arm,
+            "run": run_idx,
+            "claude_binary": claude_binary,
+            "claude_version": claude_version,
+        }) + "\n")
+
+    prompt = _build_prompt(task, scratch_dir, arm)
+    tools_flags = _build_tools_flags(arm, mcp_config_path)
+
+    # TODO(budget): increment code_run counter here — enforcement is OFF.
+    # The hook is intentionally a no-op in seed-v1 per the STRONG invariant:
+    # declare + store fields now, flip enforcement in a later epic.
+
+    start = time.time()
+    verdict: str
+    grade_result: GradeResult | None = None
+    try:
+        run_claude(
+            prompt=prompt,
+            repo_dir=str(scratch_dir),
+            system_prompt="You are a helpful assistant.",
+            tools_flags=tools_flags,
+            result_file=str(agent_jsonl),
+            claude_binary=claude_binary,
+        )
+        wall_secs = int(time.time() - start)
+        echo(f"  [{task.instance_id} {arm} run{run_idx}] Grading...")
+        try:
+            grade_result = invoke_grader(task, scratch_dir)
+            verdict = "PASS" if grade_result.passed else "FAIL"
+        except GraderInvocationError as exc:
+            echo(f"  [{task.instance_id} {arm} run{run_idx}] ERROR: {exc}")
+            verdict = "ERROR"
+    except Exception as exc:  # noqa: BLE001 — any agent-launch failure is ERROR
+        wall_secs = int(time.time() - start)
+        echo(f"  [{task.instance_id} {arm} run{run_idx}] ERROR during run: {exc}")
+        verdict = "ERROR"
+
+    cost, turns = _extract_cost_and_turns(agent_jsonl)
+
+    result = ArtifactArmResult(
+        instance_id=task.instance_id,
+        arm=arm,
+        run_idx=run_idx,
+        verdict=verdict,
+        grade_result=grade_result,
+        budget={
+            "max_code_runs": task.execution_budget.max_code_runs,
+            "max_wall_seconds": task.execution_budget.max_wall_seconds,
+            "enforcement": task.execution_budget.enforcement,
+        },
+        wall_secs=wall_secs,
+        cost_usd=cost,
+        num_turns=turns,
+        claude_version=claude_version,
+        agent_jsonl_path=str(agent_jsonl),
+    )
+    with open(result_json, "w") as f:
+        json.dump(result.to_dict(), f, indent=2, sort_keys=True)
+
+    echo(
+        f"  [{task.instance_id} {arm} run{run_idx}] {verdict} "
+        f"(wall={wall_secs}s, cost={cost}, turns={turns})"
+    )
+    return result

--- a/swebench/cli.py
+++ b/swebench/cli.py
@@ -6,6 +6,7 @@ from swebench.add import add_command
 from swebench.run import run_command
 from swebench.analyze import analyze_command
 from swebench.cache_cli import cache_group
+from swebench.artifact_cli import artifact_group
 
 
 @click.group()
@@ -17,3 +18,4 @@ cli.add_command(add_command, "add")
 cli.add_command(run_command, "run")
 cli.add_command(analyze_command, "analyze")
 cli.add_command(cache_group, "cache")
+cli.add_command(artifact_group, "artifact")

--- a/tests/test_artifact_cli.py
+++ b/tests/test_artifact_cli.py
@@ -1,0 +1,205 @@
+"""Tests for the ``python -m swebench artifact`` CLI wiring."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from swebench import artifact_run as artifact_run_mod
+from swebench import artifact_cli as artifact_cli_mod
+from swebench.cli import cli
+
+
+def _write_fixture_task(tasks_root: Path, agent_answer: str = "42") -> str:
+    """Create a minimal valid task at tasks/test_fixture/trivial_pass/. Returns instance_id."""
+    task_dir = tasks_root / "test_fixture" / "trivial_pass"
+    (task_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    (task_dir / "grader").mkdir(parents=True, exist_ok=True)
+    (task_dir / "prompt.md").write_text("write 42 to answer.txt\n")
+    (task_dir / "grader" / "hidden.py").write_text(textwrap.dedent("""
+        class R:
+            passed = False
+            score = 0.0
+            detail = ""
+
+        def grade(scratch_dir):
+            r = R()
+            a = scratch_dir / "answer.txt"
+            if not a.exists():
+                r.detail = "missing"
+                return r
+            r.passed = a.read_text().strip() == "42"
+            r.score = 1.0 if r.passed else 0.0
+            r.detail = "ok" if r.passed else "mismatch"
+            return r
+    """))
+    (task_dir / "grader" / "reference_output.txt").write_text("42\n")
+
+    with open(task_dir / "task.yaml", "w") as f:
+        yaml.safe_dump({
+            "instance_id": "test_fixture__trivial_pass",
+            "category": "test_fixture",
+            "difficulty": "easy",
+            "problem_statement": "prompt.md",
+            "workspace_dir": "workspace/",
+            "output_artifact": "answer.txt",
+            "hidden_grader": "grader/hidden.py",
+            "reference_output": "grader/reference_output.txt",
+            "execution_budget": {"max_code_runs": 0, "max_wall_seconds": 0},
+        }, f, sort_keys=False)
+    return "test_fixture__trivial_pass"
+
+
+@pytest.fixture
+def stub_runtime(monkeypatch):
+    """Stub out Claude launch and binary discovery so CLI tests stay hermetic."""
+    monkeypatch.setattr(
+        artifact_cli_mod, "find_claude_binary",
+        lambda: "/bin/true",
+    )
+    monkeypatch.setattr(
+        artifact_run_mod, "get_claude_version",
+        lambda _b: "claude-test",
+    )
+
+    def fake_run_claude(*, prompt, repo_dir, system_prompt, tools_flags,
+                        result_file, claude_binary):
+        Path(repo_dir, "answer.txt").write_text("42\n")
+        with open(result_file, "a") as f:
+            f.write('{"type":"result","total_cost_usd":0.01,"num_turns":2}\n')
+
+    monkeypatch.setattr(artifact_run_mod, "run_claude", fake_run_claude)
+    return monkeypatch
+
+
+def test_artifact_run_help():
+    runner = CliRunner()
+    r = runner.invoke(cli, ["artifact", "run", "--help"])
+    assert r.exit_code == 0
+    assert "--filter" in r.output
+    assert "--arms" in r.output
+    assert "--runs" in r.output
+
+
+def test_artifact_verify_is_placeholder():
+    runner = CliRunner()
+    r = runner.invoke(cli, ["artifact", "verify"])
+    # Placeholder exits 2 with a pointer message.
+    assert r.exit_code == 2
+    assert "placeholder" in (r.output + r.stderr).lower()
+
+
+def test_artifact_run_end_to_end(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    results_dir = tmp_path / "results"
+    iid = _write_fixture_task(tasks_root)
+
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "both",
+    ])
+    assert r.exit_code == 0, r.output
+
+    for arm in ("code_only", "tool_rich"):
+        run_dir = results_dir / iid / arm / "run1"
+        assert (run_dir / "result.json").is_file()
+        assert (run_dir / "agent.jsonl").is_file()
+        scratch = run_dir / "scratch"
+        assert (scratch / "answer.txt").read_text() == "42\n"
+        # No-leak invariant — this is the falsifiability check.
+        assert not any(scratch.rglob("hidden.py"))
+        assert not any(scratch.rglob("reference_output*"))
+        data = json.loads((run_dir / "result.json").read_text())
+        assert data["verdict"] == "PASS"
+        assert data["arm"] == arm
+
+
+def test_artifact_run_single_arm(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    results_dir = tmp_path / "results"
+    iid = _write_fixture_task(tasks_root)
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "code_only",
+    ])
+    assert r.exit_code == 0, r.output
+    assert (results_dir / iid / "code_only" / "run1" / "result.json").is_file()
+    assert not (results_dir / iid / "tool_rich").exists()
+
+
+def test_artifact_run_resume_skips(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    results_dir = tmp_path / "results"
+    iid = _write_fixture_task(tasks_root)
+    runner = CliRunner()
+    # First run
+    r1 = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "code_only",
+    ])
+    assert r1.exit_code == 0
+    # Second run with --resume (default on) must skip.
+    r2 = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "code_only",
+    ])
+    assert r2.exit_code == 0
+    assert "Skipping" in r2.output
+
+
+def test_artifact_run_filter_no_match(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    _write_fixture_task(tasks_root)
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(tmp_path / "results"),
+        "--filter", "does_not_exist__nope",
+    ])
+    assert r.exit_code == 1
+    assert "No matching" in (r.output + r.stderr)
+
+
+def test_artifact_run_no_tasks(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    tasks_root.mkdir()
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(tmp_path / "results"),
+    ])
+    assert r.exit_code == 1
+    assert "No tasks found" in (r.output + r.stderr)
+
+
+def test_swebench_run_unchanged_smoke():
+    """Additive-only: ``python -m swebench run --help`` must still work and
+    must not advertise any artifact-mode flag."""
+    runner = CliRunner()
+    r = runner.invoke(cli, ["run", "--help"])
+    assert r.exit_code == 0
+    assert "--filter" in r.output
+    # The artifact arm names must not leak into the SWE-bench run help.
+    assert "code_only" not in r.output
+    assert "tool_rich" not in r.output

--- a/tests/test_artifact_grade.py
+++ b/tests/test_artifact_grade.py
@@ -1,0 +1,131 @@
+"""Tests for swebench.artifact_grade (subprocess-based grader invocation)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from swebench.artifact_grade import GraderInvocationError, invoke_grader
+from swebench.artifact_models import ExecutionBudget, GradeResult, Task
+
+
+def _write_task_with_grader(task_dir: Path, grader_body: str) -> Task:
+    (task_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    (task_dir / "grader").mkdir(parents=True, exist_ok=True)
+    (task_dir / "grader" / "hidden.py").write_text(textwrap.dedent(grader_body))
+    (task_dir / "grader" / "reference_output.txt").write_text("ref")
+    return Task(
+        instance_id="test_fixture__grader",
+        category="test_fixture",
+        difficulty="easy",
+        problem_statement="prompt.md",
+        workspace_dir="workspace/",
+        output_artifact="out.txt",
+        hidden_grader="grader/hidden.py",
+        reference_output="grader/reference_output.txt",
+        execution_budget=ExecutionBudget(0, 0),
+        task_dir=task_dir.resolve(),
+    )
+
+
+def test_grader_pass(tmp_path: Path) -> None:
+    task = _write_task_with_grader(tmp_path / "task", """
+        from dataclasses import dataclass
+
+        @dataclass
+        class R:
+            passed: bool
+            score: float
+            detail: str
+
+        def grade(scratch_dir):
+            return R(True, 1.0, "looks good")
+    """)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    result = invoke_grader(task, scratch)
+    assert isinstance(result, GradeResult)
+    assert result.passed is True
+    assert result.score == 1.0
+    assert result.detail == "looks good"
+
+
+def test_grader_fail_reports_detail(tmp_path: Path) -> None:
+    task = _write_task_with_grader(tmp_path / "task", """
+        class R:
+            def __init__(self, p, s, d):
+                self.passed, self.score, self.detail = p, s, d
+
+        def grade(scratch_dir):
+            return R(False, 0.25, "missing key foo")
+    """)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    result = invoke_grader(task, scratch)
+    assert result.passed is False
+    assert result.score == 0.25
+    assert "missing key foo" in result.detail
+
+
+def test_grader_reads_scratch_dir(tmp_path: Path) -> None:
+    """Verify the grader actually receives the scratch_dir path as a Path."""
+    task = _write_task_with_grader(tmp_path / "task", """
+        from pathlib import Path
+
+        class R:
+            passed = False
+            score = 0.0
+            detail = ""
+
+        def grade(scratch_dir):
+            assert isinstance(scratch_dir, Path)
+            artifact = scratch_dir / "answer.txt"
+            r = R()
+            r.passed = artifact.exists() and artifact.read_text().strip() == "42"
+            r.score = 1.0 if r.passed else 0.0
+            r.detail = f"artifact={'found' if artifact.exists() else 'missing'}"
+            return r
+    """)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    (scratch / "answer.txt").write_text("42\n")
+    result = invoke_grader(task, scratch)
+    assert result.passed is True
+    assert result.score == 1.0
+
+
+def test_grader_exception_surfaces_as_invocation_error(tmp_path: Path) -> None:
+    task = _write_task_with_grader(tmp_path / "task", """
+        def grade(scratch_dir):
+            raise RuntimeError("boom")
+    """)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    with pytest.raises(GraderInvocationError, match="boom"):
+        invoke_grader(task, scratch)
+
+
+def test_grader_missing_raises(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    (task_dir / "workspace").mkdir(parents=True)
+    (task_dir / "grader").mkdir(parents=True)
+    # Deliberately no hidden.py
+    (task_dir / "grader" / "reference_output.txt").write_text("")
+    task = Task(
+        instance_id="test_fixture__nograder",
+        category="test_fixture",
+        difficulty="easy",
+        problem_statement="prompt.md",
+        workspace_dir="workspace/",
+        output_artifact="out.txt",
+        hidden_grader="grader/hidden.py",
+        reference_output="grader/reference_output.txt",
+        execution_budget=ExecutionBudget(0, 0),
+        task_dir=task_dir.resolve(),
+    )
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    with pytest.raises(GraderInvocationError, match="grader/hidden.py not found"):
+        invoke_grader(task, scratch)

--- a/tests/test_artifact_loader.py
+++ b/tests/test_artifact_loader.py
@@ -1,0 +1,171 @@
+"""Tests for swebench.artifact_loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from swebench.artifact_loader import load_tasks
+
+
+def _write_task(
+    tasks_dir: Path,
+    category: str,
+    slug: str,
+    overrides: dict | None = None,
+) -> Path:
+    """Create a minimal valid task at tasks/<category>/<slug>/ and return its dir."""
+    task_dir = tasks_dir / category / slug
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "workspace").mkdir(exist_ok=True)
+    (task_dir / "grader").mkdir(exist_ok=True)
+    (task_dir / "prompt.md").write_text("do the thing\n")
+    (task_dir / "grader" / "hidden.py").write_text(
+        "def grade(d):\n    class R:\n        passed=True\n        score=1.0\n        detail='ok'\n    return R()\n"
+    )
+    (task_dir / "grader" / "reference_output.txt").write_text("ref\n")
+
+    data = {
+        "instance_id": f"{category}__{slug}",
+        "category": category,
+        "difficulty": "easy",
+        "problem_statement": "prompt.md",
+        "workspace_dir": "workspace/",
+        "output_artifact": "answer.txt",
+        "hidden_grader": "grader/hidden.py",
+        "reference_output": "grader/reference_output.txt",
+        "execution_budget": {"max_code_runs": 0, "max_wall_seconds": 0},
+    }
+    if overrides:
+        data.update(overrides)
+    with open(task_dir / "task.yaml", "w") as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+    return task_dir
+
+
+def test_load_empty_tasks_dir(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    assert load_tasks(tasks_dir) == []
+
+
+def test_load_missing_tasks_dir(tmp_path: Path) -> None:
+    assert load_tasks(tmp_path / "does_not_exist") == []
+
+
+def test_load_single_task(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(tasks_dir, "data_processing", "p95_latency_easy")
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    t = tasks[0]
+    assert t.instance_id == "data_processing__p95_latency_easy"
+    assert t.category == "data_processing"
+    assert t.difficulty == "easy"
+    assert t.execution_budget.max_code_runs == 0
+    assert t.execution_budget.max_wall_seconds == 0
+    assert t.execution_budget.is_unlimited
+    assert t.task_dir is not None and t.task_dir.is_dir()
+
+
+def test_filter_exact_match(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(tasks_dir, "data_processing", "p95_latency_easy")
+    _write_task(tasks_dir, "algorithmic", "makespan_scheduling")
+    tasks = load_tasks(tasks_dir, filter_ids={"data_processing__p95_latency_easy"})
+    assert len(tasks) == 1
+    assert tasks[0].instance_id == "data_processing__p95_latency_easy"
+
+
+def test_filter_no_match_raises(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(tasks_dir, "data_processing", "p95_latency_easy")
+    with pytest.raises(ValueError, match="No matching tasks"):
+        load_tasks(tasks_dir, filter_ids={"nope__nada"})
+
+
+def test_unknown_field_rejected(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(
+        tasks_dir,
+        "data_processing",
+        "bad_extra",
+        overrides={"unknown_key": "oops"},
+    )
+    with pytest.raises(ValueError, match="unknown field"):
+        load_tasks(tasks_dir)
+
+
+def test_missing_required_field_rejected(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    task_dir = _write_task(tasks_dir, "data_processing", "missing_cat")
+    # Strip a required field
+    with open(task_dir / "task.yaml") as f:
+        data = yaml.safe_load(f)
+    data.pop("difficulty")
+    with open(task_dir / "task.yaml", "w") as f:
+        yaml.safe_dump(data, f)
+    with pytest.raises(ValueError, match="missing required field"):
+        load_tasks(tasks_dir)
+
+
+def test_instance_id_category_prefix_mismatch(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(
+        tasks_dir,
+        "data_processing",
+        "wrong_prefix",
+        overrides={"instance_id": "algorithmic__wrong_prefix"},
+    )
+    with pytest.raises(ValueError, match="category prefix mismatch"):
+        load_tasks(tasks_dir)
+
+
+def test_unknown_category_rejected(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(
+        tasks_dir,
+        "data_processing",
+        "fine",
+        overrides={"category": "not_a_category",
+                   "instance_id": "not_a_category__fine"},
+    )
+    with pytest.raises(ValueError, match="unknown category"):
+        load_tasks(tasks_dir)
+
+
+def test_invalid_difficulty_rejected(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(
+        tasks_dir,
+        "data_processing",
+        "hard_forbidden",
+        overrides={"difficulty": "hard"},
+    )
+    with pytest.raises(ValueError, match="difficulty must be"):
+        load_tasks(tasks_dir)
+
+
+def test_negative_budget_rejected(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(
+        tasks_dir,
+        "data_processing",
+        "neg_budget",
+        overrides={"execution_budget": {"max_code_runs": -1, "max_wall_seconds": 0}},
+    )
+    with pytest.raises(ValueError, match="must be int >= 0"):
+        load_tasks(tasks_dir)
+
+
+def test_tasks_sorted_by_instance_id(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(tasks_dir, "algorithmic", "zebra")
+    _write_task(tasks_dir, "data_processing", "alpha")
+    tasks = load_tasks(tasks_dir)
+    assert [t.instance_id for t in tasks] == [
+        "algorithmic__zebra",
+        "data_processing__alpha",
+    ]

--- a/tests/test_artifact_materialize.py
+++ b/tests/test_artifact_materialize.py
@@ -1,0 +1,79 @@
+"""Tests for swebench.artifact_materialize (no-leak invariant)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from swebench.artifact_materialize import (
+    MaterializationError,
+    materialize,
+    scratch_dir_for,
+)
+from swebench.artifact_models import ExecutionBudget, Task
+
+
+def _make_task(task_dir: Path, with_grader: bool = True) -> Task:
+    (task_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    (task_dir / "workspace" / "input.txt").write_text("hello\n")
+    (task_dir / "workspace" / "sub").mkdir(exist_ok=True)
+    (task_dir / "workspace" / "sub" / "nested.txt").write_text("deep\n")
+    if with_grader:
+        (task_dir / "grader").mkdir(exist_ok=True)
+        (task_dir / "grader" / "hidden.py").write_text("def grade(d): ...")
+        (task_dir / "grader" / "reference_output.txt").write_text("secret\n")
+    return Task(
+        instance_id="test_fixture__trivial",
+        category="test_fixture",
+        difficulty="easy",
+        problem_statement="prompt.md",
+        workspace_dir="workspace/",
+        output_artifact="out.txt",
+        hidden_grader="grader/hidden.py",
+        reference_output="grader/reference_output.txt",
+        execution_budget=ExecutionBudget(0, 0),
+        task_dir=task_dir.resolve(),
+    )
+
+
+def test_materialize_copies_workspace(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "task")
+    scratch = tmp_path / "scratch"
+    materialize(task, scratch)
+    assert (scratch / "input.txt").read_text() == "hello\n"
+    assert (scratch / "sub" / "nested.txt").read_text() == "deep\n"
+
+
+def test_materialize_never_copies_grader(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "task")
+    scratch = tmp_path / "scratch"
+    materialize(task, scratch)
+    # Absolute invariant: no hidden.py, no reference_output* anywhere in scratch.
+    assert not any(scratch.rglob("hidden.py"))
+    assert not any(scratch.rglob("reference_output*"))
+    assert not (scratch / "grader").exists()
+
+
+def test_materialize_detects_leak(tmp_path: Path) -> None:
+    """If a task author accidentally put a grader file inside workspace/,
+    the post-copy scan must flag it."""
+    task = _make_task(tmp_path / "task")
+    (task.task_dir / "workspace" / "reference_output.jsonl").write_text("leaked\n")
+    scratch = tmp_path / "scratch"
+    with pytest.raises(MaterializationError, match="No-leak invariant"):
+        materialize(task, scratch)
+
+
+def test_materialize_detects_hidden_py_leak(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "task")
+    (task.task_dir / "workspace" / "hidden.py").write_text("def grade(d): ...")
+    scratch = tmp_path / "scratch"
+    with pytest.raises(MaterializationError):
+        materialize(task, scratch)
+
+
+def test_scratch_dir_for_layout() -> None:
+    results = Path("/r")
+    p = scratch_dir_for(results, "cat__slug", "code_only", 3)
+    assert p == Path("/r/cat__slug/code_only/run3/scratch")

--- a/tests/test_artifact_run.py
+++ b/tests/test_artifact_run.py
@@ -1,0 +1,234 @@
+"""Tests for swebench.artifact_run — end-to-end arm execution with a stubbed Claude.
+
+We monkeypatch ``swebench.harness.run_claude`` so no real Claude binary is
+invoked. The agent behaviour is simulated by writing output files into the
+scratch dir directly.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from swebench import artifact_run as artifact_run_mod
+from swebench.artifact_models import ExecutionBudget, Task
+from swebench.artifact_run import (
+    ARMS,
+    _build_tools_flags,
+    is_run_complete,
+    run_artifact_arm,
+    run_dir_for,
+)
+
+
+def _make_fixture(task_dir: Path, grader_src: str, budget=(0, 0)) -> Task:
+    (task_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    (task_dir / "workspace" / "starter.txt").write_text("START\n")
+    (task_dir / "grader").mkdir(parents=True, exist_ok=True)
+    (task_dir / "grader" / "hidden.py").write_text(textwrap.dedent(grader_src))
+    (task_dir / "grader" / "reference_output.txt").write_text("42\n")
+    (task_dir / "prompt.md").write_text("write 42 to answer.txt\n")
+    return Task(
+        instance_id="test_fixture__trivial_pass",
+        category="test_fixture",
+        difficulty="easy",
+        problem_statement="prompt.md",
+        workspace_dir="workspace/",
+        output_artifact="answer.txt",
+        hidden_grader="grader/hidden.py",
+        reference_output="grader/reference_output.txt",
+        execution_budget=ExecutionBudget(*budget),
+        task_dir=task_dir.resolve(),
+    )
+
+
+_GRADER_CHECKS_42 = """
+    class R:
+        passed = False
+        score = 0.0
+        detail = ""
+
+    def grade(scratch_dir):
+        r = R()
+        artifact = scratch_dir / "answer.txt"
+        if not artifact.exists():
+            r.detail = "output artifact not produced"
+            return r
+        val = artifact.read_text().strip()
+        r.passed = val == "42"
+        r.score = 1.0 if r.passed else 0.0
+        r.detail = "ok" if r.passed else f"got {val!r}"
+        return r
+"""
+
+
+def _stub_claude_writes(contents: str):
+    """Return a fake run_claude that drops a file named answer.txt in cwd."""
+    def fake_run_claude(*, prompt, repo_dir, system_prompt, tools_flags,
+                       result_file, claude_binary):
+        # Simulate the agent writing its artifact into the scratch dir.
+        Path(repo_dir, "answer.txt").write_text(contents)
+        # Also append a fake stream-json entry so cost/turns extraction paths run.
+        with open(result_file, "a") as f:
+            f.write(json.dumps({
+                "type": "result",
+                "total_cost_usd": 0.0123,
+                "num_turns": 4,
+            }) + "\n")
+    return fake_run_claude
+
+
+@pytest.fixture
+def stub_claude(monkeypatch):
+    """Replace run_claude + get_claude_version with harmless stubs."""
+    monkeypatch.setattr(
+        artifact_run_mod, "get_claude_version",
+        lambda _b: "claude-test-1.0.0",
+    )
+    return monkeypatch
+
+
+def test_build_tools_flags_code_only_includes_blocked_builtins():
+    flags = _build_tools_flags("code_only", mcp_config_path="/tmp/mcp.json")
+    assert "--mcp-config" in flags
+    assert "--strict-mcp-config" in flags
+    assert "--disallowedTools" in flags
+    # Matched verbatim with run.py — confirm a few canary tools.
+    disallowed = flags[flags.index("--disallowedTools") + 1]
+    for name in ("Bash", "Read", "Write", "Edit", "Grep"):
+        assert name in disallowed
+
+
+def test_build_tools_flags_tool_rich_empty():
+    assert _build_tools_flags("tool_rich", mcp_config_path="/tmp/mcp.json") == []
+
+
+def test_build_tools_flags_rejects_unknown_arm():
+    with pytest.raises(ValueError):
+        _build_tools_flags("nonsense", mcp_config_path=None)
+
+
+def test_run_artifact_arm_end_to_end_pass(tmp_path, stub_claude, monkeypatch):
+    task = _make_fixture(tmp_path / "task", _GRADER_CHECKS_42)
+    monkeypatch.setattr(
+        artifact_run_mod, "run_claude",
+        _stub_claude_writes("42\n"),
+    )
+    results_dir = tmp_path / "results"
+    result = run_artifact_arm(
+        task, "code_only", 1,
+        results_dir=results_dir,
+        claude_binary="/bin/true",
+        echo=lambda _m: None,
+    )
+    assert result.verdict == "PASS"
+    assert result.grade_result is not None
+    assert result.grade_result.passed is True
+    assert result.grade_result.score == 1.0
+    assert result.budget == {
+        "max_code_runs": 0, "max_wall_seconds": 0, "enforcement": "OFF",
+    }
+    # Cost / turns parsed from stubbed stream-json.
+    assert result.cost_usd == pytest.approx(0.0123)
+    assert result.num_turns == 4
+
+    run_dir = run_dir_for(results_dir, task.instance_id, "code_only", 1)
+    assert (run_dir / "result.json").is_file()
+    assert (run_dir / "agent.jsonl").is_file()
+    assert (run_dir / "scratch" / "answer.txt").read_text() == "42\n"
+    # Starter workspace file must have been copied.
+    assert (run_dir / "scratch" / "starter.txt").read_text() == "START\n"
+
+
+def test_run_artifact_arm_fail_verdict(tmp_path, stub_claude, monkeypatch):
+    task = _make_fixture(tmp_path / "task", _GRADER_CHECKS_42)
+    monkeypatch.setattr(
+        artifact_run_mod, "run_claude",
+        _stub_claude_writes("wrong\n"),
+    )
+    results_dir = tmp_path / "results"
+    result = run_artifact_arm(
+        task, "tool_rich", 1,
+        results_dir=results_dir,
+        claude_binary="/bin/true",
+        echo=lambda _m: None,
+    )
+    assert result.verdict == "FAIL"
+    assert result.grade_result is not None
+    assert result.grade_result.passed is False
+
+
+def test_run_artifact_arm_no_leak_in_scratch(tmp_path, stub_claude, monkeypatch):
+    task = _make_fixture(tmp_path / "task", _GRADER_CHECKS_42)
+    monkeypatch.setattr(
+        artifact_run_mod, "run_claude",
+        _stub_claude_writes("42\n"),
+    )
+    results_dir = tmp_path / "results"
+    run_artifact_arm(
+        task, "code_only", 1,
+        results_dir=results_dir,
+        claude_binary="/bin/true",
+        echo=lambda _m: None,
+    )
+    scratch = results_dir / task.instance_id / "code_only" / "run1" / "scratch"
+    # ABSOLUTE invariant: no grader/hidden.py, no reference_output.* in scratch.
+    assert not any(scratch.rglob("hidden.py"))
+    assert not any(scratch.rglob("reference_output*"))
+
+
+def test_budget_log_unlimited(tmp_path, stub_claude, monkeypatch, capsys):
+    task = _make_fixture(tmp_path / "task", _GRADER_CHECKS_42, budget=(0, 0))
+    monkeypatch.setattr(
+        artifact_run_mod, "run_claude",
+        _stub_claude_writes("42\n"),
+    )
+    captured: list[str] = []
+    run_artifact_arm(
+        task, "code_only", 1,
+        results_dir=tmp_path / "results",
+        claude_binary="/bin/true",
+        echo=captured.append,
+    )
+    joined = "\n".join(captured)
+    assert "budget enforcement OFF (0 = unlimited)" in joined
+
+
+def test_budget_log_nonzero(tmp_path, stub_claude, monkeypatch):
+    task = _make_fixture(tmp_path / "task", _GRADER_CHECKS_42, budget=(10, 300))
+    monkeypatch.setattr(
+        artifact_run_mod, "run_claude",
+        _stub_claude_writes("42\n"),
+    )
+    captured: list[str] = []
+    result = run_artifact_arm(
+        task, "code_only", 1,
+        results_dir=tmp_path / "results",
+        claude_binary="/bin/true",
+        echo=captured.append,
+    )
+    joined = "\n".join(captured)
+    assert "max_code_runs=10" in joined
+    assert "max_wall_seconds=300" in joined
+    assert "enforcement OFF" in joined
+    # Fields are stored on the result even though enforcement is off.
+    assert result.budget == {
+        "max_code_runs": 10, "max_wall_seconds": 300, "enforcement": "OFF",
+    }
+
+
+def test_is_run_complete_true_false(tmp_path):
+    run_dir = tmp_path / "r"
+    run_dir.mkdir()
+    assert not is_run_complete(run_dir)
+    (run_dir / "result.json").write_text(json.dumps({"verdict": "PASS"}))
+    assert is_run_complete(run_dir)
+    (run_dir / "result.json").write_text(json.dumps({"verdict": "ERROR"}))
+    assert not is_run_complete(run_dir)
+
+
+def test_arm_list_constants():
+    assert set(ARMS) == {"code_only", "tool_rich"}


### PR DESCRIPTION
Closes #94. Part of epic #92.

## Summary

Ships the artifact-graded benchmark harness under `python -m swebench artifact <run|verify>`. Additive-only — the existing `swebench run`/`add`/`analyze`/`cache` command groups are untouched (slice-invariant: existing SWE-bench behaviour is byte-identical post-merge).

New modules:

- `swebench/artifact_models.py` — `Task`, `ExecutionBudget`, `GradeResult`, `ArtifactArmResult`. Disjoint from `swebench.models.Problem`.
- `swebench/artifact_loader.py` — parses `tasks/<cat>/<slug>/task.yaml` per the frozen SCHEMA (#93). Strict unknown-field rejection. Exact-match `filter_ids`.
- `swebench/artifact_materialize.py` — copies `workspace/` into `results_artifact/<id>/<arm>/run<N>/scratch/`. Post-copy scan raises `MaterializationError` if any `hidden.py` or `reference_output*` file is found in the scratch tree (ABSOLUTE no-leak tripwire).
- `swebench/_artifact_grade_runner.py` + `swebench/artifact_grade.py` — runs `grader/hidden.py:grade(scratch_dir)` in a fresh Python subprocess and serialises the result over stdout JSON. Structural typing on the grader return value.
- `swebench/artifact_run.py` — arm executor mirroring `run.py:_run_arm` with arms renamed `code_only` / `tool_rich`. Reuses `harness.run_claude` with `cwd=scratch_dir`. Reads `execution_budget` and logs "enforcement OFF (0 = unlimited)"; no real numeric enforcement (per STRONG invariant / §7 non-goal). `# TODO(budget)` hook site marked for the future enforcement epic.
- `swebench/artifact_cli.py` — Click group with `run` (full) and `verify` (placeholder for #96, exits 2 with a pointer). Wired into `cli.py` via one `add_command` line.

Scaffolding:

- `tasks/.gitkeep`, `sets/seed-v1.txt` (empty; populated by #95+).
- `results_artifact/` added to `.gitignore`.
- `docs/adr-0001-artifact-mode.md` filled in: Option A on all three decisions (subcommand, copy-on-setup, no OverlayFS).

Cache explicitly not used: no artifact module imports `swebench.cache` (Open Q #3 resolution from refine-epic).

## Test plan

- [x] 40 new unit tests across loader / materializer / grader / run / CLI — all pass.
- [x] No regressions in tests modified by this slice; 25 pre-existing failures on the epic branch (patterns.json registry + OverlayFS cache integration) are unrelated.
- [x] `python -m swebench run --help` still works and does not advertise artifact-mode flags (additive-only smoke test).
- [x] `python -m swebench artifact run --help` works; help lists `--filter`, `--arms`, `--runs`, `--output-dir`, `--resume`, `--tasks-dir`, `--mcp-config`.
- [x] `python -m swebench artifact verify` prints placeholder message and exits 2.
- [x] Falsifiability check: end-to-end CLI test asserts `not any(scratch.rglob("hidden.py"))` and `not any(scratch.rglob("reference_output*"))` for both arms after a run.