### PR TITLE
fix(#159): feat(artifact): add bash_only arm — mini-SWE-agent control

### DIFF
--- a/swebench/artifact_cli.py
+++ b/swebench/artifact_cli.py
@@ -47,10 +47,10 @@ def artifact_group() -> None:
 )
 @click.option(
     "--arms",
-    type=click.Choice(["code_only", "tool_rich", "both"]),
-    default="both",
+    type=click.Choice(["code_only", "tool_rich", "bash_only", "both", "all"]),
+    default="all",
     show_default=True,
-    help="Which arms to run.",
+    help="Which arms to run. 'all' runs every arm. 'both' is a deprecated alias for 'all'.",
 )
 @click.option(
     "--runs",
@@ -134,7 +134,7 @@ def artifact_run_command(
         raise SystemExit(1)
 
     arm_list: list[str]
-    if arms == "both":
+    if arms in ("both", "all"):
         arm_list = list(ARMS)
     else:
         arm_list = [arms]

--- a/swebench/artifact_run.py
+++ b/swebench/artifact_run.py
@@ -40,7 +40,7 @@ _BLOCKED_BUILTINS = (
     "TeamCreate,TeamDelete,TodoWrite,ToolSearch,WebFetch,WebSearch,Write"
 )
 
-ARMS = ("code_only", "tool_rich")
+ARMS = ("code_only", "tool_rich", "bash_only")
 
 
 def run_dir_for(results_dir: Path, instance_id: str, arm: str, run_idx: int) -> Path:
@@ -93,6 +93,11 @@ def _build_tools_flags(arm: str, mcp_config_path: str | None) -> list[str]:
             "--disallowedTools", _BLOCKED_BUILTINS,
         ])
         return flags
+    if arm == "bash_only":
+        blocked = ",".join(
+            t for t in _BLOCKED_BUILTINS.split(",") if t.strip() != "Bash"
+        )
+        return ["--tools", "Bash", "--disallowedTools", blocked]
     raise ValueError(f"Unknown arm: {arm!r}")
 
 

--- a/tests/test_artifact_cli.py
+++ b/tests/test_artifact_cli.py
@@ -84,6 +84,7 @@ def test_artifact_run_help():
     assert "--filter" in r.output
     assert "--arms" in r.output
     assert "--runs" in r.output
+    assert "bash_only" in r.output
 
 
 def test_artifact_verify_is_placeholder():
@@ -109,7 +110,7 @@ def test_artifact_run_end_to_end(tmp_path, stub_runtime):
     ])
     assert r.exit_code == 0, r.output
 
-    for arm in ("code_only", "tool_rich"):
+    for arm in ("code_only", "tool_rich", "bash_only"):
         run_dir = results_dir / iid / arm / "run1"
         assert (run_dir / "result.json").is_file()
         assert (run_dir / "agent.jsonl").is_file()
@@ -373,6 +374,63 @@ def test_artifact_analyze_missing_results_dir(tmp_path):
     ])
     assert r.exit_code == 1
     assert "Results directory not found" in (r.output + (r.stderr or ""))
+
+
+def test_artifact_run_bash_only_arm(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    results_dir = tmp_path / "results"
+    iid = _write_fixture_task(tasks_root)
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "bash_only",
+    ])
+    assert r.exit_code == 0, r.output
+    # Only the bash_only arm dir should exist.
+    assert (results_dir / iid / "bash_only" / "run1" / "result.json").is_file()
+    assert not (results_dir / iid / "code_only").exists()
+    assert not (results_dir / iid / "tool_rich").exists()
+
+
+def test_artifact_run_all_sentinel(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    results_dir = tmp_path / "results"
+    iid = _write_fixture_task(tasks_root)
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "all",
+    ])
+    assert r.exit_code == 0, r.output
+    # All three arms must have been executed.
+    for arm in ("code_only", "tool_rich", "bash_only"):
+        assert (results_dir / iid / arm / "run1" / "result.json").is_file(), \
+            f"missing result.json for arm={arm}"
+
+
+def test_artifact_run_both_alias(tmp_path, stub_runtime):
+    tasks_root = tmp_path / "tasks"
+    results_dir = tmp_path / "results"
+    iid = _write_fixture_task(tasks_root)
+    runner = CliRunner()
+    r = runner.invoke(cli, [
+        "artifact", "run",
+        "--tasks-dir", str(tasks_root),
+        "--output-dir", str(results_dir),
+        "--filter", iid,
+        "--arms", "both",
+    ])
+    assert r.exit_code == 0, r.output
+    # 'both' is an alias for 'all' — all three arms must run.
+    for arm in ("code_only", "tool_rich", "bash_only"):
+        assert (results_dir / iid / arm / "run1" / "result.json").is_file(), \
+            f"missing result.json for arm={arm} (both alias)"
 
 
 def test_swebench_run_unchanged_smoke():

--- a/tests/test_artifact_run.py
+++ b/tests/test_artifact_run.py
@@ -232,7 +232,42 @@ def test_is_run_complete_true_false(tmp_path):
 
 
 def test_arm_list_constants():
-    assert set(ARMS) == {"code_only", "tool_rich"}
+    assert set(ARMS) == {"code_only", "tool_rich", "bash_only"}
+
+
+def test_build_tools_flags_bash_only():
+    flags = _build_tools_flags("bash_only", mcp_config_path=None)
+    assert "--tools" in flags
+    tools_val = flags[flags.index("--tools") + 1]
+    assert tools_val == "Bash"
+    assert "--disallowedTools" in flags
+    disallowed = flags[flags.index("--disallowedTools") + 1]
+    # Bash must NOT be in the disallowed list for bash_only.
+    assert "Bash" not in disallowed
+    # Known blocked builtins must still be disallowed.
+    assert "Read" in disallowed
+    # No MCP flags for bash_only.
+    assert "--mcp-config" not in flags
+    assert "--strict-mcp-config" not in flags
+
+
+def test_run_artifact_arm_end_to_end_bash_only(tmp_path, stub_claude, monkeypatch):
+    task = _make_fixture(tmp_path / "task", _GRADER_CHECKS_42)
+    monkeypatch.setattr(
+        artifact_run_mod, "run_claude",
+        _stub_claude_writes("42\n"),
+    )
+    results_dir = tmp_path / "results"
+    result = run_artifact_arm(
+        task, "bash_only", 1,
+        results_dir=results_dir,
+        claude_binary="/bin/true",
+        echo=lambda _m: None,
+    )
+    assert result.arm == "bash_only"
+    assert result.verdict == "PASS"
+    assert result.grade_result is not None
+    assert result.grade_result.passed is True
 
 
 def test_build_prompt_uses_absolute_paths(tmp_path):


### PR DESCRIPTION
Closes #159

## What changed

The artifact-graded benchmark previously compared two arms — `tool_rich` (all built-ins + MCP tools) and `code_only` (single `mcp__codebox__execute_code` MCP tool). This PR adds a third arm, `bash_only`, which allows only the built-in `Bash` tool while blocking every other built-in and all MCP servers. `bash_only` is the canonical mini-SWE-agent control: same agent loop, same prompt template, only the action surface differs. The `--arms` CLI option gains `bash_only` and `all` as explicit choices; the old `both` sentinel is preserved as a deprecated alias for backward compatibility (existing scripts keep working, now producing three arm dirs instead of two).

## Implementation walkthrough

### Modified functions

**`artifact_run.ARMS` (`swebench/artifact_run.py`)** — Extended from `("code_only", "tool_rich")` to `("code_only", "tool_rich", "bash_only")`. All downstream consumers that iterate `ARMS` (`_aggregate()`, arm-dispatch loops) pick up the new arm automatically without further edits.

**`artifact_run._build_tools_flags(arm, mcp_config_path)` (`swebench/artifact_run.py`)** — New branch added before the final `raise ValueError`. For `bash_only` it computes a `blocked` string by filtering `Bash` out of `_BLOCKED_BUILTINS` and returns `["--tools", "Bash", "--disallowedTools", blocked]`. No `--mcp-config` or `--strict-mcp-config` flags are emitted — no MCP server is needed. The `mcp_config_path` argument is intentionally ignored for this arm.

**`artifact_cli.artifact_run_command` (`swebench/artifact_cli.py`)** — Two edits. First, the `click.Choice` for `--arms` is extended to `["code_only", "tool_rich", "bash_only", "both", "all"]` and the default is changed from `"both"` to `"all"`. Second, the arm-list dispatch block is widened from `if arms == "both"` to `if arms in ("both", "all")` so both sentinels expand to `list(ARMS)`. The `--arms` help text notes `"both"` is a deprecated alias.

**`artifact_run._build_prompt()`** — Intentionally unchanged. The absolute-path preamble (input scratch dir + output artifact path) is arm-agnostic. For `bash_only`, Bash inherits `cwd` from the subprocess so relative paths would also work, but keeping all arms on the same prompt preserves comparability: any observed score delta is attributable to action surface, not prompt wording.

**`artifact_cli._aggregate()`** — No change required. It already derives `arms_present` as `sorted({r["arm"] for r in rows} | set(ARMS))`, so the `bash_only` row appears in per-arm tables automatically. The existing `code_only / tool_rich` cost-ratio line is unaffected; a `bash_only / tool_rich` ratio is a natural follow-up but is out of scope for this issue.

### How components interact

```
artifact run --arms bash_only
  → artifact_cli.artifact_run_command
      → arm_list = ["bash_only"]
      → for each task: artifact_run.run_artifact_arm(task, "bash_only", ...)
          → artifact_run._build_tools_flags("bash_only", mcp_config_path=None)
              → returns ["--tools", "Bash", "--disallowedTools", <builtins-minus-Bash>]
          → harness.run_claude(..., extra_flags=[...])   # no MCP server spawned
          → artifact_grade.grade_artifact(...)           # unchanged
          → writes result.json with "arm": "bash_only"
```

The `_BLOCKED_BUILTINS` constant is the single source of truth for all three arms' deny lists. The `bash_only` arm derives its deny list from `_BLOCKED_BUILTINS` at call time, so any future addition to that constant is automatically blocked for `bash_only` as well (unless it is `Bash` itself, which the unit test guards against).

### Default execution path

**Before:** `artifact run` (no `--arms`) defaulted to `"both"`, running two arms: `code_only` and `tool_rich`.

**After:** `artifact run` defaults to `"all"`, running three arms: `code_only`, `tool_rich`, and `bash_only`. Output directory layout gains a `bash_only/` sibling next to `code_only/` and `tool_rich/`.

Existing scripts passing `--arms both` explicitly continue to work and now run all three arms (the `both` alias was expanded rather than deprecated-and-removed to avoid breaking callers).

### Edge cases and error handling

- **Unknown arm:** `_build_tools_flags` still raises `ValueError` for any arm string not matching a known branch. The existing test `test_build_tools_flags_rejects_unknown_arm` covers this path unchanged.
- **`mcp_config_path` non-None for bash_only:** The argument is accepted but ignored. No `--mcp-config` flag is emitted. This is consistent with the arm's semantics (no MCP server) and is documented in the ADR.
- **`_BLOCKED_BUILTINS` drift:** If `Bash` were accidentally added to `_BLOCKED_BUILTINS` in the future, `bash_only` would silently lose its only tool. `test_build_tools_flags_bash_only` explicitly asserts `"Bash" not in disallowed` to guard against this regression.
- **`--arms both` backward compatibility:** `both` now expands to all three arms instead of two. Any automation that expected exactly two arm subdirectories under the results path will see a new `bash_only/` directory. No such hardcoding was found in the codebase outside the test files, which are updated in this PR.

### What was intentionally not changed

- `harness.py`, `artifact_grade.py`, `artifact_materialize.py`, `artifact_loader.py`, `artifact_models.py` — all grader and materialize machinery is arm-agnostic and required no modification.
- All SWE-bench modules (`run.py`, `add.py`, `analyze/`) — entirely separate pipeline, not involved.
- `result.json` schema — the `arm` field already accepts any string; `"bash_only"` is valid without a schema change.
- `_build_prompt()` — same prompt for all three arms to ensure score differences reflect action surface, not prompt wording (see ADR Decision 2).

## Tier / approach

Tier 2 — Planner → parallel Coder A + Tester → Wave 2 gate

## Acceptance criteria

- [x] `ARMS` tuple includes `"bash_only"`
- [x] `_build_tools_flags("bash_only")` returns `--tools Bash` with `--disallowedTools` set to all blocked builtins minus `Bash`; no `--mcp-config` or `--strict-mcp-config`
- [x] `--arms bash_only` executes without error (verified by `test_artifact_run_bash_only_arm`)
- [x] `--arms all` runs all three arms
- [x] `--arms both` remains a working backward-compat alias for all three arms
- [x] `result.json` includes `"arm": "bash_only"`
- [x] `_build_prompt()` produces identical output for all three arms (no arm-specific branching)
- [x] `--help` output for `--arms` mentions `bash_only`
- [x] All new unit tests pass (`test_build_tools_flags_bash_only`, `test_run_artifact_arm_end_to_end_bash_only`, `test_artifact_run_bash_only_arm`, `test_artifact_run_all_sentinel`, `test_artifact_run_both_alias`)
- [x] Existing tests updated and passing (`test_arm_list_constants`, `test_artifact_run_end_to_end`, `test_artifact_run_help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)