### PR TITLE
feat(#96): tools/verify_graders.py — pre-merge grader sanity gate

### DIFF
--- a/tests/test_verify_graders.py
+++ b/tests/test_verify_graders.py
@@ -1,0 +1,130 @@
+"""Tests for tools/verify_graders.py — reference_output sanity gate.
+
+We run the tool as a subprocess so the exit-code contract is verified
+end-to-end, mirroring how CI would invoke it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parent.parent / "tools" / "verify_graders.py"
+
+
+def _run_tool(tasks_dir: Path) -> subprocess.CompletedProcess:
+    env_patch = {"VERIFY_GRADERS_TASKS_DIR": str(tasks_dir)}
+    import os
+    env = os.environ.copy()
+    env.update(env_patch)
+    return subprocess.run(
+        [sys.executable, str(_TOOL), "--tasks-dir", str(tasks_dir)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_task(task_dir: Path, grader_src: str, ref_content: str,
+               workspace_content: str = "# empty\n") -> None:
+    """Build a minimal artifact task under task_dir."""
+    (task_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    (task_dir / "workspace" / "input.txt").write_text(workspace_content)
+    (task_dir / "grader").mkdir(parents=True, exist_ok=True)
+    (task_dir / "grader" / "hidden.py").write_text(textwrap.dedent(grader_src))
+    (task_dir / "grader" / "reference_output.txt").write_text(ref_content)
+    (task_dir / "prompt.md").write_text("produce answer.txt\n")
+    (task_dir / "task.yaml").write_text(textwrap.dedent(f"""\
+        instance_id: test_fixture__verify_{task_dir.name}
+        category: test_fixture
+        difficulty: easy
+        problem_statement: prompt.md
+        workspace_dir: workspace/
+        output_artifact: answer.txt
+        hidden_grader: grader/hidden.py
+        reference_output: grader/reference_output.txt
+        execution_budget:
+          max_code_runs: 0
+          max_wall_seconds: 0
+    """))
+
+
+_GRADER_CHECKS_42 = """
+    class R:
+        passed = False
+        score = 0.0
+        detail = ""
+
+    def grade(scratch_dir):
+        from pathlib import Path
+        r = R()
+        artifact = Path(scratch_dir) / "answer.txt"
+        if not artifact.exists():
+            r.detail = "output artifact not produced"
+            return r
+        val = artifact.read_text().strip()
+        r.passed = val == "42"
+        r.score = 1.0 if r.passed else 0.0
+        r.detail = "ok" if r.passed else f"got {val!r}"
+        return r
+"""
+
+_GRADER_ALWAYS_FAIL = """
+    class R:
+        passed = False
+        score = 0.0
+        detail = "always fails"
+
+    def grade(scratch_dir):
+        return R()
+"""
+
+
+def test_all_pass(tmp_path):
+    tasks_dir = tmp_path / "tasks" / "test_fixture"
+    task_dir = tasks_dir / "pass_task"
+    _make_task(task_dir, _GRADER_CHECKS_42, "42\n")
+    proc = _run_tool(tmp_path / "tasks")
+    assert proc.returncode == 0
+    assert "PASS" in proc.stdout
+    assert "test_fixture__verify_pass_task" in proc.stdout
+
+
+def test_fail_verdict(tmp_path):
+    tasks_dir = tmp_path / "tasks" / "test_fixture"
+    task_dir = tasks_dir / "fail_task"
+    _make_task(task_dir, _GRADER_ALWAYS_FAIL, "42\n")
+    proc = _run_tool(tmp_path / "tasks")
+    assert proc.returncode == 1
+    assert "FAIL" in proc.stdout
+
+
+def test_missing_reference_output(tmp_path):
+    tasks_dir = tmp_path / "tasks" / "test_fixture"
+    task_dir = tasks_dir / "miss_task"
+    _make_task(task_dir, _GRADER_CHECKS_42, "42\n")
+    # Delete the reference_output file after creating the task.
+    (task_dir / "grader" / "reference_output.txt").unlink()
+    proc = _run_tool(tmp_path / "tasks")
+    assert proc.returncode == 1
+    assert "ERROR" in proc.stdout
+
+
+def test_no_tasks_exits_2(tmp_path):
+    empty_tasks = tmp_path / "tasks"
+    empty_tasks.mkdir()
+    proc = _run_tool(empty_tasks)
+    assert proc.returncode == 2
+
+
+def test_deterministic_output(tmp_path):
+    tasks_dir = tmp_path / "tasks" / "test_fixture"
+    task_dir = tasks_dir / "det_task"
+    _make_task(task_dir, _GRADER_CHECKS_42, "42\n")
+    proc1 = _run_tool(tmp_path / "tasks")
+    proc2 = _run_tool(tmp_path / "tasks")
+    assert proc1.stdout == proc2.stdout
+    assert proc1.returncode == proc2.returncode

--- a/tools/verify_graders.py
+++ b/tools/verify_graders.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Pre-merge grader sanity gate.
+
+Walks ``tasks/<category>/<slug>/task.yaml``, copies each task's
+``reference_output`` into a temp scratch dir as the expected output artifact,
+invokes the harness grader, and reports PASS/FAIL per task.
+
+Exit codes:
+  0  all graders returned passed=True
+  1  at least one grader returned passed=False or raised GraderInvocationError
+  2  discovery/parse error (missing task.yaml fields, loader ValueError)
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+# Allow running as ``python tools/verify_graders.py`` from the repo root
+# without editable-installing swebench.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from swebench.artifact_grade import GraderInvocationError, invoke_grader
+from swebench.artifact_loader import load_tasks
+from swebench.artifact_materialize import materialize
+
+
+def _verify_task(task) -> tuple[str, str]:
+    """Run one task's grader against its reference_output.
+
+    Returns (status, detail) where status is "PASS", "FAIL", or "ERROR".
+    """
+    if task.task_dir is None:
+        return "ERROR", "task_dir not set"
+
+    ref_path = task.task_dir / task.reference_output
+    if not ref_path.is_file():
+        return "ERROR", f"reference_output not found: {ref_path}"
+
+    with tempfile.TemporaryDirectory(prefix="verify_graders_") as tmp:
+        scratch = Path(tmp) / "scratch"
+        # Materialize workspace so the grader can access input files, then
+        # place the reference output where the grader expects the agent artifact.
+        try:
+            materialize(task, scratch)
+        except Exception as exc:
+            return "ERROR", f"workspace materialization failed: {exc}"
+
+        dest = scratch / task.output_artifact
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ref_path, dest)
+
+        try:
+            result = invoke_grader(task, scratch)
+        except GraderInvocationError as exc:
+            return "ERROR", str(exc)
+
+    if result.passed:
+        return "PASS", result.detail
+    return "FAIL", result.detail
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=_REPO_ROOT / "tasks",
+        help="Root tasks directory (default: <repo>/tasks/)",
+    )
+    args = parser.parse_args(argv)
+    tasks_dir: Path = args.tasks_dir
+
+    try:
+        tasks = load_tasks(tasks_dir)
+    except ValueError as exc:
+        print(f"ERROR: task discovery/parse failed: {exc}", file=sys.stderr)
+        return 2
+
+    if not tasks:
+        print("No tasks found — nothing to verify.", file=sys.stderr)
+        return 2
+
+    overall_exit = 0
+    for task in tasks:
+        status, detail = _verify_task(task)
+        print(f"{status:5s}  {task.instance_id}  {detail}")
+        if status != "PASS":
+            overall_exit = 1
+
+    return overall_exit
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #96. Part of epic #92.

## Summary
- New `tools/verify_graders.py`: walks `tasks/` tree, materializes each task's workspace into a temp scratch dir, copies `reference_output` as the output artifact, invokes `invoke_grader()` via the same harness path, and prints `PASS`/`FAIL`/`ERROR` per task
- `--tasks-dir` flag overrides default `tasks/` root (enables isolated tests)
- Exit codes: 0=all pass, 1=any fail/error, 2=no tasks or parse error
- 5 tests covering: all-pass, fail verdict, missing reference_output, no-tasks, determinism

## Test plan
- [ ] `python tools/verify_graders.py` → `PASS  data_processing__p95_latency_easy`
- [ ] `pytest tests/test_verify_graders.py -v` → 5 passed
- [ ] Run twice back-to-back → byte-identical output (determinism check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)