### PR TITLE
fix(#146): move shell runners + summarize_results.py into scripts/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,6 @@ results_swebench/_analysis/<run_id>/
 
 ## Legacy Scripts
 
-`run_prevalidation.sh`, `run_mcp_integration_test.sh` — original fixture-based benchmarks (5-task suite in `fixtures/`). Still valid as a fast smoke test.
+`scripts/run_prevalidation.sh`, `scripts/run_mcp_integration_test.sh` — original fixture-based benchmarks (5-task suite in `fixtures/`). Still valid as a fast smoke test.
 
-`run_swebench.sh` — earlier shell-based SWE-bench runner (single instance, hardcoded problem text). Superseded by `python -m swebench run` but retained as a reference.
+`scripts/run_swebench.sh` — earlier shell-based SWE-bench runner (single instance, hardcoded problem text). Superseded by `python -m swebench run` but retained as a reference.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Three benchmark modes, each targeting a different evaluation surface:
 |---|---|---|---|
 | **SWE-bench** | `python -m swebench run` | `problems/swe/` YAML files | Test suite pass/fail |
 | **Artifact-graded** | `python -m swebench artifact run` | `problems/artifact/` YAML files | Hidden Python grader |
-| **Fixture (legacy)** | `./run_prevalidation.sh` | `fixtures/myapp/` | Oracle files in `oracle/` |
+| **Fixture (legacy)** | `./scripts/run_prevalidation.sh` | `fixtures/myapp/` | Oracle files in `oracle/` |
 
 ---
 
@@ -166,8 +166,8 @@ The "only code" approach was **2× faster and 32% cheaper** overall.
 
 **Running:**
 ```bash
-./run_prevalidation.sh          # baseline vs constrained
-./run_mcp_integration_test.sh   # only-code (MCP) arm
+./scripts/run_prevalidation.sh          # baseline vs constrained
+./scripts/run_mcp_integration_test.sh   # only-code (MCP) arm
 ```
 
 Results are written as JSONL to `results/` and `results_mcp/`. Grade against `oracle/`.
@@ -194,6 +194,5 @@ results/                   # Legacy baseline run logs (JSONL)
 results_mcp/               # Legacy only-code run logs (JSONL)
 exec-server.bundle.mjs     # MCP server exposing execute_code (fast startup ~130ms)
 mcp-config.json            # MCP server config for --mcp-config CLI flag
-run_prevalidation.sh       # Legacy baseline benchmark runner
-run_mcp_integration_test.sh  # Legacy only-code benchmark runner
+scripts/                   # Shell runners + summarize_results.py
 ```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,7 @@ tool calls. Measure whether this reduces round-trips and improves output quality
 
 Simulated Code Mode using `claude -p --tools Bash,Write` against two fixtures: a synthetic myapp
 codebase and the real psf/requests library. 5 tasks, two arms each (baseline all-tools vs.
-constrained). Full methodology in `run_prevalidation.sh` and `run_prevalidation_requests.sh`.
+constrained). Full methodology in `scripts/run_prevalidation.sh` and `scripts/run_prevalidation_requests.sh`.
 
 ### Methodology
 

--- a/scripts/run_mcp_integration_test.sh
+++ b/scripts/run_mcp_integration_test.sh
@@ -7,9 +7,10 @@ set -euo pipefail
 
 CLAUDE=/home/vscode/.vscode-server/extensions/anthropic.claude-code-2.1.109-linux-x64/resources/native-binary/claude
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-FIXTURE_DIR="$SCRIPT_DIR/fixtures"
-RESULTS_DIR="$SCRIPT_DIR/results_mcp"
-MCP_CONFIG="$SCRIPT_DIR/mcp-config.json"  # points to exec-server.bundle.mjs (bundled for fast startup)
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIXTURE_DIR="$REPO_ROOT/fixtures"
+RESULTS_DIR="$REPO_ROOT/results_mcp"
+MCP_CONFIG="$REPO_ROOT/mcp-config.json"  # points to exec-server.bundle.mjs (bundled for fast startup)
 mkdir -p "$RESULTS_DIR"
 
 # Common flags for clean, reproducible runs:

--- a/scripts/run_prevalidation.sh
+++ b/scripts/run_prevalidation.sh
@@ -6,8 +6,8 @@
 set -euo pipefail
 
 CLAUDE=/home/vscode/.vscode-server/extensions/anthropic.claude-code-2.1.109-linux-x64/resources/native-binary/claude
-FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures" && pwd)"
-RESULTS_DIR="$(cd "$(dirname "$0")" && pwd)/results"
+FIXTURE_DIR="$(cd "$(dirname "$0")/../fixtures" && pwd)"
+RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/results"
 mkdir -p "$RESULTS_DIR"
 
 # Common flags for clean, reproducible benchmark runs:

--- a/scripts/run_prevalidation_requests.sh
+++ b/scripts/run_prevalidation_requests.sh
@@ -11,8 +11,8 @@
 set -euo pipefail
 
 CLAUDE=/home/vscode/.vscode-server/extensions/anthropic.claude-code-2.1.109-linux-x64/resources/native-binary/claude
-FIXTURE_DIR="$(cd "$(dirname "$0")/fixtures_requests" && pwd)"
-RESULTS_DIR="$(cd "$(dirname "$0")" && pwd)/results_requests"
+FIXTURE_DIR="$(cd "$(dirname "$0")/../fixtures_requests" && pwd)"
+RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/results_requests"
 mkdir -p "$RESULTS_DIR"
 
 COMMON_FLAGS="--output-format stream-json --verbose --no-session-persistence --dangerously-skip-permissions --system-prompt You are a helpful assistant."

--- a/scripts/run_swebench.sh
+++ b/scripts/run_swebench.sh
@@ -16,15 +16,16 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROBLEMS_FILE="${1:-${SCRIPT_DIR}/swebench_problems.txt}"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROBLEMS_FILE="${1:-${REPO_ROOT}/swebench_problems.txt}"
 RUNS_PER_ARM="${2:-1}"
 if [[ ! "$RUNS_PER_ARM" =~ ^[1-9][0-9]*$ ]]; then
   echo "ERROR: runs_per_arm must be a positive integer, got: '$RUNS_PER_ARM'" >&2
   exit 1
 fi
-RESULTS_DIR="${SCRIPT_DIR}/results_swebench"
+RESULTS_DIR="${REPO_ROOT}/results_swebench"
 CLONE_BASE="/tmp/swebench"
-MCP_CONFIG="${SCRIPT_DIR}/mcp-config.json"
+MCP_CONFIG="${REPO_ROOT}/mcp-config.json"
 
 mkdir -p "$RESULTS_DIR" "$CLONE_BASE"
 
@@ -74,7 +75,7 @@ run_arm() {
   git -C "$REPO_DIR" clean -fd --quiet 2>/dev/null
 
   # Apply test-only patch (SWE-bench style: agent sees failing tests, must fix implementation)
-  local TEST_PATCH="${SCRIPT_DIR}/patches/${INSTANCE}_tests.patch"
+  local TEST_PATCH="${REPO_ROOT}/patches/${INSTANCE}_tests.patch"
   if [[ -f "$TEST_PATCH" ]]; then
     git -C "$REPO_DIR" apply "$TEST_PATCH" 2>/dev/null \
       && echo "  [${ARM} run ${RUN_IDX}] Applied test patch." | tee -a "$RESULTS_DIR/run.log" \

--- a/scripts/summarize_results.py
+++ b/scripts/summarize_results.py
@@ -10,7 +10,10 @@ import statistics
 import sys
 from collections import defaultdict
 
-RESULTS_DIR = os.path.join(os.path.dirname(__file__), "results_swebench")
+RESULTS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "results_swebench",
+)
 
 _RUN_RE = re.compile(r"^(?P<id>.+)_(?P<arm>baseline|onlycode)_run(?P<run>\d+)$")
 


### PR DESCRIPTION
Closes #146

## What changed

Consolidated the four `run_*.sh` scripts and `summarize_results.py` under a new `scripts/` directory:

- `run_swebench.sh`, `run_prevalidation.sh`, `run_prevalidation_requests.sh`, `run_mcp_integration_test.sh`, `summarize_results.py` → `scripts/`
- Fixed up `SCRIPT_DIR`-relative paths so repo-root siblings (`swebench_problems.txt`, `mcp-config.json`, `fixtures/`, `fixtures_requests/`, `patches/`, `results_*/`) still resolve correctly from the new one-level-deeper location.
- Fixed `summarize_results.py` so `RESULTS_DIR` uses `os.path.dirname(os.path.dirname(os.path.abspath(__file__)))` to resolve `results_swebench/` at repo root.
- Updated `README.md`, `CLAUDE.md`, and `docs/ROADMAP.md` to point at `./scripts/run_*.sh`.

## Tier / approach

Tier 1 — purely mechanical path arithmetic. Single Coder; no architecture decisions.

## Acceptance criteria

- [x] `./scripts/run_prevalidation.sh` and `./scripts/run_swebench.sh` execute from repo root with no behavior change.
- [x] `python scripts/summarize_results.py` still finds `results_swebench/`.

## Sequencing note (per issue)

Landed before #147 (fixtures→data). After #147 lands, the `../fixtures` refs in these scripts will need a second touch to `../data/fixtures`.

Co-Authored-By: Claude Code <noreply@anthropic.com>