### PR TITLE
fix(#128): Expand artifact task set — prep PR (loader, schema, checklist, ladder relabel)

### DIFF
--- a/docs/SCHEMA_ARTIFACT.md
+++ b/docs/SCHEMA_ARTIFACT.md
@@ -67,7 +67,7 @@ tags: [aggregation, jsonl]
 |---|---|---|---|
 | `instance_id` | **required** | string | Globally unique, stable. Format: `<category>__<slug>` (two underscores). Must match `^[a-z][a-z0-9_]*__[a-z0-9_]+$`. Stable across re-grades — do not rename. If a task is replaced with a different problem shape, allocate a new `instance_id` instead of reusing. |
 | `category` | **required** | string | One of the six canonical categories: `data_processing`, `algorithmic`, `verification_heavy`, `enumeration`, `stateful_reasoning`, `iterative_numerical`. Must equal the `<category>` segment of `instance_id`. |
-| `difficulty` | **required** | string | One of: `easy`, `medium`. (`hard` is reserved for a future epic and MUST NOT be used in seed-v1.) |
+| `difficulty` | **required** | string | One of: `easy`, `medium`, `hard`. Author's self-assessment against `docs/TASK_REALISM_CHECKLIST.md`; the seed-v2 ladder targets 2 easy / 3 medium / 3 hard per category. |
 | `problem_statement` | **required** | string (relative path) | Path to the natural-language prompt shown to the agent. Convention: `prompt.md`. Resolved relative to the task directory. The file's entire contents are placed verbatim into the agent's problem prompt. |
 | `workspace_dir` | **required** | string (relative path) | Directory copied into the agent's scratch dir at run time. Convention: `workspace/`. May be empty (rare — e.g. pure-enumeration tasks that need no input files) but the field must still be declared. |
 | `output_artifact` | **required** | string (relative path) | Path, **relative to the scratch dir**, that the agent MUST write. The grader reads from `scratch_dir / output_artifact`. Parent directories are created by the agent, not pre-created by the harness. |

--- a/docs/TASK_REALISM_CHECKLIST.md
+++ b/docs/TASK_REALISM_CHECKLIST.md
@@ -1,0 +1,94 @@
+# Task Realism Checklist (v1)
+
+Self-applied by the author of every artifact-graded task in `problems/artifact/`. Created per issue #128.
+
+**Purpose.** The onlycodes benchmark contrasts a tool-restricted Claude arm against a tool-rich one on work a practitioner would actually recognize. Tasks engineered to stress or favor a particular arm are explicitly out of scope. A task is "realistic" when it looks like something a working data engineer, ML engineer, or research programmer would receive as a ticket, memo, or DM — not a textbook exercise.
+
+## How to use this document
+
+When authoring a new task:
+
+1. Work through every checkbox below. Each one is binary — if you cannot answer "yes" outright, the item is a "no".
+2. Fix any "no" item before opening a PR. If you cannot fix it (e.g. the problem genuinely needs a banned library), either reshape the task or drop it.
+3. Record compliance in `task.yaml` by adding the tag `realism_checklist_v1` to the `tags:` list. This tag is the on-disk evidence that the author self-certified against this checklist. See `swebench/artifact_loader.py` — the loader does not enforce the tag, but CI/review tooling may.
+4. Keep this document versioned. If the criteria change materially, bump the version (`realism_checklist_v2`) rather than mutating v1 in place.
+
+## v1 criteria
+
+### Libraries
+
+- [ ] The agent-facing code paths (the problem as stated, any hints, and any `structural_verifier`) use only: `pandas`, `numpy`, `scikit-learn`, `scipy`, or the Python standard library.
+- [ ] The `workspace_generator.py` script (if present) imports from the Python standard library only. **No pandas, no numpy, no sklearn, no scipy in generators** — the materialize env is deliberately scrubbed (see SCHEMA §5.1).
+- [ ] No `matplotlib`, `seaborn`, `plotly`, `bokeh`, `altair`, or any other visualization library is imported anywhere under the task directory.
+- [ ] No `networkx`, `polars`, `dask`, `pyarrow`-standalone, `duckdb`, `torch`, `tensorflow`, `jax`, `xgboost`, `lightgbm`, or similar heavyweight libraries.
+- [ ] No `requests`, `urllib`, `httpx`, `socket`, or any other network I/O — tasks run fully offline.
+- [ ] No GPU-dependent code paths.
+
+### Problem framing
+
+- [ ] The `prompt.md` reads like a ticket, memo, Slack message, or email a working practitioner would plausibly receive. It states the business question, not a math problem.
+- [ ] Variable names, column names, and file names match domain conventions a practitioner would use (e.g. `order_id`, `event_ts`, `churn_label`, `p95_latency_ms`). No `foo`, `bar`, `x`, `y` in the problem-facing surface.
+- [ ] The success criterion is something a practitioner would actually care about — a correct number, a correct prediction, a correct aggregate, a correct transform — not trivia.
+
+### Data shape
+
+- [ ] If the task includes tabular data, the schema is non-trivial (multi-column DataFrame, multi-file layout, mixed dtypes, or realistic skew).
+- [ ] If the task includes array data, the shape resembles real measurements (time series, image-like grid, feature matrix), not a toy vector.
+- [ ] Input data volume is bounded: total workspace size ≤ 50 MB, row count ≤ 1M per file. (SCHEMA §8.)
+- [ ] Individual files ≤ 10 MB. (SCHEMA §8.)
+
+### Execution envelope
+
+- [ ] A competent practitioner could complete the task in ≤ 30 minutes of wall time on the harness venv. (Reference solution should typically run in seconds.)
+- [ ] The task does not require more than 50 `execute_code` invocations on the happy path. (Declared as `max_code_runs: 0` / unlimited per SCHEMA §2.3 — enforcement is off — but design within this envelope anyway.)
+
+### Grader
+
+- [ ] `grader/hidden.py:grade()` is deterministic. Given the same `scratch_dir`, it always returns the same `GradeResult`.
+- [ ] The grader is offline — no network, no external files outside `scratch_dir` and the task's own `grader/` directory.
+- [ ] The grader does not write to `scratch_dir`.
+- [ ] The grader's pass/fail decision checks behavior a practitioner would actually care about, not trivia (e.g. field presence, numeric tolerance, ordering invariants — not exact float equality where floating-point drift is expected).
+- [ ] The grader handles malformed-output cases gracefully (missing file, bad JSON, wrong shape) and returns `passed=False` with a useful `detail` — it does not crash the harness.
+- [ ] `reference_output.*` is a known-good artifact that grades `passed=True, score=1.0`. (Enforced by `tests/test_verify_graders.py`.)
+
+### Arm neutrality
+
+- [ ] The task does NOT require reading many files via filesystem tools (would favor the tool-rich arm).
+- [ ] The task does NOT require many small code-execution steps (would favor the code-only arm).
+- [ ] The task is solvable by either arm with only a modest efficiency difference attributable to tool availability, not task design.
+- [ ] The problem statement makes no reference to specific tools the agent should or should not use.
+
+### No-leak invariant
+
+- [ ] `grader/hidden.py` is **not** placed under `workspace/` — it lives only in `grader/` and is never copied into the agent's scratch dir.
+- [ ] `reference_output.*` is **not** placed under `workspace/` — it lives only in `grader/`.
+- [ ] If a `workspace_generator.py` is used, it is placed under `workspace/` (so the harness can exclude it from the scratch copy) — not under `grader/`.
+
+### Difficulty ladder
+
+- [ ] The author has placed this task on the `easy` / `medium` / `hard` ladder per an honest assessment of the effort a practitioner would spend. Rule of thumb:
+  - **easy** — a practitioner solves it in ≤ 5 minutes of focused work, mostly straight-line code.
+  - **medium** — 5–15 minutes, involves at least one decision (algorithm choice, library function selection, correctness check).
+  - **hard** — 15–30 minutes, involves multi-step reasoning, non-obvious edge cases, or composing several capabilities.
+
+### Category fit
+
+- [ ] The task's primary work matches its declared `category`:
+  - `data_processing` — pandas / numpy / tabular ingestion, transformation, aggregation.
+  - `algorithmic` — combinatorial optimization, graph work, scheduling.
+  - `verification_heavy` — correctness-critical parsing, stateful machines, subtle invariants.
+  - `enumeration` — exhaustive search under a constraint.
+  - `stateful_reasoning` — event streams, sequential state, replay.
+  - `iterative_numerical` — root-finding, fitting, optimization, hyperparameter search.
+
+## Compliance marker
+
+When every box above is checked, add `realism_checklist_v1` to `task.yaml:tags`:
+
+```yaml
+tags:
+  - <existing tags...>
+  - realism_checklist_v1
+```
+
+This marker is versioned — if the criteria here change materially, bump to `realism_checklist_v2` so older tasks are clearly still certified against v1.

--- a/problems/artifact/data_processing/multi_file_cohort/task.yaml
+++ b/problems/artifact/data_processing/multi_file_cohort/task.yaml
@@ -1,6 +1,6 @@
 instance_id: data_processing__multi_file_cohort
 category: data_processing
-difficulty: medium
+difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 workspace_generator: workspace/generator.py

--- a/problems/artifact/iterative_numerical/bisection_calibration/task.yaml
+++ b/problems/artifact/iterative_numerical/bisection_calibration/task.yaml
@@ -1,6 +1,6 @@
 instance_id: iterative_numerical__bisection_calibration
 category: iterative_numerical
-difficulty: easy
+difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/result.json

--- a/problems/artifact/iterative_numerical/hparam_search/task.yaml
+++ b/problems/artifact/iterative_numerical/hparam_search/task.yaml
@@ -1,6 +1,6 @@
 instance_id: iterative_numerical__hparam_search
 category: iterative_numerical
-difficulty: medium
+difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/result.json

--- a/problems/artifact/stateful_reasoning/event_ledger/task.yaml
+++ b/problems/artifact/stateful_reasoning/event_ledger/task.yaml
@@ -1,6 +1,6 @@
 instance_id: stateful_reasoning__event_ledger
 category: stateful_reasoning
-difficulty: medium
+difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 workspace_generator: workspace/generator.py

--- a/problems/artifact/stateful_reasoning/unreachable_functions/task.yaml
+++ b/problems/artifact/stateful_reasoning/unreachable_functions/task.yaml
@@ -1,6 +1,6 @@
 instance_id: stateful_reasoning__unreachable_functions
 category: stateful_reasoning
-difficulty: easy
+difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/unreachable.jsonl

--- a/sets/seed-v1.txt
+++ b/sets/seed-v1.txt
@@ -1,9 +1,13 @@
-# Curated artifact task set — seed-v1.
+# Curated artifact task set — seed-v1 (frozen at 15 tasks).
 # One instance_id per line. Blank lines and # comments are ignored.
-# Append-only: this file is populated by the seed-task slices (#95 onward).
+#
+# This set is the historical 15-task reference used by epics #95-#127. It is
+# frozen — do not add or remove tasks. For the expanded 48-task ladder, see
+# sets/seed-v2.txt (issue #128 onward).
 
 data_processing__p95_latency_easy
 data_processing__regression_detection
+data_processing__multi_file_cohort
 algorithmic__makespan_scheduling
 algorithmic__min_cost_assignment
 verification_heavy__parse_iso_duration
@@ -12,10 +16,7 @@ enumeration__latin_squares_3
 enumeration__graphs_chromatic_3
 stateful_reasoning__unreachable_functions
 stateful_reasoning__upgrade_impact
+stateful_reasoning__event_ledger
 iterative_numerical__exp_decay_fit
 iterative_numerical__hparam_search
-
-# Arm-gate signal tasks (B/C stress)
-data_processing__multi_file_cohort
-stateful_reasoning__event_ledger
 iterative_numerical__bisection_calibration

--- a/sets/seed-v2.txt
+++ b/sets/seed-v2.txt
@@ -1,0 +1,42 @@
+# Curated artifact task set — seed-v2.
+# One instance_id per line. Blank lines and # comments are ignored.
+#
+# Target: 48 tasks total (8 per category, graded 2 easy / 3 medium / 3 hard).
+# Current status: bootstrapped with the 15 seed-v1 tasks retro-labeled onto
+# the ladder (issue #128). Category-expansion PRs (#128 follow-ups) will
+# append the remaining ~33 tasks to reach 48.
+#
+# Per-category counts as of seed-v2 bootstrap:
+#   algorithmic:         1 easy / 1 medium / 0 hard  (target 2/3/3)
+#   data_processing:     1 easy / 1 medium / 1 hard  (target 2/3/3)
+#   enumeration:         1 easy / 1 medium / 0 hard  (target 2/3/3)
+#   iterative_numerical: 1 easy / 1 medium / 1 hard  (target 2/3/3)
+#   stateful_reasoning:  0 easy / 2 medium / 1 hard  (target 2/3/3)
+#   verification_heavy:  1 easy / 1 medium / 0 hard  (target 2/3/3)
+
+# algorithmic
+algorithmic__makespan_scheduling
+algorithmic__min_cost_assignment
+
+# data_processing
+data_processing__p95_latency_easy
+data_processing__regression_detection
+data_processing__multi_file_cohort
+
+# enumeration
+enumeration__latin_squares_3
+enumeration__graphs_chromatic_3
+
+# iterative_numerical
+iterative_numerical__exp_decay_fit
+iterative_numerical__hparam_search
+iterative_numerical__bisection_calibration
+
+# stateful_reasoning
+stateful_reasoning__unreachable_functions
+stateful_reasoning__upgrade_impact
+stateful_reasoning__event_ledger
+
+# verification_heavy
+verification_heavy__parse_iso_duration
+verification_heavy__lru_cache_impl

--- a/swebench/artifact_loader.py
+++ b/swebench/artifact_loader.py
@@ -28,7 +28,7 @@ _CATEGORIES = frozenset({
     "test_fixture",
 })
 
-_DIFFICULTIES = frozenset({"easy", "medium"})
+_DIFFICULTIES = frozenset({"easy", "medium", "hard"})
 
 _REQUIRED_FIELDS = frozenset({
     "instance_id",

--- a/tests/test_artifact_loader.py
+++ b/tests/test_artifact_loader.py
@@ -136,13 +136,28 @@ def test_unknown_category_rejected(tmp_path: Path) -> None:
         load_tasks(tasks_dir)
 
 
-def test_invalid_difficulty_rejected(tmp_path: Path) -> None:
+def test_hard_difficulty_accepted(tmp_path: Path) -> None:
+    """Issue #128: `hard` is admitted to the difficulty whitelist."""
     tasks_dir = tmp_path / "tasks"
     _write_task(
         tasks_dir,
         "data_processing",
-        "hard_forbidden",
+        "hard_task",
         overrides={"difficulty": "hard"},
+    )
+    tasks = load_tasks(tasks_dir)
+    assert len(tasks) == 1
+    assert tasks[0].difficulty == "hard"
+
+
+def test_invalid_difficulty_rejected(tmp_path: Path) -> None:
+    """Any value outside {easy, medium, hard} is still rejected."""
+    tasks_dir = tmp_path / "tasks"
+    _write_task(
+        tasks_dir,
+        "data_processing",
+        "impossible_difficulty",
+        overrides={"difficulty": "impossible"},
     )
     with pytest.raises(ValueError, match="difficulty must be"):
         load_tasks(tasks_dir)


### PR DESCRIPTION
Closes #128 (prep scope; category expansion tracked by follow-ups #130–#135)

## What changed

This PR lands the **prep scope** for issue #128 (expand the artifact benchmark from 15 to 48 tasks). Per the approved ADR (Decision 8, Option A), authoring the 33 new tasks is deferred to six category-expansion follow-ups (#130–#135). This PR delivers the infrastructure those follow-ups need.

- Widened the difficulty whitelist to admit `hard`: `swebench/artifact_loader.py` and `docs/SCHEMA_ARTIFACT.md:70`. The schema doc no longer claims `hard` is reserved for a future epic.
- Retro-labeled all 15 existing `task.yaml` files onto the final 2 easy / 3 medium / 3 hard ladder, using an honest assessment against the realism checklist rule-of-thumb (≤5min / 5–15min / 15–30min). Five tasks moved to new positions (`multi_file_cohort`, `bisection_calibration`, `hparam_search`, `event_ledger`, `unreachable_functions`).
- Authored `docs/TASK_REALISM_CHECKLIST.md` (v1) — binary criteria every new artifact task must self-certify against. Compliance is recorded on disk via a `realism_checklist_v1` tag in `task.yaml:tags`.
- Cut `sets/seed-v2.txt` as the canonical forward set with a target of 48 tasks. Bootstrapped with the 15 existing tasks, with a per-category-slot ledger in a header comment so follow-up PRs know exactly which ladder slots they are filling.
- Froze `sets/seed-v1.txt` at the historical 15-task reference. Removed the retired "Arm-gate B/C stress" comment framing per Decision 6; the three previously-segregated tasks (`multi_file_cohort`, `event_ledger`, `bisection_calibration`) now sit in their natural category order.
- Updated `tests/test_artifact_loader.py`: flipped the "hard rejected" test to "hard accepted" with a positive assertion, and added a replacement negative test (`difficulty: "impossible"`) so the rejection path stays covered.
- Filed six follow-up issues (#130–#135), one per category, each scoped to add 5–6 new tasks to bring that category to 8 (2/3/3).

## Implementation walkthrough

### Difficulty whitelist

`_DIFFICULTIES` in `swebench/artifact_loader.py:31` was a `frozenset({"easy", "medium"})`. It now includes `"hard"`. The loader's `_parse_task_yaml` validates the `difficulty` field against this set and raises `ValueError` with a readable message on miss — that error path is still tested.

### Ladder placement (existing 15)

| Task | Old | New | Why moved |
|---|---|---|---|
| `data_processing__multi_file_cohort` | medium | hard | multi-file join + per-customer aggregation + tiebreak ordering — 15–30min work |
| `iterative_numerical__bisection_calibration` | easy | medium | bisection over a calibration curve is not straight-line; requires a convergence decision |
| `iterative_numerical__hparam_search` | medium | hard | sklearn pipeline + CV + search loop — composes several capabilities |
| `stateful_reasoning__event_ledger` | medium | hard | stream replay with reconciliation invariants |
| `stateful_reasoning__unreachable_functions` | easy | medium | static reachability analysis — at least one algorithmic decision |

The remaining 10 tasks kept their original labels. None of the task content was modified — only the `difficulty:` field.

### Seed set split

`seed-v1` and `seed-v2` now serve different purposes. `seed-v1` is frozen at 15 tasks so historical epics (#95–#127) can still reference a stable corpus. `seed-v2` is the forward-looking 48-task target; when follow-ups land, they append to `seed-v2` in the correct `# <category>` block. The header comment in `seed-v2.txt` carries a per-category ladder ledger so follow-up authors see at a glance which slots they are filling.

### Realism checklist

`docs/TASK_REALISM_CHECKLIST.md` is structured as seven sections of binary checkboxes (libraries, problem framing, data shape, execution envelope, grader, arm neutrality, no-leak, difficulty, category fit). The compliance marker is a single tag (`realism_checklist_v1`) rather than a new schema field — this keeps `task.yaml` schema stable (Out-of-scope item #2 from the refined spec). The checklist is versioned; material changes will bump to v2 rather than mutating v1 in place.

### What was intentionally not changed

- No `task.yaml` schema fields added or removed (out of scope per ADR and refined spec).
- No grader, generator, verifier, or grader-runner code modified for any of the 15 existing tasks (out of scope — "relabel difficulty only").
- No `instance_id` renamed, including `data_processing__p95_latency_easy` whose `__easy` suffix is now redundant with the retro-label (SCHEMA §6.2: stable across re-grades).
- The `artifact verify` CLI remains a placeholder (that wiring is a separate future child issue).
- No changes to `artifact_models.py` — `difficulty: str` already accepted `hard` freely; only the loader's whitelist was the gate.

## Tier / approach

Tier 3 — Planner → Architect (ADR gate, 8 decisions user-approved) → single implementation pass (low file count made parallel Coders unnecessary once scope was narrowed to prep-only) → self-review → follow-up issues filed.

## Acceptance criteria (prep-PR scope)

- [x] `_DIFFICULTIES` in `artifact_loader.py` includes `"hard"`.
- [x] `docs/SCHEMA_ARTIFACT.md:70` updated — `hard` no longer "reserved".
- [x] `tests/test_artifact_loader.py` passes with `hard` accepted; positive and negative cases both present.
- [x] All 15 existing tasks carry their final `difficulty` label per the ladder.
- [x] `docs/TASK_REALISM_CHECKLIST.md` exists with the binary criteria from Scenario 4.
- [x] `sets/seed-v2.txt` exists listing the 15 current `instance_id`s under per-category blocks.
- [x] `sets/seed-v1.txt` retained; the "arm-gate B/C stress" comment block removed.
- [x] `pytest tests/test_artifact_loader.py tests/test_verify_graders.py` passes (21 passed).
- [x] Six follow-up issues filed on GitHub (#130 algorithmic, #131 data_processing, #132 enumeration, #133 iterative_numerical, #134 stateful_reasoning, #135 verification_heavy).

## Outstanding items

None for this PR. The 33 new tasks themselves are deferred to #130–#135 per Decision 8.

Note: `tests/test_analyze_registry.py` has 12 pre-existing failures on `main` unrelated to this change; confirmed present without this branch applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)