### PR TITLE
fix(#108): sandbox grader/hidden.py from agent kernel + per-run leak audit

### DIFF
--- a/docs/SCHEMA_ARTIFACT.md
+++ b/docs/SCHEMA_ARTIFACT.md
@@ -206,6 +206,13 @@ The harness (#2) is responsible for the copy step and for ensuring no grader pat
 
 The invariant "no golden solution or correctness signal is ever visible to the agent" is a hard epic invariant (see #92). Any task author who finds themselves needing to reference `grader/` or `reference_output` from inside `workspace/` has a bug — the task is miscategorized and needs re-shaping.
 
+**Issue #108 mitigation (defense in depth).** The materialiser alone is not sufficient — the agent's Python kernel could previously read `tasks/<category>/<slug>/grader/` by traversing up from a scratch dir that lived inside the repo tree. Two additional measures now apply:
+
+1. **Scratch root lives outside the repo.** The default `--output-dir` for `python -m swebench artifact run` is `/tmp/onlycodes-artifact/` rather than `<repo>/results_artifact/`. An agent starting at `scratch_dir` has no structural way to guess the onlycodes repo location.
+2. **Per-run leak audit.** After every run, the harness scans `agent.jsonl` for the task's grader fingerprints (a committed `# GRADER-SENTINEL: <uuid>` in `hidden.py`, plus the first distinctive lines of `reference_output.*`). The result is recorded on `result.json` as `leak_detected: bool`. Tainted runs are flagged by `analyze summary` and excluded from the headline pass-rate.
+
+Task authors creating a new grader MUST include a unique `# GRADER-SENTINEL: <uuid>` comment near the top of `hidden.py`. Generate a fresh UUID4 for each new task; never reuse sentinels across tasks.
+
 ### 5.4 Pre-merge sanity check
 
 Before a task PR lands, a harness utility runs the task's `reference_output` through its `grade()` function and asserts `passed=True, score=1.0`. This catches graders that reject their own known-good answer — the single most common silent-failure mode.

--- a/swebench/analyze/summary.py
+++ b/swebench/analyze/summary.py
@@ -20,6 +20,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 import click
 
@@ -161,7 +162,7 @@ def _detect_artifact_layout(results_dir: Path) -> bool:
     return False
 
 
-def _print_artifact_table(rows: list[ArtifactRow], echo) -> None:
+def _print_artifact_table(rows: list[ArtifactRow], echo: Callable[[str], None]) -> None:
     try:
         from tabulate import tabulate
 
@@ -195,9 +196,8 @@ def _print_artifact_table(rows: list[ArtifactRow], echo) -> None:
             )
 
     # Pass-rate with and without tainted runs.
-    total = len(rows)
     clean = [r for r in rows if not r.leak_detected]
-    tainted = total - len(clean)
+    tainted = len(rows) - len(clean)
     passes_clean = sum(1 for r in clean if r.verdict == "PASS")
     echo("")
     echo(

--- a/swebench/analyze/summary.py
+++ b/swebench/analyze/summary.py
@@ -1,9 +1,24 @@
-"""`analyze summary` — parse results and print summary table."""
+"""`analyze summary` — parse results and print summary table.
+
+Supports two result layouts:
+
+1. SWE-bench mode (historic): flat ``<iid>_<arm>_run<N>_test.txt`` + ``*.jsonl``
+   pairs under ``results_swebench/``.
+2. Artifact mode (issue #108): nested ``<iid>/<arm>/run<N>/result.json`` tree
+   produced by ``python -m swebench artifact run``.
+
+The summary command auto-detects which layout it is looking at. Artifact-mode
+rows carry a ``leak`` column (Y / .) surfacing runs where the per-run grader
+leak auditor flagged a fingerprint match in the agent transcript. Tainted rows
+are excluded from the headline pass-rate and counted separately.
+"""
 
 from __future__ import annotations
 
 import csv
+import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -83,6 +98,142 @@ def _parse_results(results_dir: Path) -> list[ArmResult]:
     return results
 
 
+@dataclass
+class ArtifactRow:
+    """Row shape for artifact-mode summary entries (issue #108)."""
+
+    instance_id: str
+    arm: str
+    run_idx: int
+    verdict: str
+    cost_usd: float | None
+    num_turns: int | None
+    wall_secs: int
+    leak_detected: bool
+    result_json_path: str
+
+
+def _parse_artifact_results(results_dir: Path) -> list[ArtifactRow]:
+    """Walk ``<iid>/<arm>/run<N>/result.json`` and return one row per run.
+
+    Unknown / missing fields are tolerated — older result.json files without
+    ``leak_detected`` default to ``False`` (pre-audit data is treated as clean).
+    """
+    rows: list[ArtifactRow] = []
+    for result_path in sorted(results_dir.glob("*/*/run*/result.json")):
+        try:
+            data = json.loads(result_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        rows.append(
+            ArtifactRow(
+                instance_id=str(data.get("instance_id", result_path.parts[-4])),
+                arm=str(data.get("arm", result_path.parts[-3])),
+                run_idx=int(data.get("run_idx", _run_idx_from_name(result_path.parts[-2]))),
+                verdict=str(data.get("verdict", "ERROR")),
+                cost_usd=(
+                    float(data["cost_usd"])
+                    if data.get("cost_usd") is not None
+                    else None
+                ),
+                num_turns=(
+                    int(data["num_turns"])
+                    if data.get("num_turns") is not None
+                    else None
+                ),
+                wall_secs=int(data.get("wall_secs", 0)),
+                leak_detected=bool(data.get("leak_detected", False)),
+                result_json_path=str(result_path),
+            )
+        )
+    return rows
+
+
+def _run_idx_from_name(name: str) -> int:
+    m = re.match(r"run(\d+)$", name)
+    return int(m.group(1)) if m else 0
+
+
+def _detect_artifact_layout(results_dir: Path) -> bool:
+    """Return True if ``results_dir`` contains any artifact-mode result.json."""
+    for _ in results_dir.glob("*/*/run*/result.json"):
+        return True
+    return False
+
+
+def _print_artifact_table(rows: list[ArtifactRow], echo) -> None:
+    try:
+        from tabulate import tabulate
+
+        headers = ["instance_id", "arm", "run", "verdict", "leak", "cost", "turns"]
+        body = [
+            [
+                r.instance_id,
+                r.arm,
+                r.run_idx,
+                r.verdict,
+                "Y" if r.leak_detected else ".",
+                f"${r.cost_usd:.3f}" if r.cost_usd is not None else "N/A",
+                r.num_turns if r.num_turns is not None else "N/A",
+            ]
+            for r in rows
+        ]
+        echo(tabulate(body, headers=headers, tablefmt="plain"))
+    except ImportError:  # pragma: no cover — tabulate is a hard dep in this repo
+        header = (
+            f"{'instance_id':<30} {'arm':<12} {'run':<5} {'verdict':<8} "
+            f"{'leak':<5} {'cost':<10} {'turns':<7}"
+        )
+        echo(header)
+        for r in rows:
+            cost_str = f"${r.cost_usd:.3f}" if r.cost_usd is not None else "N/A"
+            turns_str = str(r.num_turns) if r.num_turns is not None else "N/A"
+            echo(
+                f"{r.instance_id:<30} {r.arm:<12} {r.run_idx:<5} "
+                f"{r.verdict:<8} {('Y' if r.leak_detected else '.'):<5} "
+                f"{cost_str:<10} {turns_str:<7}"
+            )
+
+    # Pass-rate with and without tainted runs.
+    total = len(rows)
+    clean = [r for r in rows if not r.leak_detected]
+    tainted = total - len(clean)
+    passes_clean = sum(1 for r in clean if r.verdict == "PASS")
+    echo("")
+    echo(
+        f"Clean runs: {len(clean)}; PASS={passes_clean} "
+        f"({(passes_clean / len(clean) * 100):.1f}% pass-rate excluding tainted)"
+        if clean else
+        f"Clean runs: 0; PASS=0"
+    )
+    if tainted:
+        echo(
+            f"Tainted runs (leak_detected=true): {tainted} — excluded from pass-rate."
+        )
+
+
+def _write_artifact_csv(rows: list[ArtifactRow], out_path: str) -> None:
+    fieldnames = [
+        "instance_id", "arm", "run_idx", "verdict", "leak_detected",
+        "cost_usd", "num_turns", "wall_secs", "result_json_path",
+    ]
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({
+                "instance_id": r.instance_id,
+                "arm": r.arm,
+                "run_idx": r.run_idx,
+                "verdict": r.verdict,
+                "leak_detected": r.leak_detected,
+                "cost_usd": r.cost_usd,
+                "num_turns": r.num_turns,
+                "wall_secs": r.wall_secs,
+                "result_json_path": r.result_json_path,
+            })
+
+
 def _register(analyze_command: click.Group) -> None:
     """Register the `summary` subcommand on the given analyze group."""
 
@@ -111,6 +262,20 @@ def _register(analyze_command: click.Group) -> None:
             click.echo(f"ERROR: Results directory not found: {rdir}", err=True)
             click.echo("Run 'python -m swebench run' first, or specify --results-dir.", err=True)
             raise SystemExit(1)
+
+        # Issue #108: auto-detect artifact-mode results layout and surface a
+        # leak column + tainted-run counter when the layout matches. Falls back
+        # to the SWE-bench flat layout otherwise.
+        if _detect_artifact_layout(rdir):
+            artifact_rows = _parse_artifact_results(rdir)
+            if not artifact_rows:
+                click.echo(f"No result files found in {rdir}/")
+                return
+            _print_artifact_table(artifact_rows, click.echo)
+            if out_path:
+                _write_artifact_csv(artifact_rows, out_path)
+                click.echo(f"\nCSV written to {out_path}")
+            return
 
         results = _parse_results(rdir)
 

--- a/swebench/artifact_audit.py
+++ b/swebench/artifact_audit.py
@@ -42,6 +42,11 @@ MIN_LINE_LEN = 8
 MIN_COMBINED_LEN = 80
 MAX_LINES = 3
 
+# The regex deliberately accepts any >=8-char alnum+hyphen token rather than a
+# strict UUID4 shape. Seed-v1 tasks use UUID4 per the PR-#119 / SCHEMA
+# convention, but a later task-generation pipeline may prefer slug-based
+# identifiers (e.g. `task-slug-v2-a1b2c3`). The laxity is intentional; any
+# unique high-entropy token committed into hidden.py will work as a sentinel.
 _SENTINEL_RE = re.compile(r"#\s*GRADER-SENTINEL:\s*([A-Za-z0-9][A-Za-z0-9\-]{7,})")
 
 

--- a/swebench/artifact_audit.py
+++ b/swebench/artifact_audit.py
@@ -1,0 +1,153 @@
+"""Per-run leak auditor for artifact-graded benchmark tasks.
+
+Issue #108. The ABSOLUTE no-leak invariant (SCHEMA §Invariants) forbids the
+agent from seeing ``grader/hidden.py`` or ``grader/reference_output.*`` for
+the task it is being graded on. The materialiser (``artifact_materialize``)
+makes sure those files never land in the agent's scratch dir, but the agent's
+Python kernel can still walk the filesystem and read them if the scratch dir
+lives inside the repo tree (see #108 root-cause analysis).
+
+Defense in depth: this module scans the agent's transcript (``agent.jsonl``)
+after every run for two fingerprints derived from the task's own grader files:
+
+1. **Sentinel UUID** — a ``# GRADER-SENTINEL: <uuid>`` comment committed into
+   each task's ``hidden.py``. If the agent ``open()``s the grader and dumps
+   its contents anywhere the harness captures (stdout, tool results, chat
+   messages), the UUID will appear in ``agent.jsonl``.
+
+2. **Reference-output fingerprint** — the first 3 non-trivial lines of the
+   task's ``reference_output.*`` file, verbatim. Each line that is at least
+   8 characters long and contains alphanumerics counts as a "line check"; a
+   line that appears in ``agent.jsonl`` is considered a hit. The combined
+   length of the three lines must reach ``MIN_COMBINED_LEN`` (80 chars) for
+   any one line to count as a fingerprint (prevents trivial-prefix false
+   positives on e.g. two-row files).
+
+``audit_leak(task, agent_jsonl_path) -> bool`` returns ``True`` iff *any*
+fingerprint matches. False by default — unreadable grader files (missing
+sentinel, missing reference, unreadable transcript) never cause a false
+positive; they just mean we have nothing to match against.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from swebench.artifact_models import Task
+
+
+MIN_LINE_LEN = 8
+MIN_COMBINED_LEN = 80
+MAX_LINES = 3
+
+_SENTINEL_RE = re.compile(r"#\s*GRADER-SENTINEL:\s*([A-Za-z0-9][A-Za-z0-9\-]{7,})")
+
+
+@dataclass(frozen=True)
+class Fingerprints:
+    """Tokens extracted from a task's grader that must not appear in the agent transcript."""
+
+    sentinel: str | None
+    reference_lines: tuple[str, ...]
+
+
+def _read_text_safely(path: Path) -> str | None:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return None
+
+
+def _extract_reference_lines(text: str) -> tuple[str, ...]:
+    """Return up to ``MAX_LINES`` non-trivial lines, or () if the pool is too small.
+
+    A line is "non-trivial" if it is >= ``MIN_LINE_LEN`` chars after stripping
+    and contains at least one alphanumeric character. We return the fingerprint
+    tuple only if the combined length of the kept lines is >= ``MIN_COMBINED_LEN``
+    (makes accidental matches on an agent echoing "hello" impossible).
+    """
+    kept: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if len(line) < MIN_LINE_LEN:
+            continue
+        if not any(ch.isalnum() for ch in line):
+            continue
+        kept.append(line)
+        if len(kept) >= MAX_LINES:
+            break
+    if sum(len(s) for s in kept) < MIN_COMBINED_LEN:
+        return ()
+    return tuple(kept)
+
+
+def extract_fingerprints(task: Task) -> Fingerprints:
+    """Read ``task``'s grader files and extract the sentinel + reference-line fingerprints.
+
+    Returns ``Fingerprints(None, ())`` if the task is not on disk, the grader
+    files are missing, or no fingerprint could be extracted. The caller should
+    treat the empty case as "nothing to audit" rather than an error — the
+    materialiser already guarantees the grader files are not visible to the
+    agent, so an absent fingerprint just means we lose one layer of defense
+    in depth, not that the run is unsafe.
+    """
+    if task.task_dir is None:
+        return Fingerprints(None, ())
+
+    sentinel: str | None = None
+    hidden_path = task.task_dir / task.hidden_grader
+    text = _read_text_safely(hidden_path)
+    if text is not None:
+        m = _SENTINEL_RE.search(text)
+        if m:
+            sentinel = m.group(1)
+
+    reference_lines: tuple[str, ...] = ()
+    ref_path = task.task_dir / task.reference_output
+    ref_text = _read_text_safely(ref_path)
+    if ref_text is not None:
+        reference_lines = _extract_reference_lines(ref_text)
+
+    return Fingerprints(sentinel=sentinel, reference_lines=reference_lines)
+
+
+def _normalise(text: str) -> str:
+    """Collapse JSON-string escaping so reference lines match inside stream-json.
+
+    ``agent.jsonl`` is a stream of JSON records; any reference line with double
+    quotes (common for ``reference_output.jsonl``) will appear with the quotes
+    escaped as ``\\"``. We strip those backslashes so a needle like
+    ``{"endpoint": ...}`` matches both raw and JSON-embedded occurrences.
+    """
+    return text.replace('\\"', '"').replace("\\n", "\n")
+
+
+def scan_text_for_fingerprints(text: str, fp: Fingerprints) -> bool:
+    """Return True iff ``text`` contains the sentinel or any reference line."""
+    haystack = _normalise(text)
+    if fp.sentinel and fp.sentinel in haystack:
+        return True
+    for line in fp.reference_lines:
+        if line and line in haystack:
+            return True
+    return False
+
+
+def audit_leak(task: Task, agent_jsonl_path: Path) -> bool:
+    """Scan ``agent.jsonl`` for any fingerprint derived from ``task``'s grader.
+
+    Returns ``True`` iff a leak is detected. Never raises — a missing or
+    unreadable transcript is treated as "nothing to scan" and returns ``False``.
+    """
+    fp = extract_fingerprints(task)
+    if fp.sentinel is None and not fp.reference_lines:
+        return False
+
+    path = Path(agent_jsonl_path)
+    text = _read_text_safely(path)
+    if text is None:
+        return False
+
+    return scan_text_for_fingerprints(text, fp)

--- a/swebench/artifact_cli.py
+++ b/swebench/artifact_cli.py
@@ -28,6 +28,13 @@ from swebench.artifact_run import (
 from swebench.harness import find_claude_binary
 
 
+# Issue #108: default results root. Chosen to live outside /workspaces/hub_1
+# (the repo mount) so an agent traversing up from its scratch dir cannot
+# reach tasks/<category>/<slug>/grader/. Override with --output-dir for
+# persistent per-experiment result storage.
+DEFAULT_RESULTS_ROOT = "/tmp/onlycodes-artifact"
+
+
 @click.group()
 def artifact_group() -> None:
     """Artifact-graded benchmark: run tasks, verify graders (future)."""
@@ -60,7 +67,12 @@ def artifact_group() -> None:
     "output_dir",
     type=click.Path(file_okay=False, dir_okay=True, resolve_path=False),
     default=None,
-    help="Directory for result files [default: <repo>/results_artifact/].",
+    help=(
+        "Directory for result files [default: /tmp/onlycodes-artifact/]. "
+        "Default lives outside the repo tree so an agent that traverses "
+        "from its scratch cwd cannot reach tasks/<cat>/<slug>/grader/ "
+        "(issue #108)."
+    ),
 )
 @click.option(
     "--resume/--no-resume",
@@ -102,7 +114,10 @@ def artifact_run_command(
 
     root = repo_root()
     tasks_root = Path(tasks_dir) if tasks_dir else (root / "tasks")
-    results_dir = Path(output_dir) if output_dir else (root / "results_artifact")
+    # Issue #108: default scratch root lives OUTSIDE the repo tree. The agent's
+    # Python kernel runs with cwd=scratch_dir; if scratch_dir were under the
+    # repo, the agent could read tasks/.../grader/hidden.py by traversing up.
+    results_dir = Path(output_dir) if output_dir else Path(DEFAULT_RESULTS_ROOT)
 
     filter_set: set[str] | None = None
     if filter_ids:

--- a/swebench/artifact_models.py
+++ b/swebench/artifact_models.py
@@ -96,6 +96,10 @@ class ArtifactArmResult:
     num_turns: int | None
     claude_version: str | None
     agent_jsonl_path: str
+    # Issue #108: per-run leak audit. True if the agent transcript contained a
+    # grader sentinel or a reference-output fingerprint for this task. Defaults
+    # to False so pre-audit runs/data remain loadable.
+    leak_detected: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)

--- a/swebench/artifact_run.py
+++ b/swebench/artifact_run.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 from typing import Callable
 
+from swebench.artifact_audit import audit_leak
 from swebench.artifact_grade import GraderInvocationError, invoke_grader
 from swebench.artifact_materialize import materialize, scratch_dir_for
 from swebench.artifact_models import ArtifactArmResult, GradeResult, Task
@@ -224,6 +225,18 @@ def run_artifact_arm(
 
     cost, turns = _extract_cost_and_turns(agent_jsonl)
 
+    # Issue #108: per-run leak audit. Soft mitigation — the materialiser keeps
+    # grader files out of scratch, and the default scratch root lives outside
+    # the repo tree, but a motivated agent could still probe upward. Scanning
+    # the transcript for the task's sentinel + reference-output fingerprints
+    # flags any run where the agent saw the grader regardless of path.
+    leak_detected = audit_leak(task, agent_jsonl)
+    if leak_detected:
+        echo(
+            f"  [{task.instance_id} {arm} run{run_idx}] "
+            "WARNING: grader-leak fingerprint found in agent.jsonl — run tainted."
+        )
+
     result = ArtifactArmResult(
         instance_id=task.instance_id,
         arm=arm,
@@ -240,6 +253,7 @@ def run_artifact_arm(
         num_turns=turns,
         claude_version=claude_version,
         agent_jsonl_path=str(agent_jsonl),
+        leak_detected=leak_detected,
     )
     with open(result_json, "w") as f:
         json.dump(result.to_dict(), f, indent=2, sort_keys=True)

--- a/tasks/algorithmic/makespan_scheduling/grader/hidden.py
+++ b/tasks/algorithmic/makespan_scheduling/grader/hidden.py
@@ -14,6 +14,7 @@ Correctness criterion:
 
 Determinism: pure function of scratch_dir contents. No clock, no network.
 """
+# GRADER-SENTINEL: 4cc6e89d-cc81-47d0-9e34-96d6ced97589
 
 from __future__ import annotations
 

--- a/tasks/algorithmic/min_cost_assignment/grader/hidden.py
+++ b/tasks/algorithmic/min_cost_assignment/grader/hidden.py
@@ -14,6 +14,7 @@ Correctness criterion:
 
 Determinism: pure function of scratch_dir contents. No clock, no network.
 """
+# GRADER-SENTINEL: 5fd288b7-d1b5-482f-8d41-2d6e364be1ce
 
 from __future__ import annotations
 

--- a/tasks/data_processing/multi_file_cohort/grader/hidden.py
+++ b/tasks/data_processing/multi_file_cohort/grader/hidden.py
@@ -1,4 +1,6 @@
 """Hidden grader for data_processing__multi_file_cohort."""
+
+# GRADER-SENTINEL: 8bd7db4f-42e8-476d-a9ea-56c596390d77
 from __future__ import annotations
 import csv, json
 from dataclasses import dataclass

--- a/tasks/data_processing/p95_latency_easy/grader/hidden.py
+++ b/tasks/data_processing/p95_latency_easy/grader/hidden.py
@@ -21,6 +21,7 @@ Determinism: pure function of scratch_dir contents. No clock, no network, no
 unseeded randomness. (No randomness is used at all; the identity comes from
 instance_id if ever needed — see SCHEMA §3.2.3.)
 """
+# GRADER-SENTINEL: 16de0e28-a93c-44fd-8c31-066cd36833d4
 
 from __future__ import annotations
 

--- a/tasks/data_processing/regression_detection/grader/hidden.py
+++ b/tasks/data_processing/regression_detection/grader/hidden.py
@@ -22,6 +22,7 @@ Correctness criterion:
 
 Determinism: pure function of scratch_dir contents. No clock, no network.
 """
+# GRADER-SENTINEL: d5c6fd69-3da6-483c-aaf8-85255815af50
 
 from __future__ import annotations
 

--- a/tasks/enumeration/graphs_chromatic_3/grader/hidden.py
+++ b/tasks/enumeration/graphs_chromatic_3/grader/hidden.py
@@ -12,6 +12,7 @@ Correctness criterion:
 
 Determinism: deterministic enumeration, no randomness.
 """
+# GRADER-SENTINEL: 3c634b2d-56ba-4e3b-ba6f-96a74920240c
 
 from __future__ import annotations
 

--- a/tasks/enumeration/latin_squares_3/grader/hidden.py
+++ b/tasks/enumeration/latin_squares_3/grader/hidden.py
@@ -16,6 +16,7 @@ Correctness criterion:
 
 Determinism: pure enumeration, no randomness.
 """
+# GRADER-SENTINEL: 8bb210a2-c805-4ef4-ab2c-af518e2c9911
 
 from __future__ import annotations
 

--- a/tasks/iterative_numerical/bisection_calibration/grader/hidden.py
+++ b/tasks/iterative_numerical/bisection_calibration/grader/hidden.py
@@ -1,4 +1,6 @@
 """Hidden grader for iterative_numerical__bisection_calibration."""
+
+# GRADER-SENTINEL: a06f058d-701e-4e7b-bf73-f9493659e9d6
 from __future__ import annotations
 import json
 import importlib.util

--- a/tasks/iterative_numerical/exp_decay_fit/grader/hidden.py
+++ b/tasks/iterative_numerical/exp_decay_fit/grader/hidden.py
@@ -13,6 +13,7 @@ Correctness criterion:
 
 Determinism: pure function of scratch_dir/data.jsonl contents.
 """
+# GRADER-SENTINEL: 32ae948a-f0ed-496a-96c3-4c6d3f17fc56
 
 from __future__ import annotations
 

--- a/tasks/iterative_numerical/hparam_search/grader/hidden.py
+++ b/tasks/iterative_numerical/hparam_search/grader/hidden.py
@@ -13,6 +13,7 @@ Correctness criterion:
 
 Determinism: the toy model is a deterministic pure-Python function.
 """
+# GRADER-SENTINEL: 5f2e1c62-a552-48e1-bf36-3a4f6522f888
 
 from __future__ import annotations
 

--- a/tasks/stateful_reasoning/event_ledger/grader/hidden.py
+++ b/tasks/stateful_reasoning/event_ledger/grader/hidden.py
@@ -1,4 +1,6 @@
 """Hidden grader for stateful_reasoning__event_ledger."""
+
+# GRADER-SENTINEL: 836b3259-1763-4529-bdc3-e1dfcd8ac5ec
 from __future__ import annotations
 import json
 from dataclasses import dataclass

--- a/tasks/stateful_reasoning/unreachable_functions/grader/hidden.py
+++ b/tasks/stateful_reasoning/unreachable_functions/grader/hidden.py
@@ -13,6 +13,7 @@ Correctness criterion:
 
 Determinism: pure AST analysis, no randomness.
 """
+# GRADER-SENTINEL: 2030e144-569e-4d45-a247-e8e6c0d1290c
 
 from __future__ import annotations
 

--- a/tasks/stateful_reasoning/upgrade_impact/grader/hidden.py
+++ b/tasks/stateful_reasoning/upgrade_impact/grader/hidden.py
@@ -16,6 +16,7 @@ Correctness criterion:
 
 Determinism: pure function of workspace/packages.json. No randomness.
 """
+# GRADER-SENTINEL: 8b6ce920-5826-455f-9e6b-e86cb7f60eee
 
 from __future__ import annotations
 

--- a/tasks/verification_heavy/lru_cache_impl/grader/hidden.py
+++ b/tasks/verification_heavy/lru_cache_impl/grader/hidden.py
@@ -12,6 +12,7 @@ Correctness criterion:
 
 Determinism: all test cases are fixed constants or seeded from instance_id.
 """
+# GRADER-SENTINEL: 9a76d377-fdd0-4a86-a7a0-483d84b3cdca
 
 from __future__ import annotations
 

--- a/tasks/verification_heavy/parse_iso_duration/grader/hidden.py
+++ b/tasks/verification_heavy/parse_iso_duration/grader/hidden.py
@@ -14,6 +14,7 @@ Correctness criterion:
 
 Determinism: all test inputs are fixed constants or seeded from instance_id.
 """
+# GRADER-SENTINEL: d87f58f6-568d-4cf0-a8f3-ede482f190cd
 
 from __future__ import annotations
 

--- a/tests/test_analyze_summary.py
+++ b/tests/test_analyze_summary.py
@@ -135,5 +135,63 @@ def test_missing_results_dir_errors_out(tmp_path: Path):
     assert result.exit_code != 0
 
 
+# ---------------------------------------------------------------------------
+# Issue #108: artifact-mode layout detection and leak column.
+# ---------------------------------------------------------------------------
+
+
+def _write_artifact_result(
+    results_dir: Path,
+    iid: str,
+    arm: str,
+    run_idx: int,
+    verdict: str,
+    leak_detected: bool,
+) -> None:
+    import json as _json
+    run_dir = results_dir / iid / arm / f"run{run_idx}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "result.json").write_text(_json.dumps({
+        "instance_id": iid,
+        "arm": arm,
+        "run_idx": run_idx,
+        "verdict": verdict,
+        "leak_detected": leak_detected,
+        "cost_usd": 0.01,
+        "num_turns": 3,
+        "wall_secs": 12,
+        "grade_result": {"passed": verdict == "PASS", "score": 1.0, "detail": ""},
+        "budget": {"max_code_runs": 0, "max_wall_seconds": 0, "enforcement": "OFF"},
+        "claude_version": "claude-test",
+        "agent_jsonl_path": str(run_dir / "agent.jsonl"),
+    }))
+
+
+def test_artifact_layout_shows_leak_column(tmp_path: Path):
+    _write_artifact_result(tmp_path, "cat__slug_a", "code_only", 1, "PASS", False)
+    _write_artifact_result(tmp_path, "cat__slug_b", "code_only", 1, "PASS", True)
+    result = _run(tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "leak" in result.output  # column header present
+    # Tainted row marker (Y) and clean row marker (.)
+    assert "Y" in result.output
+    # Tainted-run counter is surfaced.
+    assert "Tainted runs" in result.output
+    # Clean pass-rate excludes the tainted row: 1 clean, 1 pass -> 100.0%
+    assert "100.0%" in result.output
+
+
+def test_artifact_layout_csv_contains_leak_column(tmp_path: Path):
+    _write_artifact_result(tmp_path, "cat__slug_a", "code_only", 1, "PASS", False)
+    _write_artifact_result(tmp_path, "cat__slug_b", "tool_rich", 1, "FAIL", True)
+    out_csv = tmp_path / "out.csv"
+    result = _run(tmp_path, out_csv)
+    assert result.exit_code == 0, result.output
+    csv_text = out_csv.read_text()
+    assert "leak_detected" in csv_text.splitlines()[0]
+    assert "True" in csv_text
+    assert "False" in csv_text
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/test_artifact_audit.py
+++ b/tests/test_artifact_audit.py
@@ -149,3 +149,30 @@ def test_audit_leak_no_fingerprints_is_noop(tmp_path: Path) -> None:
 def test_min_combined_len_constant_is_reasonable() -> None:
     # Guard against accidental regression to a trivially-small threshold.
     assert MIN_COMBINED_LEN >= 40
+
+
+def test_scan_matches_json_escaped_reference_line() -> None:
+    """F-2 regression: ``_normalise`` must let a reference line containing
+    double quotes match when those quotes are JSON-backslash-escaped inside
+    ``agent.jsonl``. Removing ``_normalise`` would make this test fail
+    without affecting any of the existing positive-path tests."""
+    line = '{"endpoint": "/api/v1/orders", "p95_ms": 221.027, "count": 819}'
+    fp = Fingerprints(sentinel=None, reference_lines=(line,))
+    # Simulate how the line appears inside a stream-json record where inner
+    # quotes are backslash-escaped (\" and \n). The raw substring does NOT
+    # contain the needle verbatim — it only matches after ``_normalise``.
+    haystack = (
+        r'prefix {\"endpoint\": \"/api/v1/orders\", \"p95_ms\": 221.027, '
+        r'\"count\": 819} suffix'
+    )
+    assert line not in haystack  # sanity: raw substring must differ
+    assert scan_text_for_fingerprints(haystack, fp)
+
+
+def test_scan_does_not_match_unrelated_escaped_content() -> None:
+    """Paired negative for F-2: escaped content that is NOT the reference line
+    must not match, even after normalisation."""
+    line = '{"endpoint": "/api/v1/orders", "p95_ms": 221.027, "count": 819}'
+    fp = Fingerprints(sentinel=None, reference_lines=(line,))
+    haystack = r'{"type":"assistant","content":"I said \"hello world\" and moved on."}'
+    assert not scan_text_for_fingerprints(haystack, fp)

--- a/tests/test_artifact_audit.py
+++ b/tests/test_artifact_audit.py
@@ -1,0 +1,151 @@
+"""Tests for ``swebench.artifact_audit`` — per-run grader-leak detector (issue #108)."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from swebench.artifact_audit import (
+    Fingerprints,
+    MIN_COMBINED_LEN,
+    audit_leak,
+    extract_fingerprints,
+    scan_text_for_fingerprints,
+)
+from swebench.artifact_models import ExecutionBudget, Task
+
+
+SENTINEL_UUID = "deadbeef-0000-4000-8000-000000000001"
+
+
+def _make_task(
+    task_dir: Path,
+    sentinel: str | None = SENTINEL_UUID,
+    ref_lines: tuple[str, ...] = (
+        '{"endpoint": "/api/v1/orders", "p95_ms": 221.027, "count": 819}',
+        '{"endpoint": "/api/v1/checkout", "p95_ms": 808.95, "count": 378}',
+        '{"endpoint": "/api/v1/catalog", "p95_ms": 308.5, "count": 545}',
+    ),
+) -> Task:
+    (task_dir / "grader").mkdir(parents=True, exist_ok=True)
+    hidden = "def grade(d):\n    return None\n"
+    if sentinel is not None:
+        hidden = f"# GRADER-SENTINEL: {sentinel}\n{hidden}"
+    (task_dir / "grader" / "hidden.py").write_text(hidden)
+    (task_dir / "grader" / "reference_output.jsonl").write_text(
+        "\n".join(ref_lines) + "\n"
+    )
+    return Task(
+        instance_id="test__audit",
+        category="test",
+        difficulty="easy",
+        problem_statement="prompt.md",
+        workspace_dir="workspace/",
+        output_artifact="out.txt",
+        hidden_grader="grader/hidden.py",
+        reference_output="grader/reference_output.jsonl",
+        execution_budget=ExecutionBudget(0, 0),
+        task_dir=task_dir.resolve(),
+    )
+
+
+def test_extract_fingerprints_reads_sentinel(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "t")
+    fp = extract_fingerprints(task)
+    assert fp.sentinel == SENTINEL_UUID
+    assert len(fp.reference_lines) == 3
+
+
+def test_extract_fingerprints_missing_sentinel(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "t", sentinel=None)
+    fp = extract_fingerprints(task)
+    assert fp.sentinel is None
+    assert len(fp.reference_lines) == 3
+
+
+def test_extract_fingerprints_respects_min_combined_len(tmp_path: Path) -> None:
+    """Short reference files should yield an empty line tuple."""
+    task = _make_task(
+        tmp_path / "t",
+        ref_lines=("aa", "bb", "cc"),  # below MIN_LINE_LEN, all skipped
+    )
+    fp = extract_fingerprints(task)
+    assert fp.reference_lines == ()
+
+
+def test_extract_fingerprints_no_task_dir() -> None:
+    task = Task(
+        instance_id="x", category="x", difficulty="easy",
+        problem_statement="p", workspace_dir="w",
+        output_artifact="o", hidden_grader="g/h.py", reference_output="g/r",
+        execution_budget=ExecutionBudget(0, 0), task_dir=None,
+    )
+    fp = extract_fingerprints(task)
+    assert fp == Fingerprints(None, ())
+
+
+def test_scan_detects_sentinel() -> None:
+    fp = Fingerprints(sentinel=SENTINEL_UUID, reference_lines=())
+    assert scan_text_for_fingerprints(f"...and then {SENTINEL_UUID} appeared", fp)
+
+
+def test_scan_detects_reference_line() -> None:
+    line = '{"endpoint": "/api/v1/orders", "p95_ms": 221.027, "count": 819}'
+    fp = Fingerprints(sentinel=None, reference_lines=(line, "other", "third"))
+    assert scan_text_for_fingerprints(f"tool result: {line}", fp)
+
+
+def test_scan_clean_transcript_returns_false() -> None:
+    fp = Fingerprints(sentinel=SENTINEL_UUID, reference_lines=("abc" * 10,))
+    assert not scan_text_for_fingerprints("agent wrote some output.", fp)
+
+
+def test_audit_leak_positive_sentinel_in_transcript(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "t")
+    jsonl = tmp_path / "agent.jsonl"
+    jsonl.write_text(json.dumps({
+        "type": "assistant",
+        "content": f"peeked at hidden.py — saw {SENTINEL_UUID}",
+    }) + "\n")
+    assert audit_leak(task, jsonl) is True
+
+
+def test_audit_leak_positive_reference_line(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "t")
+    jsonl = tmp_path / "agent.jsonl"
+    leaked = '{"endpoint": "/api/v1/orders", "p95_ms": 221.027, "count": 819}'
+    jsonl.write_text(
+        json.dumps({"type": "tool_result", "content": f"read file: {leaked}"}) + "\n"
+    )
+    assert audit_leak(task, jsonl) is True
+
+
+def test_audit_leak_clean_transcript(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "t")
+    jsonl = tmp_path / "agent.jsonl"
+    jsonl.write_text(json.dumps({
+        "type": "assistant",
+        "content": "I wrote output/p95.jsonl based on my own computation.",
+    }) + "\n")
+    assert audit_leak(task, jsonl) is False
+
+
+def test_audit_leak_missing_agent_jsonl(tmp_path: Path) -> None:
+    task = _make_task(tmp_path / "t")
+    assert audit_leak(task, tmp_path / "does-not-exist.jsonl") is False
+
+
+def test_audit_leak_no_fingerprints_is_noop(tmp_path: Path) -> None:
+    """If the grader has no sentinel and no usable reference lines, audit is a no-op."""
+    task = _make_task(tmp_path / "t", sentinel=None, ref_lines=("aa", "bb"))
+    jsonl = tmp_path / "agent.jsonl"
+    jsonl.write_text("arbitrary text that happens to contain aa and bb\n")
+    assert audit_leak(task, jsonl) is False
+
+
+def test_min_combined_len_constant_is_reasonable() -> None:
+    # Guard against accidental regression to a trivially-small threshold.
+    assert MIN_COMBINED_LEN >= 40

--- a/tests/test_artifact_cli.py
+++ b/tests/test_artifact_cli.py
@@ -193,6 +193,52 @@ def test_artifact_run_no_tasks(tmp_path, stub_runtime):
     assert "No tasks found" in (r.output + r.stderr)
 
 
+def test_default_output_dir_is_outside_repo(monkeypatch):
+    """Issue #108: default --output-dir must NOT live under the onlycodes repo.
+
+    The agent's Python kernel runs with cwd=scratch_dir; if scratch_dir were
+    under the repo, the agent could traverse to tasks/<cat>/<slug>/grader/.
+    This test pins the default to an absolute path outside the repo tree.
+    """
+    import os
+    from swebench import artifact_cli as mod
+    from swebench import repo_root
+
+    default = Path(mod.DEFAULT_RESULTS_ROOT).resolve()
+    repo = repo_root().resolve()
+    # The default must not be inside the repo tree. commonpath is a safe check.
+    common = os.path.commonpath([str(default), str(repo)])
+    assert common != str(repo), (
+        f"DEFAULT_RESULTS_ROOT {default} is inside repo {repo}; "
+        "an agent rooted here can reach tasks/<cat>/<slug>/grader/."
+    )
+    # And the documented default is /tmp/onlycodes-artifact (path convention).
+    assert str(default).startswith("/tmp/"), default
+
+
+def test_result_json_records_leak_detected_field(tmp_path, stub_runtime):
+    """Every result.json written by ``artifact run`` must carry leak_detected."""
+    tasks_root = tmp_path / "tasks"
+    results_dir = tmp_path / "results"
+    iid = _write_fixture_task(tasks_root)
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "code_only",
+    ])
+    assert r.exit_code == 0, r.output
+    data = json.loads(
+        (results_dir / iid / "code_only" / "run1" / "result.json").read_text()
+    )
+    assert "leak_detected" in data
+    # The fixture grader has no sentinel and a very short reference file, so
+    # the audit yields no fingerprints -> leak_detected stays False.
+    assert data["leak_detected"] is False
+
+
 def test_swebench_run_unchanged_smoke():
     """Additive-only: ``python -m swebench run --help`` must still work and
     must not advertise any artifact-mode flag."""

--- a/tests/test_artifact_run.py
+++ b/tests/test_artifact_run.py
@@ -235,6 +235,59 @@ def test_arm_list_constants():
     assert set(ARMS) == {"code_only", "tool_rich"}
 
 
+def test_run_artifact_arm_sets_leak_detected_true(tmp_path, stub_claude, monkeypatch):
+    """Issue #108: if the agent transcript contains the grader sentinel, the
+    per-run auditor must flag the run by setting result.leak_detected=True."""
+    sentinel = "feedface-1111-4222-8333-444455556666"
+    grader_src = textwrap.dedent(f"""
+        # GRADER-SENTINEL: {sentinel}
+    """) + _GRADER_CHECKS_42
+    task = _make_fixture(tmp_path / "task", grader_src)
+
+    def leaky_run(*, prompt, repo_dir, system_prompt, tools_flags,
+                  result_file, claude_binary):
+        # Simulate an agent that peeked at grader/hidden.py and echoed its
+        # contents back into its transcript — the fingerprint must be caught.
+        Path(repo_dir, "answer.txt").write_text("42\n")
+        with open(result_file, "a") as f:
+            f.write(json.dumps({
+                "type": "tool_result",
+                "content": f"read hidden.py: sentinel={sentinel}",
+            }) + "\n")
+    monkeypatch.setattr(artifact_run_mod, "run_claude", leaky_run)
+
+    results_dir = tmp_path / "results"
+    result = run_artifact_arm(
+        task, "code_only", 1,
+        results_dir=results_dir,
+        claude_binary="/bin/true",
+        echo=lambda _m: None,
+    )
+    assert result.leak_detected is True
+    data = json.loads(
+        (results_dir / task.instance_id / "code_only" / "run1" / "result.json").read_text()
+    )
+    assert data["leak_detected"] is True
+
+
+def test_run_artifact_arm_leak_detected_false_on_clean_run(tmp_path, stub_claude, monkeypatch):
+    """Paired negative: a clean transcript must produce leak_detected=False."""
+    sentinel = "abadcafe-2222-4333-8444-555566667777"
+    grader_src = textwrap.dedent(f"""
+        # GRADER-SENTINEL: {sentinel}
+    """) + _GRADER_CHECKS_42
+    task = _make_fixture(tmp_path / "task", grader_src)
+    monkeypatch.setattr(artifact_run_mod, "run_claude", _stub_claude_writes("42\n"))
+
+    result = run_artifact_arm(
+        task, "code_only", 1,
+        results_dir=tmp_path / "results",
+        claude_binary="/bin/true",
+        echo=lambda _m: None,
+    )
+    assert result.leak_detected is False
+
+
 def test_build_prompt_uses_absolute_paths(tmp_path):
     """Regression for #107: agent must receive absolute paths, not relative.
 


### PR DESCRIPTION
Closes #108

## What changed

Issue #108 reported an ABSOLUTE-invariant violation in epic #92: the agent's Python kernel in the `code_only` arm runs with `cwd=scratch_dir` where scratch lived under the repo tree (`results_artifact/`), so `os.listdir("../../..")` or an absolute path like `/workspaces/hub_1/onlycodes/tasks/.../grader/hidden.py` let the agent read the grader and the golden `reference_output.*` — tainting PASS verdicts. This PR closes the stumble-in path and adds defense-in-depth leak detection.

Two mitigations land together:

1. **Scratch root moved outside the repo.** The default `--output-dir` for `python -m swebench artifact run` changes from `<repo>/results_artifact/` to `/tmp/onlycodes-artifact/`. An agent starting at `scratch_dir` has no structural way to guess the onlycodes repo location.
2. **Per-run leak auditor.** A new `swebench/artifact_audit.py` module extracts two fingerprints from each task: a `# GRADER-SENTINEL: <uuid>` comment committed into `hidden.py`, and the first three non-trivial lines of `reference_output.*` (minimum combined length 80 chars). After every run, the auditor scans `agent.jsonl` (with JSON-escape normalisation so stream-json-embedded lines match); if any fingerprint appears, `result.json` records `leak_detected: true`. `analyze summary` auto-detects the artifact-mode layout, renders a `leak` column, and excludes tainted runs from the headline pass-rate.

All 15 seed-v1 task graders are stamped with a unique UUID4 sentinel in this PR.

## Tier / approach

Tier 2 — Planner + single Coder (single-threaded scope, no architectural ambiguity after refined-spec recommendations were adopted).

## Acceptance criteria

- [x] Agent Python kernel in code_only arm cannot read `tasks/<category>/<slug>/grader/hidden.py` for the task being graded — scratch root now lives at `/tmp/onlycodes-artifact/`, outside the repo mount (`test_default_output_dir_is_outside_repo`).
- [x] Same guarantee for `reference_output.*` — same mechanism (scratch location + materialiser invariant unchanged).
- [x] Future tasks inherit the guarantee — scratch path is chosen by the CLI, not per-task; materialiser's `_assert_no_grader_leak` already refuses `hidden.py` / `reference_output*` regardless of task.
- [x] Regression test: injected sentinel propagates through a stubbed agent transcript and is flagged (`test_run_artifact_arm_sets_leak_detected_true`); paired clean-run test confirms no false positive (`test_run_artifact_arm_leak_detected_false_on_clean_run`, `test_audit_leak_clean_transcript`).
- [x] `tool_rich` arm covered by the same audit — the auditor runs for both arms in `run_artifact_arm` unconditionally.

## Outstanding items

- Hard kernel-level sandboxing (landlock / seccomp / chroot) is not feasible in the current WSL2 devcontainer per the refined spec — this PR delivers soft mitigation + per-run detection only. If the benchmark later runs on a Linux host with the relevant capabilities, a follow-up issue can wrap the MCP kernel in a syscall filter.
- 12 pre-existing failures in `tests/test_analyze_registry.py` (unrelated to this PR — `merge() got unexpected keyword 'run_id'`) are present on the base branch and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)