### PR TITLE
fix(#161): use FORCE_PROMPT_CACHING_5M instead of disabling caching

### DIFF
--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -432,7 +432,7 @@ def run_claude(
 
         env = os.environ.copy()
         env["CLAUDE_CONFIG_DIR"] = cfg_dir
-        env["DISABLE_PROMPT_CACHING"] = "1"
+        env["FORCE_PROMPT_CACHING_5M"] = "1"
 
         with open(result_file, "w") as out:
             subprocess.run(cmd, cwd=repo_dir, stdout=out, stderr=subprocess.STDOUT, env=env)


### PR DESCRIPTION
## Summary
- Replaces `DISABLE_PROMPT_CACHING=1` with `FORCE_PROMPT_CACHING_5M=1` in `run_claude()`
- Disabling caching entirely was ~4x more expensive ($0.43 vs $0.11 on a simple task)
- 5-minute ephemeral cache matches cost of 1-hour cache within the run window, without long-lived cache charges

## Test plan
- [x] Ran `algorithmic__coin_change_min` tool_rich arm — confirmed `ephemeral_5m_input_tokens` non-zero, `ephemeral_1h_input_tokens` = 0
- [x] Cost $0.098 (vs $0.43 with no cache, $0.11 with 1h cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)