### PR TITLE
fix(#107): give agent absolute paths in artifact-mode prompt

### DIFF
--- a/swebench/artifact_run.py
+++ b/swebench/artifact_run.py
@@ -57,9 +57,16 @@ def _build_prompt(task: Task, scratch_dir: Path, arm: str) -> str:
         raise FileNotFoundError(f"problem_statement not found: {prompt_path}")
     prompt_body = prompt_path.read_text()
 
+    # Use absolute paths so the agent does not need to thread cwd through
+    # every code-execution call. The tool_rich arm's Bash inherits cwd from
+    # run_claude's subprocess, but code_only routes through MCP execute_code
+    # which defaults to a fresh tmpdir when the agent omits the cwd= param.
+    # Absolute paths remove the ambiguity for both arms.
+    scratch_abs = scratch_dir.resolve()
+    output_abs = scratch_abs / task.output_artifact
     parts = [
-        f"You are working in the directory: {scratch_dir}",
-        f"Write your output artifact to the relative path: {task.output_artifact}",
+        f"Your input files are under the absolute path: {scratch_abs}",
+        f"Write your output artifact to the absolute path: {output_abs}",
         "",
         prompt_body,
     ]

--- a/tests/test_artifact_run.py
+++ b/tests/test_artifact_run.py
@@ -17,6 +17,7 @@ from swebench import artifact_run as artifact_run_mod
 from swebench.artifact_models import ExecutionBudget, Task
 from swebench.artifact_run import (
     ARMS,
+    _build_prompt,
     _build_tools_flags,
     is_run_complete,
     run_artifact_arm,
@@ -232,3 +233,28 @@ def test_is_run_complete_true_false(tmp_path):
 
 def test_arm_list_constants():
     assert set(ARMS) == {"code_only", "tool_rich"}
+
+
+def test_build_prompt_uses_absolute_paths(tmp_path):
+    """Regression for #107: agent must receive absolute paths, not relative.
+
+    The MCP ``execute_code`` tool defaults to a fresh tmpdir when the agent
+    omits ``cwd=`` on a call. Relative paths in the prompt would resolve
+    against that tmpdir, not scratch_dir — so the output artifact would land
+    outside where the grader looks. Absolute paths remove the ambiguity.
+    """
+    task_dir = tmp_path / "task"
+    task = _make_fixture(task_dir, _GRADER_CHECKS_42)
+    scratch = tmp_path / "results" / task.instance_id / "code_only" / "run1" / "scratch"
+    scratch.mkdir(parents=True)
+
+    prompt = _build_prompt(task, scratch, "code_only")
+
+    scratch_abs = str(scratch.resolve())
+    output_abs = str((scratch.resolve() / task.output_artifact))
+
+    # Must contain absolute scratch path and absolute output path.
+    assert scratch_abs in prompt
+    assert output_abs in prompt
+    # Must NOT contain the old "relative path" framing that caused #107.
+    assert "relative path" not in prompt


### PR DESCRIPTION
Closes #107

## Root cause

The code_only arm routes execution through the MCP codebox server. `mcp__codebox__execute_code` ignores the MCP config's `cwd` field — the server's `executeCode` ([exec-server.js:417](https://github.com/hyang0129/onlycodes/blob/main/exec-server.js#L417)) spawns a fresh `/tmp/onlycodes-*` dir per call when the agent omits `cwd=` on the call. So the prompt's `"relative path: output/p95.jsonl"` resolved against a throwaway tmpdir, not scratch_dir.

The tool_rich arm didn't see this because its Bash inherits cwd from `run_claude`'s subprocess (via `repo_dir=scratch_dir`). Only the code_only path hit the ambiguity.

## Fix

Switch `_build_prompt` to emit absolute paths for both the input directory and the output artifact. No MCP config changes, no exec-server changes — the agent gets a path it can use directly, no cwd threading required.

## Verification

Re-ran the code_only arm on `data_processing__p95_latency_easy`:

```
[data_processing__p95_latency_easy code_only run1] PASS
  (wall=24s, cost=0.058, turns=5)
```

Previously: FAIL, score 0.0, 70s, 10 turns (the agent spent most of its budget searching for input files because the tmpdir had no `access.jsonl`).

## Tests

- New regression test `test_build_prompt_uses_absolute_paths` — asserts the built prompt contains absolute scratch + output paths and no `"relative path"` framing.
- All existing `test_artifact_run.py` tests pass (11/11).
- Wider suite: pre-existing `test_analyze_registry` / `test_cache_integration` failures unchanged (not introduced here — same state as the epic branch pre-fix).

## Related

- Parent epic: #92
- Sibling (filed during diagnosis, **not** fixed here): #108 — agent Python kernel can still read `grader/hidden.py` and `reference_output.*` via absolute filesystem paths. This fix does NOT address that leak — it only removes the cwd ambiguity. #108 requires either sandboxing the kernel or moving scratch dirs outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)