### PR TITLE
fix(#149): consolidate results*/ and logs/ under runs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,13 @@
 .venv/
 venv/
-results/
-results_mcp/
-results_requests/
-results_swebench/
-results_swebench/_analysis/
-results_artifact/
+runs/*
+!runs/logs/
+runs/logs/*
+!runs/logs/.gitkeep
 __pycache__/
 *.pyc
 .pytest_cache/
 data/fixtures_requests/
 node_modules/
-logs/session.jsonl
 exec_server/dist/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Instance ID format: `<category>__<slug>` (two underscores). Category must match 
 ## Analysis Sidecar Layout
 
 ```
-results_swebench/_analysis/<run_id>/
+runs/swebench/_analysis/<run_id>/
   mechanical/          # Stage 1: JSON per JSONL log (mechanical flags + metrics)
   subagents/           # Stage 2: JSON per flagged log (Claude-classified findings)
   synthesizer.json     # Stage 3: full synthesizer output before merge into patterns.json

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ python -m swebench analyze pathology --run-id my-run
 python -m swebench analyze pathology --concurrency 4
 ```
 
-Results go to `results_swebench/` keyed by `instance_id`. Analysis sidecars go to `results_swebench/_analysis/<run_id>/`.
+Results go to `runs/swebench/` keyed by `instance_id`. Analysis sidecars go to `runs/swebench/_analysis/<run_id>/`.
 
 ### OverlayFS Cache
 
@@ -136,7 +136,7 @@ python -m swebench artifact run --runs 3
 python -m swebench artifact run --no-resume
 ```
 
-Results go to `results_artifact/`. Task schema is documented in [`docs/SCHEMA_ARTIFACT.md`](docs/SCHEMA_ARTIFACT.md). Architecture decisions in [`docs/adr-0001-artifact-mode.md`](docs/adr-0001-artifact-mode.md).
+Results go to `runs/artifact/`. Task schema is documented in [`docs/SCHEMA_ARTIFACT.md`](docs/SCHEMA_ARTIFACT.md). Architecture decisions in [`docs/adr-0001-artifact-mode.md`](docs/adr-0001-artifact-mode.md).
 
 ---
 
@@ -170,7 +170,7 @@ The "only code" approach was **2× faster and 32% cheaper** overall.
 ./scripts/run_mcp_integration_test.sh   # only-code (MCP) arm
 ```
 
-Results are written as JSONL to `results/` and `results_mcp/`. Grade against `data/oracle/`.
+Results are written as JSONL to `runs/default/` and `runs/mcp/`. Grade against `data/oracle/`.
 
 ---
 
@@ -181,8 +181,13 @@ swebench/                  # Python harness package (python -m swebench)
 problems/
   swe/                     # SWE-bench problem YAML files (organized by set)
   artifact/                # Artifact-graded task trees (organized by category)
-results_swebench/          # SWE-bench run outputs (JSONL, keyed by instance_id)
-results_artifact/          # Artifact run outputs
+runs/                      # All run outputs (gitignored)
+  swebench/                #   SWE-bench run outputs (JSONL, keyed by instance_id)
+  artifact/                #   Artifact run outputs
+  mcp/                     #   Legacy only-code (MCP) run logs (JSONL)
+  requests/                #   Requests-fixture run logs (JSONL)
+  default/                 #   Legacy baseline run logs (JSONL)
+  logs/                    #   Session logs (e.g. session.jsonl)
 docs/
   SCHEMA_ARTIFACT.md       # Normative artifact task schema
   adr-0001-artifact-mode.md
@@ -192,8 +197,6 @@ data/                      # Legacy fixture/oracle reference files (prevalidatio
   fixtures_requests/       #   Alternate fixture set (HTTP/requests-based tasks; gitignored)
   oracle/                  #   Ground-truth answers for legacy fixture grading
   oracle_requests/         #   Ground-truth answers for requests-fixture grading
-results/                   # Legacy baseline run logs (JSONL)
-results_mcp/               # Legacy only-code run logs (JSONL)
 exec_server/               # MCP exec-server stack (JS + Python kernel helpers)
   exec-server.js           #   MCP stdio entry point
   bridge-server.js         #   Unix-socket bridge for sub-MCP passthrough

--- a/docs/adr-0002-arm-collapse-gate.md
+++ b/docs/adr-0002-arm-collapse-gate.md
@@ -28,8 +28,8 @@ The **arm-collapse smoke gate** is a three-signal check run after a single
 `artifact run --filter data_processing__p95_latency_easy --arms both` completes.
 The run must produce two agent JSONL logs, one per arm:
 
-- `results_artifact/<instance_id>/code_only/run0/agent.jsonl`
-- `results_artifact/<instance_id>/tool_rich/run0/agent.jsonl`
+- `runs/artifact/<instance_id>/code_only/run0/agent.jsonl`
+- `runs/artifact/<instance_id>/tool_rich/run0/agent.jsonl`
 
 A small script at `tools/arm_collapse_check.py` (slice #95 ships a stub; full
 implementation may land in #96 alongside `verify_graders.py`) computes the

--- a/scripts/run_mcp_integration_test.sh
+++ b/scripts/run_mcp_integration_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # MCP Integration Test
 # Runs 5 tasks using only the execute_code MCP tool (codebox).
-# Results written to results_mcp/
+# Results written to runs/mcp/
 
 set -euo pipefail
 
@@ -9,7 +9,7 @@ CLAUDE=/home/vscode/.vscode-server/extensions/anthropic.claude-code-2.1.109-linu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 FIXTURE_DIR="$REPO_ROOT/data/fixtures"
-RESULTS_DIR="$REPO_ROOT/results_mcp"
+RESULTS_DIR="$REPO_ROOT/runs/mcp"
 MCP_CONFIG="$REPO_ROOT/mcp-config.json"  # points to exec-server.bundle.mjs (bundled for fast startup)
 mkdir -p "$RESULTS_DIR"
 

--- a/scripts/run_prevalidation.sh
+++ b/scripts/run_prevalidation.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Pre-M1 hypothesis validation
 # Runs 5 tasks in two arms: baseline (all tools) vs constrained (Bash only)
-# Results written to results/
+# Results written to runs/default/
 
 set -euo pipefail
 
 CLAUDE=/home/vscode/.vscode-server/extensions/anthropic.claude-code-2.1.109-linux-x64/resources/native-binary/claude
 FIXTURE_DIR="$(cd "$(dirname "$0")/../data/fixtures" && pwd)"
-RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/results"
+RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/runs/default"
 mkdir -p "$RESULTS_DIR"
 
 # Common flags for clean, reproducible benchmark runs:

--- a/scripts/run_prevalidation_requests.sh
+++ b/scripts/run_prevalidation_requests.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 CLAUDE=/home/vscode/.vscode-server/extensions/anthropic.claude-code-2.1.109-linux-x64/resources/native-binary/claude
 FIXTURE_DIR="$(cd "$(dirname "$0")/../data/fixtures_requests" && pwd)"
-RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/results_requests"
+RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/runs/requests"
 mkdir -p "$RESULTS_DIR"
 
 COMMON_FLAGS="--output-format stream-json --verbose --no-session-persistence --dangerously-skip-permissions --system-prompt You are a helpful assistant."

--- a/scripts/run_swebench.sh
+++ b/scripts/run_swebench.sh
@@ -23,7 +23,7 @@ if [[ ! "$RUNS_PER_ARM" =~ ^[1-9][0-9]*$ ]]; then
   echo "ERROR: runs_per_arm must be a positive integer, got: '$RUNS_PER_ARM'" >&2
   exit 1
 fi
-RESULTS_DIR="${REPO_ROOT}/results_swebench"
+RESULTS_DIR="${REPO_ROOT}/runs/swebench"
 CLONE_BASE="/tmp/swebench"
 MCP_CONFIG="${REPO_ROOT}/mcp-config.json"
 

--- a/scripts/summarize_results.py
+++ b/scripts/summarize_results.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Summarize SWE-bench experiment results from results_swebench/."""
+"""Summarize SWE-bench experiment results from runs/swebench/."""
 
 import csv
 import json
@@ -12,7 +12,8 @@ from collections import defaultdict
 
 RESULTS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "results_swebench",
+    "runs",
+    "swebench",
 )
 
 _RUN_RE = re.compile(r"^(?P<id>.+)_(?P<arm>baseline|onlycode)_run(?P<run>\d+)$")

--- a/swebench/analyze/registry.py
+++ b/swebench/analyze/registry.py
@@ -3,7 +3,7 @@
 ``patterns.json`` is the canonical pathology vocabulary for epic #62: it
 collects every distinct pathology ``candidate_id`` and its human-readable
 description. Tracking metadata (frequency, arm distribution, evidence refs)
-lives in the per-run analysis output under ``results_swebench/_analysis/``,
+lives in the per-run analysis output under ``runs/swebench/_analysis/``,
 not here. This module exposes:
 
 - :func:`load_patterns` — read + validate an existing file.

--- a/swebench/analyze/run.py
+++ b/swebench/analyze/run.py
@@ -4,7 +4,7 @@ Pipeline overview (epic #62):
 
 - **Stage 1 (mechanical).** For every ``*_run*.jsonl`` under ``--results-dir``,
   call :func:`swebench.analyze.extractor.extract` and persist the result as a
-  sidecar JSON under ``results_swebench/_analysis/<run_id>/mechanical/``.
+  sidecar JSON under ``runs/swebench/_analysis/<run_id>/mechanical/``.
   Produce a ``triage.json`` listing the top ``TRIAGE_TOP_PERCENTILE`` of runs
   (via :func:`swebench.analyze.extractor.triage_rank`) — those are the ones
   fed to Stage 2.
@@ -12,7 +12,7 @@ Pipeline overview (epic #62):
   ``claude -p`` command using :func:`swebench.harness.find_claude_binary` and
   :func:`swebench.harness.make_isolated_claude_config`, compressed log body +
   the system prompt at ``subagent_prompt.md``. Write the subagent's JSON reply
-  to ``results_swebench/_analysis/<run_id>/subagents/<log_ref>.json``.
+  to ``runs/swebench/_analysis/<run_id>/subagents/<log_ref>.json``.
   Parallel fan-out follows the ``swebench/add.py`` template: ``_print_lock``
   serialises ``click.echo`` and ``_process_one`` returns ``(id, ok, msg)``.
 - **Stage 3 (synthesize).** Read every Stage 2 subagent sidecar, pass the
@@ -66,7 +66,7 @@ def _echo(msg: str, *, err: bool = False) -> None:
 
 
 #: Regex to split a run filename stem into (instance_id, arm, run_idx).
-#: SWE-bench layout: ``results_swebench/<instance>_<arm>_run<N>.jsonl``.
+#: SWE-bench layout: ``runs/swebench/<instance>_<arm>_run<N>.jsonl``.
 _RUN_STEM_RE = re.compile(r"^(?P<instance>.+)_(?P<arm>baseline|onlycode)_run(?P<run>\d+)$")
 
 #: Valid artifact-arm directory names (matches ``VALID_ARMS`` in registry.py).
@@ -672,8 +672,8 @@ def register_pathology_command(analyze_command: click.Group) -> None:
         type=click.Path(exists=True, file_okay=False, path_type=Path),
         default=None,
         help=(
-            "Path to results directory (default: results_swebench/). "
-            "Pass results_artifact/ for the artifact benchmark; layouts "
+            "Path to results directory (default: runs/swebench/). "
+            "Pass runs/artifact/ for the artifact benchmark; layouts "
             "(flat SWE-bench, nested <task>/<arm>/run<N>/agent.jsonl) are "
             "auto-detected."
         ),
@@ -722,7 +722,7 @@ def register_pathology_command(analyze_command: click.Group) -> None:
         if concurrency < 1:
             raise click.UsageError("--concurrency must be >= 1.")
 
-        rdir = Path(results_dir) if results_dir else (repo_root() / "results_swebench")
+        rdir = Path(results_dir) if results_dir else (repo_root() / "runs" / "swebench")
         if not rdir.is_dir():
             _echo(f"ERROR: results directory not found: {rdir}", err=True)
             sys.exit(1)

--- a/swebench/analyze/summary.py
+++ b/swebench/analyze/summary.py
@@ -91,7 +91,7 @@ def _register(analyze_command: click.Group) -> None:
         "--results-dir",
         type=click.Path(exists=True, file_okay=False),
         default=None,
-        help="Path to results directory (default: auto-detect results_swebench/).",
+        help="Path to results directory (default: auto-detect runs/swebench/).",
     )
     @click.option(
         "--out",
@@ -105,7 +105,7 @@ def _register(analyze_command: click.Group) -> None:
         if results_dir:
             rdir = Path(results_dir)
         else:
-            rdir = repo_root() / "results_swebench"
+            rdir = repo_root() / "runs" / "swebench"
 
         if not rdir.is_dir():
             click.echo(f"ERROR: Results directory not found: {rdir}", err=True)

--- a/swebench/artifact_cli.py
+++ b/swebench/artifact_cli.py
@@ -6,7 +6,7 @@ Additive-only: does not touch the existing ``run`` / ``add`` / ``analyze`` /
 Subcommands:
 
 - ``artifact run``     — execute code_only / tool_rich arms against artifact tasks.
-- ``artifact analyze`` — summarise ``results_artifact/`` as a flat table + aggregates.
+- ``artifact analyze`` — summarise ``runs/artifact/`` as a flat table + aggregates.
 - ``artifact verify``  — placeholder for the ``tools/verify_graders.py``
   functionality shipped in a later slice (#96). Declared here so the command
   namespace exists; invoking it prints a pointer message and exits 2.
@@ -65,7 +65,7 @@ def artifact_group() -> None:
     "output_dir",
     type=click.Path(file_okay=False, dir_okay=True, resolve_path=False),
     default=None,
-    help="Directory for result files [default: <repo>/results_artifact/].",
+    help="Directory for result files [default: <repo>/runs/artifact/].",
 )
 @click.option(
     "--resume/--no-resume",
@@ -107,7 +107,7 @@ def artifact_run_command(
 
     root = repo_root()
     tasks_root = Path(tasks_dir) if tasks_dir else (root / "problems" / "artifact")
-    results_dir = Path(output_dir) if output_dir else (root / "results_artifact")
+    results_dir = Path(output_dir) if output_dir else (root / "runs" / "artifact")
 
     filter_set: set[str] | None = None
     if filter_ids:
@@ -221,7 +221,7 @@ def _collect_artifact_rows(
     if not results_dir.is_dir():
         return rows
 
-    # results_artifact/<instance_id>/<arm>/run<N>/
+    # runs/artifact/<instance_id>/<arm>/run<N>/
     for instance_dir in sorted(p for p in results_dir.iterdir() if p.is_dir()):
         instance_id = instance_dir.name
         # Skip the analysis sidecar used by SWE-bench mode if it ever leaks
@@ -397,7 +397,7 @@ def _write_csv(rows: list[dict[str, Any]], out_path: Path) -> None:
     "results_dir",
     type=click.Path(file_okay=False, dir_okay=True, resolve_path=False),
     default=None,
-    help="Directory with artifact run results [default: <repo>/results_artifact/].",
+    help="Directory with artifact run results [default: <repo>/runs/artifact/].",
 )
 @click.option(
     "--tasks-dir",
@@ -418,9 +418,9 @@ def artifact_analyze_command(
     tasks_dir: str | None,
     out_path: str | None,
 ) -> None:
-    """Summarise results_artifact/ as a flat table + aggregates."""
+    """Summarise runs/artifact/ as a flat table + aggregates."""
     root = repo_root()
-    rdir = Path(results_dir) if results_dir else (root / "results_artifact")
+    rdir = Path(results_dir) if results_dir else (root / "runs" / "artifact")
     tdir = Path(tasks_dir) if tasks_dir else (root / "problems" / "artifact")
 
     if not rdir.is_dir():

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -585,7 +585,7 @@ def _cleanup_stale_overlays(
     "output_dir",
     type=click.Path(file_okay=False, dir_okay=True, resolve_path=False),
     default=None,
-    help="Directory for result files [default: <repo>/results_swebench/]. Created if it does not exist.",
+    help="Directory for result files [default: <repo>/runs/swebench/]. Created if it does not exist.",
 )
 @click.option(
     "--resume/--no-resume",
@@ -618,7 +618,7 @@ def run_command(
 
     root = repo_root()
     problems_dir = root / "problems" / "swe"
-    results_dir = Path(output_dir) if output_dir else root / "results_swebench"
+    results_dir = Path(output_dir) if output_dir else root / "runs" / "swebench"
     mcp_config_path = str(root / "mcp-config.json")
     clone_base = "/tmp/swebench"
 

--- a/tests/test_analyze_artifact_parity.py
+++ b/tests/test_analyze_artifact_parity.py
@@ -3,7 +3,7 @@
 Before this change, ``_discover_logs`` only globbed flat ``*_run*.jsonl``
 files and ``_parse_log_ref`` only recognised the SWE-bench filename
 shape. Artifact logs live at
-``results_artifact/<task>/<arm>/run<N>/agent.jsonl`` and were silently
+``runs/artifact/<task>/<arm>/run<N>/agent.jsonl`` and were silently
 dropped.
 
 These tests exercise:


### PR DESCRIPTION
Closes #149

## What changed

Replace the five sibling output directories plus repo-root `logs/` with a single `runs/` parent:

| Before | After |
|---|---|
| `results/` | `runs/default/` |
| `results_swebench/` | `runs/swebench/` |
| `results_mcp/` | `runs/mcp/` |
| `results_requests/` | `runs/requests/` |
| `results_artifact/` | `runs/artifact/` |
| `logs/` | `runs/logs/` |

Updated sites:
- Python CLI defaults: `swebench/run.py`, `swebench/artifact_cli.py`, `swebench/analyze/run.py`, `swebench/analyze/summary.py`
- Docstrings/comments: `swebench/analyze/registry.py`, `tests/test_analyze_artifact_parity.py`
- Scripts: `scripts/run_swebench.sh`, `scripts/run_prevalidation.sh`, `scripts/run_prevalidation_requests.sh`, `scripts/run_mcp_integration_test.sh`, `scripts/summarize_results.py`
- `.gitignore`: collapsed five `results*/` entries into `runs/*` (preserving `runs/logs/.gitkeep`)
- `README.md` + `CLAUDE.md` directory-layout and analysis-sidecar references
- `docs/adr-0002-arm-collapse-gate.md` example paths
- Moved `logs/.gitkeep` to `runs/logs/.gitkeep`

## Migration note

**Collaborators with pre-existing local result dirs need to migrate after pulling:**
```bash
mkdir -p runs
for d in results results_swebench results_mcp results_requests results_artifact; do
  [ -d "$d" ] && mv "$d" "runs/${d#results_}"
done
# Note: 'results/' → 'runs/default/' (rename)
[ -d runs/results ] && mv runs/results runs/default
```

## Tier / approach

Tier 2 — mechanical string replacement; all sites well-enumerated in the issue. Single Coder, no architecture decisions required.

## Acceptance criteria

- [x] `python -m swebench run` writes to `runs/swebench/` (default flipped; `--help` confirmed)
- [x] `python -m swebench artifact run` writes to `runs/artifact/` (default flipped; `--help` confirmed)
- [x] `python -m swebench analyze ...` auto-detects `runs/swebench/` when no `--results-dir` given
- [x] `scripts/summarize_results.py` reads from `runs/swebench/`

## Validation

- All non-preexisting-failure tests pass (223 passed; 12 `test_analyze_registry.py` failures pre-exist on base branch `epic/144-flatten-root` and are unrelated)
- CLI help strings render the new `runs/` defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)