### PR TITLE
chore: ignore results*/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ __pycache__/
 data/fixtures_requests/
 node_modules/
 exec_server/dist/
+results*/
 


### PR DESCRIPTION
## Summary
- Add `results*/` to `.gitignore` so stray top-level `results*` directories (e.g. `results/`, `results_old/`) don't get committed.

## Test plan
- [x] `.gitignore` diff is a single-line addition.