### PR TITLE
fix(#135): expand verification_heavy artifact tasks to 8 (2/3/3)

### DIFF
--- a/problems/artifact/verification_heavy/cron_next_fire/grader/hidden.py
+++ b/problems/artifact/verification_heavy/cron_next_fire/grader/hidden.py
@@ -1,0 +1,92 @@
+"""Hidden grader for verification_heavy__cron_next_fire.
+
+Correctness: next_fire(expr, after) returns the exact expected datetime.
+Tests cover common schedules, step values, restricted DOM+DOW OR semantics,
+month/year rollovers, and leap-year handling.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import traceback
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    passed: bool
+    score: float
+    detail: str
+
+
+OUTPUT_REL = "output/solution.py"
+
+
+def _import_module(solution_path: Path):
+    spec = importlib.util.spec_from_file_location("agent_solution", solution_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# (expr, after, expected)
+_TESTS: list[tuple[str, datetime, datetime]] = [
+    ("* * * * *",       datetime(2024, 1, 1, 12, 0),  datetime(2024, 1, 1, 12, 1)),
+    ("0 * * * *",       datetime(2024, 1, 1, 12, 0),  datetime(2024, 1, 1, 13, 0)),
+    ("0 0 * * *",       datetime(2024, 1, 1, 12, 0),  datetime(2024, 1, 2, 0, 0)),
+    ("30 14 * * *",     datetime(2024, 1, 1, 12, 0),  datetime(2024, 1, 1, 14, 30)),
+    ("30 14 * * *",     datetime(2024, 1, 1, 15, 0),  datetime(2024, 1, 2, 14, 30)),
+    ("0 0 1 * *",       datetime(2024, 1, 1, 12, 0),  datetime(2024, 2, 1, 0, 0)),
+    ("*/15 * * * *",    datetime(2024, 1, 1, 12, 0),  datetime(2024, 1, 1, 12, 15)),
+    ("*/15 * * * *",    datetime(2024, 1, 1, 12, 14), datetime(2024, 1, 1, 12, 15)),
+    ("0/20 * * * *",    datetime(2024, 1, 1, 12, 0),  datetime(2024, 1, 1, 12, 20)),
+    ("0 9-17 * * 1-5",  datetime(2024, 1, 1, 12, 0),  datetime(2024, 1, 1, 13, 0)),  # Mon 13:00
+    ("0 9-17 * * 1-5",  datetime(2024, 1, 5, 17, 0),  datetime(2024, 1, 8, 9, 0)),   # Fri->Mon
+    ("0 0 29 2 *",      datetime(2023, 3, 1, 0, 0),   datetime(2024, 2, 29, 0, 0)),  # leap
+    ("0 0 29 2 *",      datetime(2024, 3, 1, 0, 0),   datetime(2028, 2, 29, 0, 0)),  # next leap
+    ("15,45 * * * *",   datetime(2024, 1, 1, 12, 20), datetime(2024, 1, 1, 12, 45)),
+    ("15,45 * * * *",   datetime(2024, 1, 1, 12, 45), datetime(2024, 1, 1, 13, 15)),
+    ("0 0 1 1 *",       datetime(2024, 6, 1, 0, 0),   datetime(2025, 1, 1, 0, 0)),
+    ("0 0 * * 0",       datetime(2024, 1, 1, 0, 0),   datetime(2024, 1, 7, 0, 0)),   # Sunday
+    ("0 0 15 * 1",      datetime(2024, 1, 1, 0, 0),   datetime(2024, 1, 8, 0, 0)),   # 15th OR Monday; Jan 8 2024 = Mon
+    ("30 */6 * * *",    datetime(2024, 1, 1, 0, 0),   datetime(2024, 1, 1, 0, 30)),
+    ("30 */6 * * *",    datetime(2024, 1, 1, 0, 30),  datetime(2024, 1, 1, 6, 30)),
+]
+
+
+def grade(scratch_dir: Path) -> GradeResult:
+    scratch_dir = Path(scratch_dir).resolve()
+    solution_path = scratch_dir / OUTPUT_REL
+
+    if not solution_path.is_file():
+        return GradeResult(False, 0.0, "output artifact not produced (output/solution.py missing)")
+
+    try:
+        mod = _import_module(solution_path)
+    except Exception as exc:
+        tb = traceback.format_exc()
+        return GradeResult(False, 0.0, f"failed to import solution.py: {exc}\n{tb[:400]}")
+
+    if not hasattr(mod, "next_fire"):
+        return GradeResult(False, 0.0, "solution.py does not define 'next_fire'")
+
+    fn = mod.next_fire
+    failures: list[str] = []
+    for expr, after, expected in _TESTS:
+        try:
+            got = fn(expr, after)
+        except Exception as exc:
+            failures.append(f"  next_fire({expr!r}, {after}): raised {type(exc).__name__}: {exc}")
+            continue
+        if not isinstance(got, datetime):
+            failures.append(f"  next_fire({expr!r}, {after}): expected datetime, got {type(got).__name__}")
+        elif got != expected:
+            failures.append(f"  next_fire({expr!r}, {after}): expected {expected}, got {got}")
+
+    n_pass = len(_TESTS) - len(failures)
+    if failures:
+        detail = f"{n_pass}/{len(_TESTS)} cases passed. Failures:\n" + "\n".join(failures)
+        return GradeResult(False, round(n_pass / len(_TESTS), 4), detail)
+    return GradeResult(True, 1.0, f"all {len(_TESTS)} cases passed")

--- a/problems/artifact/verification_heavy/cron_next_fire/grader/reference_output.py
+++ b/problems/artifact/verification_heavy/cron_next_fire/grader/reference_output.py
@@ -1,0 +1,119 @@
+"""Reference next_fire() for verification_heavy__cron_next_fire.
+
+Implements a minute-by-minute cron schedule resolver by expanding each of the
+five fields to an explicit set of legal values and walking the minute axis
+forward from `after + 1 minute`. Worst-case lookahead is 4 years.
+
+Vixie-cron DOM/DOW OR semantics:
+  - If BOTH fields are restricted (not '*'), fire if either matches.
+  - If ONE is '*' and the other is restricted, only the restricted one applies.
+"""
+
+from datetime import datetime, timedelta
+
+
+_RANGES = {
+    "minute":       (0, 59),
+    "hour":         (0, 23),
+    "day_of_month": (1, 31),
+    "month":        (1, 12),
+    "day_of_week":  (0, 6),
+}
+
+
+def _parse_field(field: str, lo: int, hi: int) -> tuple[set[int], bool]:
+    """Return (values, is_star)."""
+    if field == "*":
+        return set(range(lo, hi + 1)), True
+
+    values: set[int] = set()
+    for chunk in field.split(","):
+        step = 1
+        if "/" in chunk:
+            base, step_s = chunk.split("/", 1)
+            step = int(step_s)
+        else:
+            base = chunk
+
+        if base == "*":
+            start, end = lo, hi
+        elif "-" in base:
+            a_s, b_s = base.split("-", 1)
+            start, end = int(a_s), int(b_s)
+        else:
+            start = int(base)
+            # With a step and a single base (e.g. "0/20"), treat it as
+            # "start at base, step upward to field max".
+            end = hi if step != 1 else start
+
+        for v in range(start, end + 1, step):
+            values.add(v)
+
+    return values, False
+
+
+def next_fire(expr: str, after: datetime) -> datetime:
+    parts = expr.split()
+    if len(parts) != 5:
+        raise ValueError(f"cron expression must have 5 fields, got {len(parts)}: {expr!r}")
+
+    min_vals, _ = _parse_field(parts[0], *_RANGES["minute"])
+    hr_vals, _  = _parse_field(parts[1], *_RANGES["hour"])
+    dom_vals, dom_star = _parse_field(parts[2], *_RANGES["day_of_month"])
+    mon_vals, _ = _parse_field(parts[3], *_RANGES["month"])
+    dow_vals, dow_star = _parse_field(parts[4], *_RANGES["day_of_week"])
+
+    # Walk minute by minute from the next minute after `after`.
+    candidate = (after + timedelta(minutes=1)).replace(second=0, microsecond=0)
+    # Cap lookahead: 4 years of minutes.
+    horizon = candidate + timedelta(days=366 * 4)
+
+    while candidate <= horizon:
+        if candidate.month not in mon_vals:
+            # Fast-forward to 1st of next legal month
+            m = candidate.month + 1
+            y = candidate.year
+            while True:
+                if m > 12:
+                    m = 1
+                    y += 1
+                if m in mon_vals:
+                    break
+                m += 1
+            candidate = datetime(y, m, 1, 0, 0)
+            continue
+
+        # Day match (Vixie-cron OR semantics)
+        # Python weekday(): Monday=0..Sunday=6. Cron: Sunday=0..Saturday=6.
+        cron_dow = (candidate.weekday() + 1) % 7
+        dom_match = candidate.day in dom_vals
+        dow_match = cron_dow in dow_vals
+
+        if dom_star and dow_star:
+            day_ok = True
+        elif dom_star and not dow_star:
+            day_ok = dow_match
+        elif dow_star and not dom_star:
+            day_ok = dom_match
+        else:
+            day_ok = dom_match or dow_match
+
+        if not day_ok:
+            # Advance to next day at 00:00
+            next_day = candidate.replace(hour=0, minute=0) + timedelta(days=1)
+            candidate = next_day
+            continue
+
+        if candidate.hour not in hr_vals:
+            # Advance to next hour :00
+            next_hr = candidate.replace(minute=0) + timedelta(hours=1)
+            candidate = next_hr
+            continue
+
+        if candidate.minute not in min_vals:
+            candidate = candidate + timedelta(minutes=1)
+            continue
+
+        return candidate
+
+    raise ValueError(f"no cron match within 4 years for {expr!r} after {after!r}")

--- a/problems/artifact/verification_heavy/cron_next_fire/prompt.md
+++ b/problems/artifact/verification_heavy/cron_next_fire/prompt.md
@@ -1,0 +1,90 @@
+# Task: Compute the next cron fire time
+
+Our job scheduler currently uses a third-party cron library that is abandoned
+and flaky around DST transitions. Before we replace it, we need a small,
+well-tested reference implementation of "given a cron expression and a
+reference instant, what is the next instant the job would fire?"
+
+Implement `next_fire(expr: str, after: datetime) -> datetime`. The returned
+datetime must be **strictly after** `after` (equal is not a match) and must
+be the earliest matching instant.
+
+## Cron expression format
+
+Five space-separated fields, in order:
+
+```
+minute hour day-of-month month day-of-week
+```
+
+Each field supports:
+
+- `*` — any value in the field's range.
+- A single integer — exact match.
+- A comma-separated list, e.g. `1,5,30`.
+- A range `a-b`, inclusive.
+- A step `*/n`, `a-b/n`, or `a/n` — match every `n`th value starting from `a`
+  (or from the field's minimum if the base is `*`). With a single start value
+  `a/n`, the step runs from `a` up to the field's maximum (e.g. in the
+  minute field, `0/20` ≡ `0,20,40`).
+
+Field ranges:
+
+| Field | Range |
+|-------|-------|
+| minute | 0–59 |
+| hour | 0–23 |
+| day-of-month | 1–31 |
+| month | 1–12 |
+| day-of-week | 0–6 (0 = Sunday) |
+
+### Day-of-month / day-of-week combination
+
+If **both** day-of-month and day-of-week are restricted (not `*`), the schedule
+fires when **either** one matches — classic Vixie-cron "OR" semantics. If one
+is `*` and the other is restricted, only the restricted one applies.
+
+### Other rules
+
+- Seconds are always treated as 0. Returned datetimes have `second=0,
+  microsecond=0`.
+- Inputs are naive datetimes (no tzinfo). No DST handling needed.
+- Invalid month/day combinations (e.g. Feb 30) are simply skipped — the
+  function looks for the next valid combination.
+- You may assume cron expressions are syntactically valid; do not do error
+  handling.
+- Worst-case lookahead is 4 years; fail-safe by raising `ValueError` if no
+  match is found within that window.
+
+## Examples
+
+Given `after = datetime(2024, 1, 1, 12, 0, 0)`:
+
+| Expression | Meaning | Next fire |
+|------------|---------|-----------|
+| `* * * * *` | every minute | `2024-01-01 12:01:00` |
+| `0 * * * *` | top of every hour | `2024-01-01 13:00:00` |
+| `0 0 * * *` | daily midnight | `2024-01-02 00:00:00` |
+| `30 14 * * *` | 14:30 daily | `2024-01-01 14:30:00` |
+| `0 0 1 * *` | 1st of month | `2024-02-01 00:00:00` |
+| `*/15 * * * *` | every 15 min | `2024-01-01 12:15:00` |
+| `0 9-17 * * 1-5` | hourly 9–17 M–F | `2024-01-01 13:00:00` |
+
+## Output
+
+Write your implementation to `output/solution.py`:
+
+```python
+from datetime import datetime
+
+def next_fire(expr: str, after: datetime) -> datetime:
+    ...
+```
+
+Standard library only (`datetime`, `calendar`, etc. are fine). No `croniter`
+or other third-party packages.
+
+## Verification
+
+Run `python verify.py` to check structural shape. The hidden grader runs 20
+fixed cases including month rollovers, leap years, and step values.

--- a/problems/artifact/verification_heavy/cron_next_fire/task.yaml
+++ b/problems/artifact/verification_heavy/cron_next_fire/task.yaml
@@ -1,0 +1,18 @@
+instance_id: verification_heavy__cron_next_fire
+category: verification_heavy
+difficulty: hard
+problem_statement: prompt.md
+workspace_dir: workspace/
+output_artifact: output/solution.py
+hidden_grader: grader/hidden.py
+reference_output: grader/reference_output.py
+execution_budget:
+  max_code_runs: 15
+  max_wall_seconds: 180
+tags:
+  - verification_heavy
+  - cron
+  - scheduling
+  - datetime
+  - python
+  - realism_checklist_v1

--- a/problems/artifact/verification_heavy/cron_next_fire/workspace/verify.py
+++ b/problems/artifact/verification_heavy/cron_next_fire/workspace/verify.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Structural verifier for verification_heavy__cron_next_fire."""
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+
+OUTPUT = Path(__file__).parent / "output" / "solution.py"
+
+
+def main() -> int:
+    if not OUTPUT.is_file():
+        print(f"FAIL: output/solution.py not found at {OUTPUT}", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("agent_solution", OUTPUT)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"FAIL: could not import solution.py: {exc}", file=sys.stderr)
+        return 1
+
+    if not hasattr(mod, "next_fire") or not callable(mod.next_fire):
+        print("FAIL: solution.py does not define callable 'next_fire'", file=sys.stderr)
+        return 1
+
+    try:
+        r = mod.next_fire("* * * * *", datetime(2024, 1, 1, 12, 0))
+        if not isinstance(r, datetime):
+            print(f"WARN: next_fire returned {type(r).__name__}, expected datetime")
+    except Exception as exc:
+        print(f"WARN: next_fire raised {type(exc).__name__}: {exc}")
+
+    print("OK: solution.py imports and defines 'next_fire'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/problems/artifact/verification_heavy/csv_dialect_parser/grader/hidden.py
+++ b/problems/artifact/verification_heavy/csv_dialect_parser/grader/hidden.py
@@ -1,0 +1,97 @@
+"""Hidden grader for verification_heavy__csv_dialect_parser.
+
+Contract: ``grade(scratch_dir: Path) -> GradeResult``. See docs/SCHEMA_ARTIFACT.md §3.
+
+Correctness criterion:
+
+    The agent's output/solution.py must define ``parse_csv_line(line) -> list[str]``
+    that passes all 20 seeded fixed cases below. Each failure is reported
+    individually in ``detail``.
+
+Determinism: all test inputs are fixed constants.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    passed: bool
+    score: float
+    detail: str
+
+
+OUTPUT_REL = "output/solution.py"
+
+
+def _import_module(solution_path: Path):
+    spec = importlib.util.spec_from_file_location("agent_solution", solution_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_TESTS: list[tuple[str, list[str]]] = [
+    ("a,b,c", ["a", "b", "c"]),
+    ("", [""]),
+    (",", ["", ""]),
+    (",,", ["", "", ""]),
+    ("a", ["a"]),
+    ("a,", ["a", ""]),
+    (",a", ["", "a"]),
+    ('"a","b","c"', ["a", "b", "c"]),
+    ('a,"b,c",d', ["a", "b,c", "d"]),
+    ('a,"b""c",d', ["a", 'b"c', "d"]),
+    ('"Seattle, WA",98101', ["Seattle, WA", "98101"]),
+    ('"",""', ["", ""]),
+    ('"he said ""hi""",ok', ['he said "hi"', "ok"]),
+    ("1,2,3,4,5", ["1", "2", "3", "4", "5"]),
+    ("name,age,city", ["name", "age", "city"]),
+    ('"a,b,c"', ["a,b,c"]),
+    ('"a","b,c,d","e"', ["a", "b,c,d", "e"]),
+    ("  spaced  ,  fields  ", ["  spaced  ", "  fields  "]),
+    ('"with space", plain ,"more"', ["with space", " plain ", "more"]),
+    ('x,"",y', ["x", "", "y"]),
+]
+
+
+def grade(scratch_dir: Path) -> GradeResult:
+    scratch_dir = Path(scratch_dir).resolve()
+    solution_path = scratch_dir / OUTPUT_REL
+
+    if not solution_path.is_file():
+        return GradeResult(False, 0.0, "output artifact not produced (output/solution.py missing)")
+
+    try:
+        mod = _import_module(solution_path)
+    except Exception as exc:
+        tb = traceback.format_exc()
+        return GradeResult(False, 0.0, f"failed to import solution.py: {exc}\n{tb[:400]}")
+
+    if not hasattr(mod, "parse_csv_line"):
+        return GradeResult(False, 0.0, "solution.py does not define 'parse_csv_line'")
+
+    fn = mod.parse_csv_line
+    failures: list[str] = []
+    for line, expected in _TESTS:
+        try:
+            got = fn(line)
+        except Exception as exc:
+            failures.append(f"  {line!r}: raised {type(exc).__name__}: {exc}")
+            continue
+        if not isinstance(got, list):
+            failures.append(f"  {line!r}: expected list, got {type(got).__name__}")
+        elif got != expected:
+            failures.append(f"  {line!r}: expected {expected!r}, got {got!r}")
+
+    n_pass = len(_TESTS) - len(failures)
+    if failures:
+        detail = f"{n_pass}/{len(_TESTS)} tests passed. Failures:\n" + "\n".join(failures)
+        return GradeResult(False, round(n_pass / len(_TESTS), 4), detail)
+
+    return GradeResult(True, 1.0, f"all {len(_TESTS)} cases passed")

--- a/problems/artifact/verification_heavy/csv_dialect_parser/grader/reference_output.py
+++ b/problems/artifact/verification_heavy/csv_dialect_parser/grader/reference_output.py
@@ -1,0 +1,19 @@
+"""Reference implementation of parse_csv_line for verification_heavy__csv_dialect_parser."""
+
+import csv
+import io
+
+
+def parse_csv_line(line: str) -> list[str]:
+    """Parse one CSV record into its fields (RFC 4180 subset).
+
+    Uses csv.reader so quote handling ('""' escaping, embedded commas) is
+    covered by stdlib. csv.reader on an empty string returns no rows; we
+    normalise to [""] to match the documented contract.
+    """
+    if line == "":
+        return [""]
+    reader = csv.reader(io.StringIO(line))
+    for row in reader:
+        return row
+    return [""]

--- a/problems/artifact/verification_heavy/csv_dialect_parser/prompt.md
+++ b/problems/artifact/verification_heavy/csv_dialect_parser/prompt.md
@@ -1,0 +1,55 @@
+# Task: Parse a single CSV line (RFC 4180 subset)
+
+We have a data-ingest path that used to rely on `str.split(",")`. It breaks on
+quoted fields that contain commas (e.g. addresses like `"Seattle, WA"`). Before
+we swap in `csv.reader` across the pipeline, we need a small, auditable
+reference function that implements the RFC 4180 rules we actually see in our
+feeds so the behaviour is documented in one place.
+
+Implement `parse_csv_line(line: str) -> list[str]` that splits **one** CSV
+record into its fields according to the rules below.
+
+## Rules
+
+1. Fields are separated by `,`.
+2. A field may optionally be enclosed in double quotes `"..."`. Inside a quoted
+   field:
+   - Commas are literal (not separators).
+   - Two adjacent double quotes `""` represent a single literal `"`.
+   - Any other character (including whitespace) is kept verbatim.
+3. Unquoted fields are taken verbatim between the surrounding separators. No
+   whitespace trimming.
+4. The input is exactly one logical record, **without** a trailing newline.
+   It will not contain embedded raw newlines.
+5. An empty input string yields `[""]` (one empty field), matching the
+   behaviour of `csv.reader(["", ])`.
+
+## Examples
+
+| Input | Expected output |
+|-------|-----------------|
+| `a,b,c` | `["a", "b", "c"]` |
+| `"a","b","c"` | `["a", "b", "c"]` |
+| `a,"b,c",d` | `["a", "b,c", "d"]` |
+| `a,"b""c",d` | `["a", 'b"c', "d"]` |
+| `,,` | `["", "", ""]` |
+| `"Seattle, WA",98101` | `["Seattle, WA", "98101"]` |
+| `` (empty) | `[""]` |
+
+## Output
+
+Write your implementation to `output/solution.py`. The file must define:
+
+```python
+def parse_csv_line(line: str) -> list[str]:
+    ...
+```
+
+You may use any Python standard library module. No third-party packages are
+needed. Using `csv.reader` is acceptable — we want a correct reference
+implementation, not a from-scratch reimplementation.
+
+## Verification
+
+Run `python verify.py` to confirm `output/solution.py` imports and exposes
+`parse_csv_line`. The hidden grader runs 20 fixed cases.

--- a/problems/artifact/verification_heavy/csv_dialect_parser/task.yaml
+++ b/problems/artifact/verification_heavy/csv_dialect_parser/task.yaml
@@ -1,0 +1,17 @@
+instance_id: verification_heavy__csv_dialect_parser
+category: verification_heavy
+difficulty: easy
+problem_statement: prompt.md
+workspace_dir: workspace/
+output_artifact: output/solution.py
+hidden_grader: grader/hidden.py
+reference_output: grader/reference_output.py
+execution_budget:
+  max_code_runs: 10
+  max_wall_seconds: 120
+tags:
+  - verification_heavy
+  - parsing
+  - csv
+  - python
+  - realism_checklist_v1

--- a/problems/artifact/verification_heavy/csv_dialect_parser/workspace/verify.py
+++ b/problems/artifact/verification_heavy/csv_dialect_parser/workspace/verify.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Structural verifier for verification_heavy__csv_dialect_parser.
+
+Checks that output/solution.py:
+  - exists and is valid Python
+  - defines a callable named 'parse_csv_line'
+  - accepts a string argument (basic signature check)
+
+Does NOT run the hidden property suite.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+OUTPUT = Path(__file__).parent / "output" / "solution.py"
+
+
+def main() -> int:
+    if not OUTPUT.is_file():
+        print(f"FAIL: output/solution.py not found at {OUTPUT}", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("agent_solution", OUTPUT)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"FAIL: could not import solution.py: {exc}", file=sys.stderr)
+        return 1
+
+    if not hasattr(mod, "parse_csv_line"):
+        print("FAIL: solution.py does not define 'parse_csv_line'", file=sys.stderr)
+        return 1
+
+    fn = mod.parse_csv_line
+    if not callable(fn):
+        print("FAIL: 'parse_csv_line' is not callable", file=sys.stderr)
+        return 1
+
+    try:
+        fn("a,b,c")
+    except Exception as exc:
+        print(f"WARN: parse_csv_line('a,b,c') raised {type(exc).__name__}: {exc}")
+
+    print("OK: solution.py imports and defines 'parse_csv_line'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/problems/artifact/verification_heavy/expression_evaluator/grader/hidden.py
+++ b/problems/artifact/verification_heavy/expression_evaluator/grader/hidden.py
@@ -1,0 +1,114 @@
+"""Hidden grader for verification_heavy__expression_evaluator.
+
+Correctness: evaluate(expr) matches expected value (numeric tolerance 1e-9),
+or raises the expected exception type for error cases.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    passed: bool
+    score: float
+    detail: str
+
+
+OUTPUT_REL = "output/solution.py"
+
+
+def _import_module(solution_path: Path):
+    spec = importlib.util.spec_from_file_location("agent_solution", solution_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_OK = object()
+
+# (expr, expected) — expected is a float, or a type (subclass of Exception) the call must raise.
+_TESTS: list[tuple[str, object]] = [
+    ("1+2", 3.0),
+    ("2+3*4", 14.0),
+    ("(2+3)*4", 20.0),
+    ("10-2-3", 5.0),
+    ("10/2/5", 1.0),
+    ("-5+3", -2.0),
+    ("-(2+3)", -5.0),
+    ("2*-3", -6.0),
+    ("2 + 3 * 4", 14.0),
+    ("  42 ", 42.0),
+    ("3.14", 3.14),
+    ("0.5 + 0.25", 0.75),
+    ("((1+2)*(3+4))", 21.0),
+    ("1 + 2 + 3 + 4 + 5", 15.0),
+    ("100 / 4 * 2", 50.0),
+    ("100 / (4 * 2)", 12.5),
+    ("--5", 5.0),     # double unary minus
+    ("-(-3)", 3.0),
+    ("2*(3+4)-5", 9.0),
+    ("0", 0.0),
+    # error cases
+    ("1/0", ZeroDivisionError),
+    ("1 + ", ValueError),
+    ("(1+2", ValueError),
+    ("1+2)", ValueError),
+    ("", ValueError),
+]
+
+
+def _close(got: float, want: float) -> bool:
+    return math.isclose(got, want, rel_tol=1e-9, abs_tol=1e-9)
+
+
+def grade(scratch_dir: Path) -> GradeResult:
+    scratch_dir = Path(scratch_dir).resolve()
+    solution_path = scratch_dir / OUTPUT_REL
+
+    if not solution_path.is_file():
+        return GradeResult(False, 0.0, "output artifact not produced (output/solution.py missing)")
+
+    try:
+        mod = _import_module(solution_path)
+    except Exception as exc:
+        tb = traceback.format_exc()
+        return GradeResult(False, 0.0, f"failed to import solution.py: {exc}\n{tb[:400]}")
+
+    if not hasattr(mod, "evaluate"):
+        return GradeResult(False, 0.0, "solution.py does not define 'evaluate'")
+
+    fn = mod.evaluate
+    failures: list[str] = []
+    for expr, expected in _TESTS:
+        if isinstance(expected, type) and issubclass(expected, BaseException):
+            try:
+                got = fn(expr)
+                failures.append(f"  evaluate({expr!r}): expected {expected.__name__}, got result {got!r}")
+            except expected:
+                pass
+            except Exception as exc:
+                failures.append(
+                    f"  evaluate({expr!r}): expected {expected.__name__}, raised {type(exc).__name__}: {exc}"
+                )
+        else:
+            try:
+                got = fn(expr)
+            except Exception as exc:
+                failures.append(f"  evaluate({expr!r}): raised {type(exc).__name__}: {exc}")
+                continue
+            if not isinstance(got, (int, float)) or isinstance(got, bool):
+                failures.append(f"  evaluate({expr!r}): expected float, got {type(got).__name__}")
+            elif not _close(float(got), float(expected)):
+                failures.append(f"  evaluate({expr!r}): expected {expected}, got {got}")
+
+    n_pass = len(_TESTS) - len(failures)
+    if failures:
+        detail = f"{n_pass}/{len(_TESTS)} cases passed. Failures:\n" + "\n".join(failures)
+        return GradeResult(False, round(n_pass / len(_TESTS), 4), detail)
+    return GradeResult(True, 1.0, f"all {len(_TESTS)} cases passed")

--- a/problems/artifact/verification_heavy/expression_evaluator/grader/reference_output.py
+++ b/problems/artifact/verification_heavy/expression_evaluator/grader/reference_output.py
@@ -1,0 +1,104 @@
+"""Reference evaluate() — recursive descent arithmetic parser.
+
+Grammar:
+    expr   := term (('+'|'-') term)*
+    term   := factor (('*'|'/') factor)*
+    factor := ('-' factor) | '(' expr ')' | NUMBER
+"""
+
+import re
+
+
+_TOK = re.compile(r"\s*(?:(\d+(?:\.\d+)?)|([+\-*/()]))")
+
+
+def _tokenize(s: str) -> list[tuple[str, str]]:
+    tokens: list[tuple[str, str]] = []
+    pos = 0
+    while pos < len(s):
+        m = _TOK.match(s, pos)
+        if not m or m.end() == pos:
+            # Check if the remainder is only whitespace
+            if s[pos:].strip() == "":
+                break
+            raise ValueError(f"unexpected character at position {pos}: {s[pos]!r}")
+        if m.group(1) is not None:
+            tokens.append(("NUM", m.group(1)))
+        else:
+            tokens.append(("OP", m.group(2)))
+        pos = m.end()
+    return tokens
+
+
+class _Parser:
+    def __init__(self, tokens: list[tuple[str, str]]) -> None:
+        self.tokens = tokens
+        self.i = 0
+
+    def _peek(self) -> tuple[str, str] | None:
+        return self.tokens[self.i] if self.i < len(self.tokens) else None
+
+    def _eat(self) -> tuple[str, str]:
+        if self.i >= len(self.tokens):
+            raise ValueError("unexpected end of expression")
+        tok = self.tokens[self.i]
+        self.i += 1
+        return tok
+
+    def parse_expr(self) -> float:
+        left = self.parse_term()
+        while True:
+            tok = self._peek()
+            if tok is None or tok[0] != "OP" or tok[1] not in "+-":
+                break
+            self._eat()
+            right = self.parse_term()
+            left = left + right if tok[1] == "+" else left - right
+        return left
+
+    def parse_term(self) -> float:
+        left = self.parse_factor()
+        while True:
+            tok = self._peek()
+            if tok is None or tok[0] != "OP" or tok[1] not in "*/":
+                break
+            self._eat()
+            right = self.parse_factor()
+            if tok[1] == "*":
+                left = left * right
+            else:
+                if right == 0:
+                    raise ZeroDivisionError("division by zero")
+                left = left / right
+        return left
+
+    def parse_factor(self) -> float:
+        tok = self._peek()
+        if tok is None:
+            raise ValueError("unexpected end of expression")
+        if tok[0] == "OP" and tok[1] == "-":
+            self._eat()
+            return -self.parse_factor()
+        if tok[0] == "OP" and tok[1] == "(":
+            self._eat()
+            val = self.parse_expr()
+            close = self._peek()
+            if close is None or close != ("OP", ")"):
+                raise ValueError("missing ')'")
+            self._eat()
+            return val
+        if tok[0] == "NUM":
+            self._eat()
+            return float(tok[1])
+        raise ValueError(f"unexpected token {tok!r}")
+
+
+def evaluate(expr: str) -> float:
+    tokens = _tokenize(expr)
+    if not tokens:
+        raise ValueError("empty expression")
+    p = _Parser(tokens)
+    result = p.parse_expr()
+    if p.i != len(tokens):
+        raise ValueError(f"trailing tokens at position {p.i}")
+    return float(result)

--- a/problems/artifact/verification_heavy/expression_evaluator/prompt.md
+++ b/problems/artifact/verification_heavy/expression_evaluator/prompt.md
@@ -1,0 +1,59 @@
+# Task: Safe arithmetic expression evaluator
+
+Users of our internal spreadsheet tool can type formulas into cells, and the
+backend needs to evaluate them **without** using `eval()` or `exec()` (a pen
+test flagged that last quarter). Implement a small arithmetic expression
+evaluator that handles the four basic operators, unary minus, and parentheses.
+
+Implement `evaluate(expr: str) -> float`.
+
+## Grammar
+
+- Operators: `+`, `-`, `*`, `/` (binary), plus unary `-` (prefix).
+- Parentheses: `(` and `)` for grouping.
+- Operands: non-negative integer or decimal literals, e.g. `0`, `42`, `3.14`,
+  `0.5`. No scientific notation, no leading `+` on literals, no hex.
+- Whitespace (` `, tab) is allowed anywhere between tokens and ignored.
+- Standard precedence: `*` and `/` bind tighter than `+` and `-`; operators of
+  equal precedence are left-associative. Parentheses override precedence.
+- Division is ordinary float division (`/`). Division by zero must raise
+  `ZeroDivisionError`.
+- Any syntactic error (unexpected token, unbalanced parens, empty input after
+  trimming whitespace) must raise `ValueError`. You may use a single message
+  string — the grader does not inspect it.
+
+Return the evaluated value as a Python `float`.
+
+## Examples
+
+| Input | Output |
+|-------|--------|
+| `"1+2"` | `3.0` |
+| `"2 + 3 * 4"` | `14.0` |
+| `"(2 + 3) * 4"` | `20.0` |
+| `"10 - 2 - 3"` | `5.0` |
+| `"10 / 2 / 5"` | `1.0` |
+| `"-5 + 3"` | `-2.0` |
+| `"-(2 + 3)"` | `-5.0` |
+| `"2 * -3"` | `-6.0` |
+| `"1 / 0"` | raises `ZeroDivisionError` |
+| `"1 + "` | raises `ValueError` |
+
+## Output
+
+Write your implementation to `output/solution.py`:
+
+```python
+def evaluate(expr: str) -> float:
+    ...
+```
+
+Standard library only. **You must not use `eval()`, `exec()`, `compile()`, or
+the `ast` module's `literal_eval`** — the whole point is to avoid those.
+Recursive descent or shunting-yard are both fine; you may use `re` for
+tokenising.
+
+## Verification
+
+Run `python verify.py` to check the structural shape of your output. The hidden
+grader runs 25 cases including error paths.

--- a/problems/artifact/verification_heavy/expression_evaluator/task.yaml
+++ b/problems/artifact/verification_heavy/expression_evaluator/task.yaml
@@ -1,0 +1,18 @@
+instance_id: verification_heavy__expression_evaluator
+category: verification_heavy
+difficulty: medium
+problem_statement: prompt.md
+workspace_dir: workspace/
+output_artifact: output/solution.py
+hidden_grader: grader/hidden.py
+reference_output: grader/reference_output.py
+execution_budget:
+  max_code_runs: 10
+  max_wall_seconds: 120
+tags:
+  - verification_heavy
+  - parsing
+  - expression
+  - arithmetic
+  - python
+  - realism_checklist_v1

--- a/problems/artifact/verification_heavy/expression_evaluator/workspace/verify.py
+++ b/problems/artifact/verification_heavy/expression_evaluator/workspace/verify.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Structural verifier for verification_heavy__expression_evaluator."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+OUTPUT = Path(__file__).parent / "output" / "solution.py"
+
+
+def main() -> int:
+    if not OUTPUT.is_file():
+        print(f"FAIL: output/solution.py not found at {OUTPUT}", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("agent_solution", OUTPUT)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"FAIL: could not import solution.py: {exc}", file=sys.stderr)
+        return 1
+
+    if not hasattr(mod, "evaluate") or not callable(mod.evaluate):
+        print("FAIL: solution.py does not define callable 'evaluate'", file=sys.stderr)
+        return 1
+
+    try:
+        v = mod.evaluate("1+2")
+        if not isinstance(v, float):
+            print(f"WARN: evaluate('1+2') returned {type(v).__name__}, expected float")
+    except Exception as exc:
+        print(f"WARN: evaluate('1+2') raised {type(exc).__name__}: {exc}")
+
+    print("OK: solution.py imports and defines 'evaluate'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/problems/artifact/verification_heavy/iban_validator/grader/hidden.py
+++ b/problems/artifact/verification_heavy/iban_validator/grader/hidden.py
@@ -1,0 +1,101 @@
+"""Hidden grader for verification_heavy__iban_validator.
+
+25 cases: well-known valid IBANs (DE/GB/FR/ES/IT/NL/CH/BE), space-formatted
+inputs, bad-checksum mutations, wrong length, wrong country, letter/digit
+class violations, and non-string inputs.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    passed: bool
+    score: float
+    detail: str
+
+
+OUTPUT_REL = "output/solution.py"
+
+
+def _import_module(solution_path: Path):
+    spec = importlib.util.spec_from_file_location("agent_solution", solution_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# (input, expected)
+_TESTS: list[tuple[object, bool]] = [
+    # Valid examples (all verified mod-97-ok)
+    ("DE89370400440532013000",                  True),
+    ("DE89 3704 0044 0532 0130 00",             True),
+    ("de89370400440532013000",                  True),  # lowercase ok
+    ("GB82WEST12345698765432",                  True),
+    ("FR1420041010050500013M02606",             True),
+    ("ES9121000418450200051332",                True),
+    ("IT60X0542811101000000123456",             True),
+    ("NL91ABNA0417164300",                      True),
+    ("CH9300762011623852957",                   True),
+    ("BE68539007547034",                        True),
+    # Bad checksum (toggle last digit)
+    ("DE89370400440532013001",                  False),
+    ("GB82WEST12345698765431",                  False),
+    ("BE68539007547035",                        False),
+    # Wrong length
+    ("DE8937040044053201300",                   False),   # 21, need 22
+    ("DE893704004405320130001",                 False),  # 23
+    # Unknown country code
+    ("XX89370400440532013000",                  False),
+    ("US89370400440532013000",                  False),
+    # Structure violations
+    ("GB82W3ST12345698765432",                  False),   # digit in letter slot
+    ("NL91ABNA041716430A",                      False),   # letter where digit expected
+    # Garbage / missing bits
+    ("",                                        False),
+    ("DE",                                      False),
+    ("DE89",                                    False),
+    ("DE893704004405320130AB",                  False),   # letters in all-digit BBAN
+    # Non-string / None
+    (None,                                      False),
+    (1234567890,                                False),
+]
+
+
+def grade(scratch_dir: Path) -> GradeResult:
+    scratch_dir = Path(scratch_dir).resolve()
+    solution_path = scratch_dir / OUTPUT_REL
+
+    if not solution_path.is_file():
+        return GradeResult(False, 0.0, "output artifact not produced (output/solution.py missing)")
+
+    try:
+        mod = _import_module(solution_path)
+    except Exception as exc:
+        tb = traceback.format_exc()
+        return GradeResult(False, 0.0, f"failed to import solution.py: {exc}\n{tb[:400]}")
+
+    if not hasattr(mod, "validate_iban"):
+        return GradeResult(False, 0.0, "solution.py does not define 'validate_iban'")
+
+    fn = mod.validate_iban
+    failures: list[str] = []
+    for inp, expected in _TESTS:
+        try:
+            got = fn(inp)
+        except Exception as exc:
+            failures.append(f"  validate_iban({inp!r}): raised {type(exc).__name__}: {exc}")
+            continue
+        if got is not expected:  # strict True/False (not truthy)
+            failures.append(f"  validate_iban({inp!r}): expected {expected}, got {got!r}")
+
+    n_pass = len(_TESTS) - len(failures)
+    if failures:
+        detail = f"{n_pass}/{len(_TESTS)} cases passed. Failures:\n" + "\n".join(failures)
+        return GradeResult(False, round(n_pass / len(_TESTS), 4), detail)
+    return GradeResult(True, 1.0, f"all {len(_TESTS)} cases passed")

--- a/problems/artifact/verification_heavy/iban_validator/grader/reference_output.py
+++ b/problems/artifact/verification_heavy/iban_validator/grader/reference_output.py
@@ -1,0 +1,80 @@
+"""Reference validate_iban() for verification_heavy__iban_validator."""
+
+import string
+
+
+# (total_length, BBAN structure as list of (kind, n))
+# kind: 'N' digits, 'A' letters, 'C' alphanumeric
+_COUNTRIES: dict[str, tuple[int, list[tuple[str, int]]]] = {
+    "DE": (22, [("N", 18)]),
+    "GB": (22, [("A", 4), ("N", 14)]),
+    "FR": (27, [("N", 10), ("C", 11), ("N", 2)]),
+    "ES": (24, [("N", 20)]),
+    "IT": (27, [("A", 1), ("N", 10), ("C", 12)]),
+    "NL": (18, [("A", 4), ("N", 10)]),
+    "CH": (21, [("N", 5), ("C", 12)]),
+    "BE": (16, [("N", 12)]),
+}
+
+
+def _matches(bban: str, structure: list[tuple[str, int]]) -> bool:
+    i = 0
+    for kind, n in structure:
+        piece = bban[i:i + n]
+        if len(piece) != n:
+            return False
+        if kind == "N":
+            if not piece.isdigit():
+                return False
+        elif kind == "A":
+            if not all(c in string.ascii_uppercase for c in piece):
+                return False
+        elif kind == "C":
+            if not all(c in string.ascii_uppercase or c.isdigit() for c in piece):
+                return False
+        i += n
+    return i == len(bban)
+
+
+def validate_iban(s) -> bool:
+    if not isinstance(s, str):
+        return False
+
+    # 1. strip spaces + upper
+    stripped = s.replace(" ", "").upper()
+    if stripped == "":
+        return False
+    if not all(c.isalnum() and ord(c) < 128 for c in stripped):
+        return False
+
+    # 2. structure prefix
+    if len(stripped) < 4:
+        return False
+    cc = stripped[:2]
+    check = stripped[2:4]
+    if not (cc[0] in string.ascii_uppercase and cc[1] in string.ascii_uppercase):
+        return False
+    if not check.isdigit():
+        return False
+
+    # 3. length per country
+    if cc not in _COUNTRIES:
+        return False
+    expected_len, structure = _COUNTRIES[cc]
+    if len(stripped) != expected_len:
+        return False
+
+    # 4. BBAN structure
+    if not _matches(stripped[4:], structure):
+        return False
+
+    # 5. mod-97 checksum
+    rearranged = stripped[4:] + stripped[:4]
+    numeric = []
+    for c in rearranged:
+        if c.isdigit():
+            numeric.append(c)
+        else:  # must be uppercase ASCII letter (A-Z)
+            numeric.append(str(ord(c) - ord("A") + 10))
+    big = int("".join(numeric))
+    return big % 97 == 1

--- a/problems/artifact/verification_heavy/iban_validator/prompt.md
+++ b/problems/artifact/verification_heavy/iban_validator/prompt.md
@@ -1,0 +1,79 @@
+# Task: Validate IBAN numbers (ISO 13616)
+
+Our payments microservice keeps letting through payment instructions with
+malformed IBAN numbers — usually because someone transcribed them by hand and
+a digit was wrong. We need a validator that catches both **format** errors
+(wrong length for the country, wrong character class in the BBAN) and the
+**mod-97 checksum** (ISO 13616 / ISO 7064) that IBAN uses to detect single-
+digit typos and most two-digit transpositions.
+
+Implement `validate_iban(s: str) -> bool` in `output/solution.py`.
+
+## Validation rules
+
+1. Strip ASCII spaces from `s` and uppercase the result. After stripping the
+   IBAN must consist only of ASCII letters and digits.
+2. The first two characters must be letters (the country code) and must be one
+   of the supported countries in the length table below. The next two
+   characters must be digits (the check digits).
+3. The **total length** after stripping must match the length associated with
+   the country code in the table.
+4. The BBAN (everything after the 4th character) must match the BBAN structure
+   in the table (see below). If any character is outside its declared class,
+   the IBAN is invalid.
+5. **Mod-97 check**: move the first 4 characters to the end, then replace each
+   letter with two digits (A=10, B=11, ..., Z=35). Interpret the resulting
+   digit string as a single integer; it must equal `1 mod 97`.
+
+Return `True` iff all checks pass. Return `False` for any violation (including
+None / non-string inputs). Do not raise.
+
+## Supported countries and structures
+
+| CC | Total length | BBAN structure (after `CCkk`) |
+|----|--------------|-------------------------------|
+| DE | 22 | 18 digits |
+| GB | 22 | 4 letters, 14 digits |
+| FR | 27 | 10 digits, 11 alphanumeric, 2 digits |
+| ES | 24 | 20 digits |
+| IT | 27 | 1 letter, 10 digits, 12 alphanumeric |
+| NL | 18 | 4 letters, 10 digits |
+| CH | 21 | 5 digits, 12 alphanumeric |
+| BE | 16 | 12 digits |
+
+Any country code not in this table → `False` (do not attempt to validate).
+
+"alphanumeric" means ASCII letter or ASCII digit.
+
+## Examples
+
+| Input | Output |
+|-------|--------|
+| `"DE89 3704 0044 0532 0130 00"` | `True` |
+| `"DE89370400440532013000"` | `True` |
+| `"GB82WEST12345698765432"` | `True` |
+| `"FR1420041010050500013M02606"` | `True` |
+| `"BE68539007547034"` | `True` |
+| `"DE89370400440532013001"` | `False` (wrong checksum) |
+| `"DE8937040044053201300"` | `False` (wrong length) |
+| `"XX89370400440532013000"` | `False` (unknown country) |
+| `"GB82XEST12345698765432"` | `True` if checksum holds — but this example is synthetic; real graders use known-valid / deliberately-broken IBANs |
+| `""` | `False` |
+| `None` | `False` |
+
+## Output
+
+Write your implementation to `output/solution.py`:
+
+```python
+def validate_iban(s) -> bool:
+    ...
+```
+
+Standard library only. No third-party `schwifty`, `iban`, `pycountry`, etc.
+
+## Verification
+
+Run `python verify.py` for a structural check. The hidden grader runs 25
+positive and negative cases including malformed inputs, unknown countries,
+character-class violations, and checksum mutations.

--- a/problems/artifact/verification_heavy/iban_validator/task.yaml
+++ b/problems/artifact/verification_heavy/iban_validator/task.yaml
@@ -1,0 +1,18 @@
+instance_id: verification_heavy__iban_validator
+category: verification_heavy
+difficulty: hard
+problem_statement: prompt.md
+workspace_dir: workspace/
+output_artifact: output/solution.py
+hidden_grader: grader/hidden.py
+reference_output: grader/reference_output.py
+execution_budget:
+  max_code_runs: 15
+  max_wall_seconds: 180
+tags:
+  - verification_heavy
+  - iban
+  - validation
+  - checksum
+  - python
+  - realism_checklist_v1

--- a/problems/artifact/verification_heavy/iban_validator/workspace/verify.py
+++ b/problems/artifact/verification_heavy/iban_validator/workspace/verify.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Structural verifier for verification_heavy__iban_validator."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+OUTPUT = Path(__file__).parent / "output" / "solution.py"
+
+
+def main() -> int:
+    if not OUTPUT.is_file():
+        print(f"FAIL: output/solution.py not found at {OUTPUT}", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("agent_solution", OUTPUT)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"FAIL: could not import solution.py: {exc}", file=sys.stderr)
+        return 1
+
+    if not hasattr(mod, "validate_iban") or not callable(mod.validate_iban):
+        print("FAIL: solution.py does not define callable 'validate_iban'", file=sys.stderr)
+        return 1
+
+    try:
+        r = mod.validate_iban("DE89370400440532013000")
+        if r is not True:
+            print(f"WARN: validate_iban returned {r!r}, expected True")
+    except Exception as exc:
+        print(f"WARN: validate_iban raised {type(exc).__name__}: {exc}")
+
+    print("OK: solution.py imports and defines 'validate_iban'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/problems/artifact/verification_heavy/json_pointer_rfc6901/grader/hidden.py
+++ b/problems/artifact/verification_heavy/json_pointer_rfc6901/grader/hidden.py
@@ -1,0 +1,181 @@
+"""Hidden grader for verification_heavy__json_pointer_rfc6901.
+
+Tests resolve() and set_at() against a curated RFC 6901 fixture. Each test
+case is independent (the grader deep-copies the base doc before each case).
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    passed: bool
+    score: float
+    detail: str
+
+
+OUTPUT_REL = "output/solution.py"
+
+
+def _import_module(solution_path: Path):
+    spec = importlib.util.spec_from_file_location("agent_solution", solution_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _base_doc() -> dict:
+    return {
+        "": "empty-key",
+        "a/b": "slash-in-key",
+        "m~n": "tilde-in-key",
+        "foo": ["bar", "baz"],
+        "": "empty-key",  # duplicate intentional — last wins
+        "nested": {
+            "x": 1,
+            "y": {"z": [10, 20, 30]},
+        },
+        "arr": [{"k": "v"}, [1, 2, 3], None],
+        "primitives": 42,
+    }
+
+
+# Resolve tests: (pointer, expected) where expected is a value, or a type to assert raised.
+_RESOLVE_TESTS: list[tuple[str, object]] = [
+    ("", "__DOC__"),  # special sentinel: compare to full doc
+    ("/a~1b", "slash-in-key"),
+    ("/m~0n", "tilde-in-key"),
+    ("/foo/0", "bar"),
+    ("/foo/1", "baz"),
+    ("/nested/x", 1),
+    ("/nested/y/z/2", 30),
+    ("/arr/0/k", "v"),
+    ("/arr/1/1", 2),
+    ("/primitives", 42),
+    ("/", "empty-key"),  # key = ""
+    # Error cases
+    ("/missing", KeyError),
+    ("/foo/9", KeyError),
+    ("/foo/-", KeyError),  # '-' on array not allowed in resolve
+    ("/primitives/x", KeyError),  # traverse into int
+    ("abc", ValueError),  # invalid pointer
+    ("/foo/01", KeyError),  # leading zero
+    ("/foo/-1", KeyError),  # negative
+]
+
+
+# Set tests: (pointer, value, check_fn) where check_fn(doc) -> bool.
+# Expected-exception form: (pointer, value, <exception type>)
+_SET_TESTS: list[tuple[str, object, object]] = [
+    ("/nested/x", 99,
+        lambda d: d["nested"]["x"] == 99),
+    ("/foo/0", "BAR",
+        lambda d: d["foo"][0] == "BAR"),
+    ("/foo/-", "qux",
+        lambda d: d["foo"] == ["bar", "baz", "qux"]),
+    ("/foo/2", "added",
+        lambda d: d["foo"] == ["bar", "baz", "added"]),  # idx == len → append
+    ("/nested/y/z/0", 1000,
+        lambda d: d["nested"]["y"]["z"][0] == 1000),
+    ("/nested/new_key", {"k": "v"},
+        lambda d: d["nested"]["new_key"] == {"k": "v"}),
+    ("/a~1b", "updated",
+        lambda d: d["a/b"] == "updated"),
+    ("/arr/2", "replaced",
+        lambda d: d["arr"][2] == "replaced"),
+    ("/nested/y/z/-", 40,
+        lambda d: d["nested"]["y"]["z"] == [10, 20, 30, 40]),
+    # Error cases
+    ("", 1, ValueError),
+    ("/foo/9", "x", KeyError),      # index beyond len
+    ("/missing/inner", 1, KeyError),  # parent missing (no auto-create)
+    ("abc", 1, ValueError),          # invalid pointer syntax
+]
+
+
+def grade(scratch_dir: Path) -> GradeResult:
+    scratch_dir = Path(scratch_dir).resolve()
+    solution_path = scratch_dir / OUTPUT_REL
+
+    if not solution_path.is_file():
+        return GradeResult(False, 0.0, "output artifact not produced (output/solution.py missing)")
+
+    try:
+        mod = _import_module(solution_path)
+    except Exception as exc:
+        tb = traceback.format_exc()
+        return GradeResult(False, 0.0, f"failed to import solution.py: {exc}\n{tb[:400]}")
+
+    if not hasattr(mod, "resolve") or not hasattr(mod, "set_at"):
+        return GradeResult(False, 0.0, "solution.py missing 'resolve' or 'set_at'")
+
+    resolve = mod.resolve
+    set_at = mod.set_at
+
+    failures: list[str] = []
+
+    for ptr, expected in _RESOLVE_TESTS:
+        doc = _base_doc()
+        if isinstance(expected, type) and issubclass(expected, BaseException):
+            try:
+                got = resolve(doc, ptr)
+                failures.append(f"  resolve({ptr!r}): expected {expected.__name__}, got {got!r}")
+            except expected:
+                pass
+            except Exception as exc:
+                failures.append(
+                    f"  resolve({ptr!r}): expected {expected.__name__}, raised {type(exc).__name__}: {exc}"
+                )
+        else:
+            try:
+                got = resolve(doc, ptr)
+            except Exception as exc:
+                failures.append(f"  resolve({ptr!r}): raised {type(exc).__name__}: {exc}")
+                continue
+            want = doc if expected == "__DOC__" else expected
+            if got != want:
+                failures.append(f"  resolve({ptr!r}): expected {want!r}, got {got!r}")
+
+    for ptr, value, check in _SET_TESTS:
+        doc = _base_doc()
+        if isinstance(check, type) and issubclass(check, BaseException):
+            try:
+                set_at(doc, ptr, value)
+                failures.append(f"  set_at({ptr!r}, {value!r}): expected {check.__name__}, no exception")
+            except check:
+                pass
+            except Exception as exc:
+                failures.append(
+                    f"  set_at({ptr!r}, {value!r}): expected {check.__name__}, raised {type(exc).__name__}: {exc}"
+                )
+        else:
+            snapshot = copy.deepcopy(doc)
+            try:
+                set_at(doc, ptr, value)
+            except Exception as exc:
+                failures.append(f"  set_at({ptr!r}, {value!r}): raised {type(exc).__name__}: {exc}")
+                continue
+            try:
+                ok = bool(check(doc))
+            except Exception as exc:
+                failures.append(f"  set_at({ptr!r}, {value!r}): check raised {type(exc).__name__}: {exc}")
+                continue
+            if not ok:
+                failures.append(
+                    f"  set_at({ptr!r}, {value!r}): postcondition false (doc before={snapshot!r}, after={doc!r})"
+                )
+
+    total = len(_RESOLVE_TESTS) + len(_SET_TESTS)
+    n_pass = total - len(failures)
+    if failures:
+        detail = f"{n_pass}/{total} cases passed. Failures:\n" + "\n".join(failures[:15])
+        if len(failures) > 15:
+            detail += f"\n  ... ({len(failures) - 15} more)"
+        return GradeResult(False, round(n_pass / total, 4), detail)
+    return GradeResult(True, 1.0, f"all {total} cases passed")

--- a/problems/artifact/verification_heavy/json_pointer_rfc6901/grader/reference_output.py
+++ b/problems/artifact/verification_heavy/json_pointer_rfc6901/grader/reference_output.py
@@ -1,0 +1,82 @@
+"""Reference resolve / set_at (RFC 6901 JSON Pointer) for verification_heavy__json_pointer_rfc6901."""
+
+
+def _unescape(token: str) -> str:
+    # Decode ~1 before ~0 (RFC 6901 §4).
+    return token.replace("~1", "/").replace("~0", "~")
+
+
+def _split(pointer: str) -> list[str]:
+    if pointer == "":
+        return []
+    if not pointer.startswith("/"):
+        raise ValueError(f"invalid JSON pointer (must be empty or start with '/'): {pointer!r}")
+    # Split on '/' after the leading one. Each piece is a reference token.
+    return [_unescape(tok) for tok in pointer[1:].split("/")]
+
+
+def _as_array_index(token: str, length: int, *, allow_dash: bool) -> int:
+    if token == "-":
+        if not allow_dash:
+            raise KeyError(f"'-' index not valid here")
+        return length
+    if token == "":
+        raise KeyError(f"empty array index")
+    if token != "0" and (not token.isdigit() or token[0] == "0"):
+        raise KeyError(f"invalid array index {token!r}")
+    if not token.isdigit():
+        raise KeyError(f"invalid array index {token!r}")
+    idx = int(token)
+    return idx
+
+
+def resolve(doc, pointer: str):
+    tokens = _split(pointer)
+    cur = doc
+    for tok in tokens:
+        if isinstance(cur, dict):
+            if tok not in cur:
+                raise KeyError(f"key {tok!r} not in dict")
+            cur = cur[tok]
+        elif isinstance(cur, list):
+            idx = _as_array_index(tok, len(cur), allow_dash=False)
+            if idx < 0 or idx >= len(cur):
+                raise KeyError(f"array index {idx} out of range (len={len(cur)})")
+            cur = cur[idx]
+        else:
+            raise KeyError(f"cannot traverse into {type(cur).__name__} with token {tok!r}")
+    return cur
+
+
+def set_at(doc, pointer: str, value) -> None:
+    tokens = _split(pointer)
+    if not tokens:
+        raise ValueError("cannot set at root pointer")
+
+    *parents, last = tokens
+    cur = doc
+    for tok in parents:
+        if isinstance(cur, dict):
+            if tok not in cur:
+                raise KeyError(f"parent key {tok!r} not in dict")
+            cur = cur[tok]
+        elif isinstance(cur, list):
+            idx = _as_array_index(tok, len(cur), allow_dash=False)
+            if idx < 0 or idx >= len(cur):
+                raise KeyError(f"parent array index {idx} out of range (len={len(cur)})")
+            cur = cur[idx]
+        else:
+            raise KeyError(f"cannot traverse into {type(cur).__name__}")
+
+    if isinstance(cur, dict):
+        cur[last] = value
+    elif isinstance(cur, list):
+        idx = _as_array_index(last, len(cur), allow_dash=True)
+        if idx == len(cur):
+            cur.append(value)
+        elif 0 <= idx < len(cur):
+            cur[idx] = value
+        else:
+            raise KeyError(f"array index {idx} out of range (len={len(cur)})")
+    else:
+        raise KeyError(f"target parent is not a container: {type(cur).__name__}")

--- a/problems/artifact/verification_heavy/json_pointer_rfc6901/prompt.md
+++ b/problems/artifact/verification_heavy/json_pointer_rfc6901/prompt.md
@@ -1,0 +1,75 @@
+# Task: Implement a JSON Pointer (RFC 6901) resolver and setter
+
+Our config system stores nested JSON blobs, and reviewers keep pasting things
+like `/services/api/timeouts/read_s` into PR comments to refer to specific
+fields. We want a small utility that supports **JSON Pointer** (RFC 6901) on
+in-memory Python objects loaded from JSON (so `dict`, `list`, `str`, `int`,
+`float`, `bool`, `None`).
+
+Implement two functions in `output/solution.py`:
+
+```python
+def resolve(doc, pointer: str):
+    """Return the value in doc referenced by pointer.
+
+    Raise KeyError if any step cannot be resolved (missing dict key,
+    out-of-range array index, or traversal into a non-container).
+    Raise ValueError for syntactically invalid pointers.
+    """
+
+def set_at(doc, pointer: str, value):
+    """Mutate doc in place: set the value referenced by pointer.
+
+    For array targets, an index equal to the current length (or the literal
+    '-') APPENDS. Out-of-range positive indices beyond length raise KeyError.
+    The parent of the target must exist; intermediate containers are NOT
+    auto-created.
+    Raise ValueError for syntactically invalid pointers.
+    Setting at the root pointer ("") is not supported — raise ValueError.
+    """
+```
+
+## Pointer syntax (RFC 6901)
+
+- A pointer is a possibly-empty string.
+- The empty string `""` refers to the whole document.
+- Otherwise, a pointer starts with `/` and is a sequence of reference tokens
+  separated by `/`.
+- A syntactically invalid pointer (non-empty, does not start with `/`) raises
+  `ValueError`.
+- Inside a reference token:
+  - `~1` decodes to `/`
+  - `~0` decodes to `~`
+  - The order matters: decode `~1` first, then `~0`.
+- Array indices are decimal strings with no leading zeros (except the literal
+  `"0"`). Negative indices are not allowed.
+- The literal token `-` on an array refers to "one past the last element"
+  (used by `set_at` to append; `resolve` must raise `KeyError` on `-`).
+
+## Examples
+
+```python
+doc = {"a": {"b": [10, 20, {"c~d/e": "ok"}]}, "": "empty-key"}
+
+resolve(doc, "")                       == doc
+resolve(doc, "/a/b/0")                 == 10
+resolve(doc, "/a/b/2/c~0d~1e")         == "ok"
+resolve(doc, "/")                      == "empty-key"   # key = ""
+resolve(doc, "/a/b/5")  # raises KeyError
+
+set_at(doc, "/a/b/0", 99)              # doc["a"]["b"][0] == 99
+set_at(doc, "/a/b/-", 40)              # appends 40 to doc["a"]["b"]
+set_at(doc, "/a/b/3", 50)              # appends (index == len) 50
+set_at(doc, "/a/new", {"x": 1})        # creates new key on existing dict
+set_at(doc, "/nope/inner", 1)  # raises KeyError — parent missing
+set_at(doc, "", {"wipe": True})  # raises ValueError — root not supported
+```
+
+## Output
+
+Write your implementation to `output/solution.py`. Standard library only.
+
+## Verification
+
+Run `python verify.py` to confirm the module loads and exposes both
+functions. The hidden grader runs 30 mixed resolve/set cases.

--- a/problems/artifact/verification_heavy/json_pointer_rfc6901/task.yaml
+++ b/problems/artifact/verification_heavy/json_pointer_rfc6901/task.yaml
@@ -1,0 +1,18 @@
+instance_id: verification_heavy__json_pointer_rfc6901
+category: verification_heavy
+difficulty: hard
+problem_statement: prompt.md
+workspace_dir: workspace/
+output_artifact: output/solution.py
+hidden_grader: grader/hidden.py
+reference_output: grader/reference_output.py
+execution_budget:
+  max_code_runs: 15
+  max_wall_seconds: 180
+tags:
+  - verification_heavy
+  - json_pointer
+  - rfc6901
+  - parsing
+  - python
+  - realism_checklist_v1

--- a/problems/artifact/verification_heavy/json_pointer_rfc6901/workspace/verify.py
+++ b/problems/artifact/verification_heavy/json_pointer_rfc6901/workspace/verify.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Structural verifier for verification_heavy__json_pointer_rfc6901."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+OUTPUT = Path(__file__).parent / "output" / "solution.py"
+
+
+def main() -> int:
+    if not OUTPUT.is_file():
+        print(f"FAIL: output/solution.py not found at {OUTPUT}", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("agent_solution", OUTPUT)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"FAIL: could not import solution.py: {exc}", file=sys.stderr)
+        return 1
+
+    missing = [name for name in ("resolve", "set_at") if not callable(getattr(mod, name, None))]
+    if missing:
+        print(f"FAIL: solution.py missing callable(s): {missing}", file=sys.stderr)
+        return 1
+
+    try:
+        doc = {"a": [1, 2]}
+        if mod.resolve(doc, "/a/0") != 1:
+            print("WARN: resolve(doc, '/a/0') returned unexpected value")
+        mod.set_at(doc, "/a/0", 99)
+        if doc["a"][0] != 99:
+            print("WARN: set_at did not mutate doc as expected")
+    except Exception as exc:
+        print(f"WARN: smoke test raised {type(exc).__name__}: {exc}")
+
+    print("OK: solution.py imports and defines 'resolve' and 'set_at'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/problems/artifact/verification_heavy/semver_compare/grader/hidden.py
+++ b/problems/artifact/verification_heavy/semver_compare/grader/hidden.py
@@ -1,0 +1,100 @@
+"""Hidden grader for verification_heavy__semver_compare.
+
+Contract: ``grade(scratch_dir: Path) -> GradeResult``.
+
+Correctness: compare_semver(a, b) must return -1/0/+1 per SemVer v2.0.0
+precedence across 25 fixed cases.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GradeResult:
+    passed: bool
+    score: float
+    detail: str
+
+
+OUTPUT_REL = "output/solution.py"
+
+
+def _import_module(solution_path: Path):
+    spec = importlib.util.spec_from_file_location("agent_solution", solution_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# (a, b, expected)
+_TESTS: list[tuple[str, str, int]] = [
+    ("1.0.0", "1.0.0", 0),
+    ("1.0.0", "2.0.0", -1),
+    ("2.0.0", "1.0.0", 1),
+    ("1.0.0", "1.1.0", -1),
+    ("1.2.0", "1.10.0", -1),
+    ("1.10.0", "1.2.0", 1),
+    ("1.0.1", "1.0.10", -1),
+    ("0.0.0", "0.0.1", -1),
+    ("1.0.0-alpha", "1.0.0", -1),
+    ("1.0.0", "1.0.0-alpha", 1),
+    ("1.0.0-alpha", "1.0.0-alpha.1", -1),
+    ("1.0.0-alpha.1", "1.0.0-alpha.beta", -1),
+    ("1.0.0-alpha.beta", "1.0.0-beta", -1),
+    ("1.0.0-beta", "1.0.0-beta.2", -1),
+    ("1.0.0-beta.2", "1.0.0-beta.11", -1),
+    ("1.0.0-beta.11", "1.0.0-rc.1", -1),
+    ("1.0.0-rc.1", "1.0.0", -1),
+    ("1.0.0-rc.1", "1.0.0-rc.2", -1),
+    ("1.0.0-alpha", "1.0.0-alpha", 0),
+    ("1.0.0+build.1", "1.0.0+build.2", 0),
+    ("1.0.0+20240101", "1.0.0", 0),
+    ("1.0.0-alpha+a", "1.0.0-alpha+b", 0),
+    ("2.0.0-rc.1", "2.0.0-rc.1", 0),
+    ("1.2.3-4", "1.2.3-5", -1),
+    ("1.0.0-1", "1.0.0-a", -1),
+]
+
+
+def grade(scratch_dir: Path) -> GradeResult:
+    scratch_dir = Path(scratch_dir).resolve()
+    solution_path = scratch_dir / OUTPUT_REL
+
+    if not solution_path.is_file():
+        return GradeResult(False, 0.0, "output artifact not produced (output/solution.py missing)")
+
+    try:
+        mod = _import_module(solution_path)
+    except Exception as exc:
+        tb = traceback.format_exc()
+        return GradeResult(False, 0.0, f"failed to import solution.py: {exc}\n{tb[:400]}")
+
+    if not hasattr(mod, "compare_semver"):
+        return GradeResult(False, 0.0, "solution.py does not define 'compare_semver'")
+
+    fn = mod.compare_semver
+    failures: list[str] = []
+    for a, b, expected in _TESTS:
+        try:
+            got = fn(a, b)
+        except Exception as exc:
+            failures.append(f"  compare_semver({a!r},{b!r}): raised {type(exc).__name__}: {exc}")
+            continue
+        # Normalise to -1/0/+1 to accept any signed int convention.
+        if got is True or got is False or not isinstance(got, int):
+            failures.append(f"  compare_semver({a!r},{b!r}): expected int, got {type(got).__name__} {got!r}")
+            continue
+        norm = -1 if got < 0 else (1 if got > 0 else 0)
+        if norm != expected:
+            failures.append(f"  compare_semver({a!r},{b!r}): expected {expected}, got {got}")
+
+    n_pass = len(_TESTS) - len(failures)
+    if failures:
+        detail = f"{n_pass}/{len(_TESTS)} cases passed. Failures:\n" + "\n".join(failures)
+        return GradeResult(False, round(n_pass / len(_TESTS), 4), detail)
+    return GradeResult(True, 1.0, f"all {len(_TESTS)} cases passed")

--- a/problems/artifact/verification_heavy/semver_compare/grader/reference_output.py
+++ b/problems/artifact/verification_heavy/semver_compare/grader/reference_output.py
@@ -1,0 +1,69 @@
+"""Reference implementation of compare_semver for verification_heavy__semver_compare.
+
+Implements SemVer v2.0.0 precedence rules:
+  - numeric compare on MAJOR.MINOR.PATCH
+  - pre-release lowers precedence vs no pre-release
+  - pre-release identifier compare: numeric < alphanumeric; numerics by int;
+    alphas by ASCII; shorter prefix wins when all shared identifiers equal
+  - build metadata ignored
+"""
+
+
+def _split(version: str) -> tuple[tuple[int, int, int], list[str] | None]:
+    # strip build metadata
+    plus = version.find("+")
+    if plus >= 0:
+        version = version[:plus]
+    # split pre-release
+    dash = version.find("-")
+    if dash >= 0:
+        core, pre = version[:dash], version[dash + 1 :].split(".")
+    else:
+        core, pre = version, None
+    major, minor, patch = (int(x) for x in core.split("."))
+    return (major, minor, patch), pre
+
+
+def _cmp_ident(x: str, y: str) -> int:
+    x_num = x.isdigit()
+    y_num = y.isdigit()
+    if x_num and y_num:
+        xi, yi = int(x), int(y)
+        return -1 if xi < yi else (1 if xi > yi else 0)
+    if x_num and not y_num:
+        return -1  # numeric < alphanumeric
+    if y_num and not x_num:
+        return 1
+    # both alphanumeric: ASCII lex
+    return -1 if x < y else (1 if x > y else 0)
+
+
+def compare_semver(a: str, b: str) -> int:
+    (am, an, ap), apre = _split(a)
+    (bm, bn, bp), bpre = _split(b)
+
+    for x, y in ((am, bm), (an, bn), (ap, bp)):
+        if x < y:
+            return -1
+        if x > y:
+            return 1
+
+    # Core equal. Pre-release rules: presence lowers precedence.
+    if apre is None and bpre is None:
+        return 0
+    if apre is None:
+        return 1
+    if bpre is None:
+        return -1
+
+    # Both have pre-release lists.
+    for xi, yi in zip(apre, bpre):
+        c = _cmp_ident(xi, yi)
+        if c != 0:
+            return c
+    # Shared identifiers equal — shorter list is lower.
+    if len(apre) < len(bpre):
+        return -1
+    if len(apre) > len(bpre):
+        return 1
+    return 0

--- a/problems/artifact/verification_heavy/semver_compare/prompt.md
+++ b/problems/artifact/verification_heavy/semver_compare/prompt.md
@@ -1,0 +1,70 @@
+# Task: Implement a Semantic Versioning comparator
+
+Our release-pipeline tooling currently sorts tags alphabetically, which means
+`v1.10.0` sorts before `v1.2.0` and we keep cutting hotfixes from the wrong
+base. We want one reference function that does SemVer comparison per
+[semver.org v2.0.0](https://semver.org/) so all the downstream scripts can call
+into the same logic.
+
+Implement `compare_semver(a: str, b: str) -> int` that returns:
+
+- `-1` if `a` is a lower version than `b`,
+- ` 0` if they are equal,
+- `+1` if `a` is a higher version.
+
+## SemVer rules (subset we need)
+
+A valid version string has three dot-separated numeric components:
+`MAJOR.MINOR.PATCH` (each a non-negative integer, no leading zeros except
+literal `0`). Optionally followed by:
+
+- A **pre-release** tag, introduced by `-`, consisting of one or more
+  dot-separated identifiers. An identifier is either numeric
+  (`[0-9]+`, no leading zeros) or alphanumeric (`[0-9A-Za-z-]+` with at least
+  one non-digit). Example: `1.0.0-alpha.1`, `1.0.0-rc.2`.
+- **Build metadata**, introduced by `+`, ignored for comparison. Example:
+  `1.0.0+20240101`.
+
+### Precedence (what "lower" and "higher" mean)
+
+1. Compare MAJOR, then MINOR, then PATCH as integers.
+2. A version **with** a pre-release tag is **lower** than the same version
+   **without** one. So `1.0.0-alpha < 1.0.0`.
+3. If both have pre-release tags, compare identifiers left to right:
+   - Numeric identifiers compare as integers.
+   - Alphanumeric identifiers compare lexicographically (ASCII).
+   - Numeric identifiers are always **lower** than alphanumeric ones.
+   - If all shared identifiers are equal, the shorter list is lower.
+4. Build metadata (`+...`) is ignored in comparisons. So `1.0.0+a == 1.0.0+b`.
+
+You may assume inputs are syntactically valid — no error handling required.
+
+## Examples
+
+| a | b | result |
+|---|---|--------|
+| `1.0.0` | `1.0.0` | `0` |
+| `1.0.0` | `2.0.0` | `-1` |
+| `1.10.0` | `1.2.0` | `+1` |
+| `1.0.0-alpha` | `1.0.0` | `-1` |
+| `1.0.0-alpha` | `1.0.0-alpha.1` | `-1` |
+| `1.0.0-alpha.1` | `1.0.0-alpha.beta` | `-1` |
+| `1.0.0-rc.1` | `1.0.0-rc.2` | `-1` |
+| `1.0.0+build.1` | `1.0.0+build.2` | `0` |
+| `1.0.0-alpha+a` | `1.0.0-alpha+b` | `0` |
+
+## Output
+
+Write your implementation to `output/solution.py`:
+
+```python
+def compare_semver(a: str, b: str) -> int:
+    ...
+```
+
+Standard library only. No third-party semver packages.
+
+## Verification
+
+Run `python verify.py` to check the structural shape of your output. The hidden
+grader runs 25 comparison cases.

--- a/problems/artifact/verification_heavy/semver_compare/task.yaml
+++ b/problems/artifact/verification_heavy/semver_compare/task.yaml
@@ -1,0 +1,18 @@
+instance_id: verification_heavy__semver_compare
+category: verification_heavy
+difficulty: medium
+problem_statement: prompt.md
+workspace_dir: workspace/
+output_artifact: output/solution.py
+hidden_grader: grader/hidden.py
+reference_output: grader/reference_output.py
+execution_budget:
+  max_code_runs: 10
+  max_wall_seconds: 120
+tags:
+  - verification_heavy
+  - semver
+  - parsing
+  - comparison
+  - python
+  - realism_checklist_v1

--- a/problems/artifact/verification_heavy/semver_compare/workspace/verify.py
+++ b/problems/artifact/verification_heavy/semver_compare/workspace/verify.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Structural verifier for verification_heavy__semver_compare."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+OUTPUT = Path(__file__).parent / "output" / "solution.py"
+
+
+def main() -> int:
+    if not OUTPUT.is_file():
+        print(f"FAIL: output/solution.py not found at {OUTPUT}", file=sys.stderr)
+        return 1
+
+    spec = importlib.util.spec_from_file_location("agent_solution", OUTPUT)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"FAIL: could not import solution.py: {exc}", file=sys.stderr)
+        return 1
+
+    if not hasattr(mod, "compare_semver"):
+        print("FAIL: solution.py does not define 'compare_semver'", file=sys.stderr)
+        return 1
+
+    if not callable(mod.compare_semver):
+        print("FAIL: 'compare_semver' is not callable", file=sys.stderr)
+        return 1
+
+    try:
+        r = mod.compare_semver("1.0.0", "1.0.0")
+        if r != 0:
+            print(f"WARN: compare_semver('1.0.0','1.0.0') returned {r}, expected 0")
+    except Exception as exc:
+        print(f"WARN: compare_semver raised {type(exc).__name__}: {exc}")
+
+    print("OK: solution.py imports and defines 'compare_semver'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sets/seed-v2.txt
+++ b/sets/seed-v2.txt
@@ -12,7 +12,7 @@
 #   enumeration:         2 easy / 3 medium / 3 hard  (target met, #132)
 #   iterative_numerical: 2 easy / 3 medium / 3 hard  (target met, #133)
 #   stateful_reasoning:  2 easy / 3 medium / 3 hard  (target met, #134)
-#   verification_heavy:  1 easy / 1 medium / 0 hard  (target 2/3/3)
+#   verification_heavy:  2 easy / 3 medium / 3 hard  (target met, #135)
 
 # algorithmic
 algorithmic__makespan_scheduling
@@ -66,4 +66,10 @@ stateful_reasoning__rate_limiter_replay
 
 # verification_heavy
 verification_heavy__parse_iso_duration
+verification_heavy__csv_dialect_parser
 verification_heavy__lru_cache_impl
+verification_heavy__semver_compare
+verification_heavy__expression_evaluator
+verification_heavy__cron_next_fire
+verification_heavy__json_pointer_rfc6901
+verification_heavy__iban_validator


### PR DESCRIPTION
Closes #135

Part of epic #136. Brings `verification_heavy` from 1E/1M/0H to 2E/3M/3H by adding 6 new tasks.

## What changed

New tasks (all stdlib-only for agent, `realism_checklist_v1` tagged):

| Slug | Difficulty | Theme |
|------|-----------|-------|
| `csv_dialect_parser` | easy | RFC 4180 single-line CSV parser |
| `semver_compare` | medium | SemVer v2.0.0 precedence comparator |
| `expression_evaluator` | medium | Recursive-descent arithmetic evaluator (no `eval`) |
| `cron_next_fire` | hard | Next-fire datetime for 5-field cron expressions (Vixie DOM/DOW OR semantics, leap years, month rollover) |
| `json_pointer_rfc6901` | hard | Resolve + set_at for JSON Pointer with `~0`/`~1` escaping and array `-` append |
| `iban_validator` | hard | ISO 13616 structural + mod-97 checksum (8 countries) |

Also updates `sets/seed-v2.txt`: header counts flipped to `2 easy / 3 medium / 3 hard (target met, #135)` and the 6 new instance_ids appended under the `# verification_heavy` block.

## Invariants

- v1 realism checklist tag on every new `task.yaml`
- Agent solutions: stdlib only (no pandas/numpy/sklearn/scipy needed for any of these six)
- No generators used in this set (all static fixture-free)
- No schema/grader/network/GPU/viz changes
- Arm-neutral (parse + verify tasks, solvable in either arm)

## Smoke

- `tools/verify_graders.py`: all 8 verification_heavy references grade PASS
- `pytest tests/test_artifact_loader.py tests/test_verify_graders.py`: 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)