### PR TITLE
fix(grader): strip reference values from detail strings (#165)

### DIFF
--- a/problems/artifact/algorithmic/bin_packing_first_fit_optimal/grader/hidden.py
+++ b/problems/artifact/algorithmic/bin_packing_first_fit_optimal/grader/hidden.py
@@ -128,6 +128,6 @@ def grade(scratch_dir: Path) -> GradeResult:
 
     optimal = _min_bins(weights, capacity)
     if nb != optimal:
-        return GradeResult(False, 0.0, f"num_bins {nb} is not optimal (optimal={optimal})")
+        return GradeResult(False, 0.0, f"num_bins {nb} is not optimal")
 
-    return GradeResult(True, 1.0, f"optimal num_bins={optimal}")
+    return GradeResult(True, 1.0, "num_bins is optimal")

--- a/problems/artifact/algorithmic/coin_change_min/grader/hidden.py
+++ b/problems/artifact/algorithmic/coin_change_min/grader/hidden.py
@@ -86,7 +86,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     if agent_mc != optimal:
         return GradeResult(
             False, 0.0,
-            f"min_coins {agent_mc} is not optimal (optimal={optimal})",
+            f"min_coins {agent_mc} is not optimal",
         )
 
-    return GradeResult(True, 1.0, f"optimal min_coins={optimal}")
+    return GradeResult(True, 1.0, "min_coins is optimal")

--- a/problems/artifact/algorithmic/graph_min_vertex_cover/grader/hidden.py
+++ b/problems/artifact/algorithmic/graph_min_vertex_cover/grader/hidden.py
@@ -112,6 +112,6 @@ def grade(scratch_dir: Path) -> GradeResult:
 
     optimal = _min_cover_size(n, edges)
     if cs != optimal:
-        return GradeResult(False, 0.0, f"cover_size {cs} is not optimal (optimal={optimal})")
+        return GradeResult(False, 0.0, f"cover_size {cs} is not optimal")
 
-    return GradeResult(True, 1.0, f"optimal cover_size={optimal}")
+    return GradeResult(True, 1.0, "cover_size is optimal")

--- a/problems/artifact/algorithmic/interval_scheduling_weighted/grader/hidden.py
+++ b/problems/artifact/algorithmic/interval_scheduling_weighted/grader/hidden.py
@@ -105,6 +105,6 @@ def grade(scratch_dir: Path) -> GradeResult:
 
     optimal = _optimal_revenue(requests)
     if tr != optimal:
-        return GradeResult(False, 0.0, f"total_revenue {tr} is not optimal (optimal={optimal})")
+        return GradeResult(False, 0.0, f"total_revenue {tr} is not optimal")
 
-    return GradeResult(True, 1.0, f"optimal total_revenue={optimal}")
+    return GradeResult(True, 1.0, "total_revenue is optimal")

--- a/problems/artifact/algorithmic/knapsack_01/grader/hidden.py
+++ b/problems/artifact/algorithmic/knapsack_01/grader/hidden.py
@@ -107,6 +107,6 @@ def grade(scratch_dir: Path) -> GradeResult:
 
     optimal = _optimal_value(capacity, items)
     if tv != optimal:
-        return GradeResult(False, 0.0, f"total_value {tv} is not optimal (optimal={optimal})")
+        return GradeResult(False, 0.0, f"total_value {tv} is not optimal")
 
-    return GradeResult(True, 1.0, f"optimal total_value={optimal}")
+    return GradeResult(True, 1.0, "total_value is optimal")

--- a/problems/artifact/algorithmic/makespan_scheduling/grader/hidden.py
+++ b/problems/artifact/algorithmic/makespan_scheduling/grader/hidden.py
@@ -86,7 +86,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     if int(round(agent_ms)) != optimal:
         return GradeResult(
             False, 0.0,
-            f"makespan {agent_ms} is not optimal (optimal={optimal})",
+            f"makespan {agent_ms} is not optimal",
         )
 
     # Optional: validate assignment feasibility if provided
@@ -113,4 +113,4 @@ def grade(scratch_dir: Path) -> GradeResult:
                     f"makespan {declared_ms} from the assignment",
                 )
 
-    return GradeResult(True, 1.0, f"optimal makespan {optimal} achieved")
+    return GradeResult(True, 1.0, "makespan is optimal")

--- a/problems/artifact/algorithmic/min_cost_assignment/grader/hidden.py
+++ b/problems/artifact/algorithmic/min_cost_assignment/grader/hidden.py
@@ -153,7 +153,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     if agent_cost != optimal_cost:
         return GradeResult(
             False, 0.0,
-            f"assignment cost {agent_cost} is not optimal (optimal={optimal_cost})",
+            f"assignment cost {agent_cost} is not optimal",
         )
 
-    return GradeResult(True, 1.0, f"optimal assignment cost {optimal_cost} achieved")
+    return GradeResult(True, 1.0, "assignment cost is optimal")

--- a/problems/artifact/algorithmic/traveling_salesman_small/grader/hidden.py
+++ b/problems/artifact/algorithmic/traveling_salesman_small/grader/hidden.py
@@ -142,7 +142,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     if abs(computed - optimal) > _TOL * max(1.0, abs(optimal)):
         return GradeResult(
             False, 0.0,
-            f"tour_length {computed} is not optimal (optimal={optimal})",
+            f"tour_length {computed} is not optimal",
         )
 
-    return GradeResult(True, 1.0, f"optimal tour_length={optimal:.6f}")
+    return GradeResult(True, 1.0, "tour_length is optimal")

--- a/problems/artifact/data_processing/cohort_retention/grader/hidden.py
+++ b/problems/artifact/data_processing/cohort_retention/grader/hidden.py
@@ -140,7 +140,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     if len(got_cohorts) != len(truth["cohorts"]):
         return GradeResult(
             False, 0.0,
-            f"cohort count mismatch: got {len(got_cohorts)}, expected {len(truth['cohorts'])}",
+            f"cohort count mismatch: got {len(got_cohorts)}",
         )
 
     for i, (got, want) in enumerate(zip(got_cohorts, truth["cohorts"])):
@@ -160,8 +160,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         if got["cohort_week"] != want["cohort_week"]:
             return GradeResult(
                 False, 0.0,
-                f"cohorts[{i}].cohort_week {got['cohort_week']!r} != expected "
-                f"{want['cohort_week']!r}",
+                f"cohorts[{i}].cohort_week {got['cohort_week']!r} mismatch",
             )
         cs = got["cohort_size"]
         if isinstance(cs, bool) or not isinstance(cs, int):
@@ -169,7 +168,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         if cs != want["cohort_size"]:
             return GradeResult(
                 False, 0.0,
-                f"cohort {want['cohort_week']}: size {cs} != expected {want['cohort_size']}",
+                f"cohort {want['cohort_week']}: size {cs} mismatch",
             )
 
         got_ret = got["retention"]
@@ -178,8 +177,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             return GradeResult(
                 False, 0.0,
                 f"cohort {want['cohort_week']}: retention length mismatch "
-                f"(got {len(got_ret) if isinstance(got_ret, list) else 'non-list'}, "
-                f"expected {len(want_ret)})",
+                f"(got {len(got_ret) if isinstance(got_ret, list) else 'non-list'})",
             )
         for j, (gr, wr) in enumerate(zip(got_ret, want_ret)):
             if not isinstance(gr, dict):
@@ -208,7 +206,7 @@ def grade(scratch_dir: Path) -> GradeResult:
                     return GradeResult(
                         False, 0.0,
                         f"cohort {want['cohort_week']} ret[{j}].{f_}: "
-                        f"got {gv}, expected {wr[f_]}",
+                        f"got {gv}, mismatch",
                     )
             rate = gr["retention_rate"]
             if isinstance(rate, bool) or not isinstance(rate, (int, float)):
@@ -222,7 +220,7 @@ def grade(scratch_dir: Path) -> GradeResult:
                 return GradeResult(
                     False, 0.0,
                     f"cohort {want['cohort_week']} ret[{j}].retention_rate "
-                    f"{rate} != expected ~{wr['retention_rate']}",
+                    f"{rate} out of tolerance",
                 )
 
     return GradeResult(

--- a/problems/artifact/data_processing/duplicate_orders/grader/hidden.py
+++ b/problems/artifact/data_processing/duplicate_orders/grader/hidden.py
@@ -168,7 +168,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             if got[k] != expected[k]:
                 return GradeResult(
                     False, 0.0,
-                    f"pair {pair}: {k} mismatch (got {got[k]!r}, want {expected[k]!r})",
+                    f"pair {pair}: {k} mismatch (got {got[k]!r})",
                 )
         got_amt = got["amount_cents"]
         if isinstance(got_amt, bool) or not isinstance(got_amt, int):
@@ -177,7 +177,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             return GradeResult(
                 False, 0.0,
                 f"pair {pair}: amount_cents mismatch "
-                f"(got {got_amt}, want {expected['amount_cents']})",
+                f"(got {got_amt})",
             )
         got_delta = got["delta_seconds"]
         if isinstance(got_delta, bool) or not isinstance(got_delta, (int, float)):
@@ -186,7 +186,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             return GradeResult(
                 False, 0.0,
                 f"pair {pair}: delta_seconds off "
-                f"(got {got_delta}, want ~{expected['delta_seconds']})",
+                f"(got {got_delta}, out of tolerance)",
             )
 
     return GradeResult(

--- a/problems/artifact/data_processing/funnel_conversion/grader/hidden.py
+++ b/problems/artifact/data_processing/funnel_conversion/grader/hidden.py
@@ -134,7 +134,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     if got_total != truth["total_signups"]:
         return GradeResult(
             False, 0.0,
-            f"total_signups {got_total} != expected {truth['total_signups']}",
+            f"total_signups {got_total} mismatch",
         )
 
     got_steps = doc["steps"]
@@ -157,7 +157,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         if got["step"] != want["step"]:
             return GradeResult(
                 False, 0.0,
-                f"steps[{idx}].step {got['step']!r} != expected {want['step']!r}",
+                f"steps[{idx}].step {got['step']!r} mismatch",
             )
         reached = got["reached"]
         if isinstance(reached, bool) or not isinstance(reached, int):
@@ -165,7 +165,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         if reached != want["reached"]:
             return GradeResult(
                 False, 0.0,
-                f"steps[{idx}] ({want['step']}).reached {reached} != expected {want['reached']}",
+                f"steps[{idx}] ({want['step']}).reached {reached} mismatch",
             )
         rate = got["rate_from_prev"]
         if isinstance(rate, bool) or not isinstance(rate, (int, float)):
@@ -175,11 +175,11 @@ def grade(scratch_dir: Path) -> GradeResult:
         if abs(float(rate) - want["rate_from_prev"]) > RATE_ABS_TOL:
             return GradeResult(
                 False, 0.0,
-                f"steps[{idx}] ({want['step']}).rate_from_prev {rate} != "
-                f"expected ~{want['rate_from_prev']}",
+                f"steps[{idx}] ({want['step']}).rate_from_prev {rate} "
+                f"out of tolerance",
             )
 
     return GradeResult(
         True, 1.0,
-        f"funnel matched: {[s['reached'] for s in truth['steps']]}",
+        f"funnel matched ({len(truth['steps'])} steps)",
     )

--- a/problems/artifact/data_processing/multi_file_cohort/grader/hidden.py
+++ b/problems/artifact/data_processing/multi_file_cohort/grader/hidden.py
@@ -34,7 +34,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         return GradeResult(False, 0.0, f"could not parse output: {exc}")
 
     if len(agent_top5) != 5:
-        return GradeResult(False, 0.0, f"expected 5 entries, got {len(agent_top5)}")
+        return GradeResult(False, 0.0, f"output must have 5 entries (got {len(agent_top5)})")
 
     for entry in agent_top5:
         if "product_id" not in entry or "total_revenue" not in entry:
@@ -45,7 +45,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     agent_pids = [e["product_id"] for e in agent_top5]
 
     if set(agent_pids) != set(expected_pids):
-        return GradeResult(False, 0.0, f"wrong top-5 products: got {agent_pids}, expected {expected_pids}")
+        return GradeResult(False, 0.0, f"wrong top-5 products: got {agent_pids}")
 
     # Check revenues within tolerance
     expected_dict = dict(expected)
@@ -54,6 +54,6 @@ def grade(scratch_dir: Path) -> GradeResult:
         expected_rev = expected_dict[pid]
         agent_rev = float(entry["total_revenue"])
         if abs(agent_rev - expected_rev) / expected_rev > TOLERANCE:
-            return GradeResult(False, 0.0, f"revenue for {pid}: got {agent_rev:.2f}, expected {expected_rev:.2f}")
+            return GradeResult(False, 0.0, f"revenue for {pid}: got {agent_rev:.2f}, out of tolerance")
 
     return GradeResult(True, 1.0, f"correct top-5 products identified with revenues within {TOLERANCE*100:.0f}% tolerance")

--- a/problems/artifact/data_processing/outlier_days/grader/hidden.py
+++ b/problems/artifact/data_processing/outlier_days/grader/hidden.py
@@ -144,12 +144,12 @@ def grade(scratch_dir: Path) -> GradeResult:
         if got["units_sold"] != want["units_sold"]:
             return GradeResult(
                 False, 0.0,
-                f"{key}: units_sold {got['units_sold']} != expected {want['units_sold']}",
+                f"{key}: units_sold {got['units_sold']} mismatch",
             )
         if got["direction"] != want["direction"]:
             return GradeResult(
                 False, 0.0,
-                f"{key}: direction {got['direction']!r} != expected {want['direction']!r}",
+                f"{key}: direction {got['direction']!r} mismatch",
             )
         for field in ("window_median", "mad", "modified_z"):
             gv = got[field]
@@ -164,7 +164,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             if abs(float(gv) - want[field]) > FLOAT_TOL:
                 return GradeResult(
                     False, 0.0,
-                    f"{key}: {field} {gv} != expected ~{want[field]}",
+                    f"{key}: {field} {gv} out of tolerance",
                 )
 
     return GradeResult(True, 1.0, f"matched {len(truth)} outlier day(s)")

--- a/problems/artifact/data_processing/p95_latency_easy/grader/hidden.py
+++ b/problems/artifact/data_processing/p95_latency_easy/grader/hidden.py
@@ -203,7 +203,7 @@ def grade(scratch_dir: Path) -> GradeResult:  # noqa: C901 — single entrypoint
         if abs_err > ABS_TOL and abs_err > REL_TOL * true_p95:
             bad_p95.append(ep)
         if count != true_count:
-            bad_count.append(f"{ep}(got {count}, want {true_count})")
+            bad_count.append(f"{ep}(got {count}, mismatch)")
 
     if bad_type:
         return GradeResult(

--- a/problems/artifact/data_processing/regression_detection/grader/hidden.py
+++ b/problems/artifact/data_processing/regression_detection/grader/hidden.py
@@ -120,7 +120,7 @@ def grade(scratch_dir: Path) -> GradeResult:  # noqa: C901
     if len(agent_rows) != TOP_N:
         return GradeResult(
             False, 0.0,
-            f"expected exactly {TOP_N} rows, got {len(agent_rows)}",
+            f"output must have exactly {TOP_N} rows (got {len(agent_rows)})",
         )
 
     # Compute ground truth
@@ -164,7 +164,7 @@ def grade(scratch_dir: Path) -> GradeResult:  # noqa: C901
         true_score = true_scores[ep]
         abs_err = abs(float(score) - true_score)
         if abs_err > REL_TOL * abs(true_score) + 0.5:
-            bad.append(f"{ep}(got {score:.1f}, want ~{true_score:.1f})")
+            bad.append(f"{ep}(got {score:.1f}, out of tolerance)")
 
     if bad:
         return GradeResult(

--- a/problems/artifact/data_processing/session_window/grader/hidden.py
+++ b/problems/artifact/data_processing/session_window/grader/hidden.py
@@ -139,7 +139,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             if gv != want[field]:
                 return GradeResult(
                     False, 0.0,
-                    f"{key}: {field} {gv} != expected {want[field]}",
+                    f"{key}: {field} {gv} mismatch",
                 )
         for field in ("start_ts", "end_ts"):
             gv = got[field]
@@ -148,7 +148,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             if abs(float(gv) - want[field]) > TS_ABS_TOL:
                 return GradeResult(
                     False, 0.0,
-                    f"{key}: {field} {gv} != expected ~{want[field]}",
+                    f"{key}: {field} {gv} out of tolerance",
                 )
 
     return GradeResult(True, 1.0, f"matched {len(truth)} sessions across users")

--- a/problems/artifact/enumeration/permutations_fixed_points/grader/hidden.py
+++ b/problems/artifact/enumeration/permutations_fixed_points/grader/hidden.py
@@ -75,7 +75,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         if perm is None:
             return GradeResult(
                 False, 0.0,
-                f"line {lineno}: expected permutation of 0..{N-1}, got {obj!r}",
+                f"line {lineno}: not a valid permutation of 0..{N-1}, got {obj!r}",
             )
         agent_perms.append(perm)
 

--- a/problems/artifact/stateful_reasoning/counter_replay/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/counter_replay/grader/hidden.py
@@ -82,7 +82,7 @@ def grade(scratch_dir: Path) -> GradeResult:
 
     missing = ref_keys - agent_keys
     extra = agent_keys - ref_keys
-    wrong = {k: (agent[k], reference[k]) for k in agent_keys & ref_keys if agent[k] != reference[k]}
+    wrong = {k for k in agent_keys & ref_keys if agent[k] != reference[k]}
 
     if missing or extra or wrong:
         parts = []
@@ -91,8 +91,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         if extra:
             parts.append(f"extra {len(extra)}: {sorted(extra)[:5]}")
         if wrong:
-            sample = list(wrong.items())[:3]
-            parts.append(f"{len(wrong)} wrong values, e.g. {sample}")
+            parts.append(f"{len(wrong)} wrong values (keys: {sorted(wrong)[:5]})")
         correct = len(ref_keys & agent_keys) - len(wrong)
         score = round(correct / max(len(ref_keys), 1), 4)
         return GradeResult(False, score, "; ".join(parts))

--- a/problems/artifact/stateful_reasoning/event_ledger/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/event_ledger/grader/hidden.py
@@ -63,7 +63,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     for acc, exp_bal in expected_balances.items():
         agent_bal = float(agent_balances.get(acc, -999999))
         if abs(agent_bal - exp_bal) > BALANCE_TOLERANCE:
-            wrong_balances.append(f"{acc}: got {agent_bal:.2f} expected {exp_bal:.2f}")
+            wrong_balances.append(f"{acc}: got {agent_bal:.2f}")
     if wrong_balances:
         return GradeResult(False, 0.0, f"wrong balances: {wrong_balances[:3]}")
 
@@ -74,8 +74,8 @@ def grade(scratch_dir: Path) -> GradeResult:
         extra = agent_rejected - expected_rejected_set
         missing_r = expected_rejected_set - agent_rejected
         return GradeResult(False, 0.0,
-            f"rejected mismatch: {len(expected_rejected)} expected, {len(agent_out['rejected'])} got. "
-            f"Extra: {sorted(extra)[:3]}, Missing: {sorted(missing_r)[:3]}")
+            f"rejected mismatch: got {len(agent_out['rejected'])} entries, "
+            f"{len(extra)} extra, {len(missing_r)} missing")
 
     return GradeResult(True, 1.0,
         f"all {len(expected_balances)} balances correct, {len(expected_rejected)} rejected transactions identified")

--- a/problems/artifact/stateful_reasoning/feature_flag_timeline/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/feature_flag_timeline/grader/hidden.py
@@ -90,9 +90,9 @@ def grade(scratch_dir: Path) -> GradeResult:
     wrong: list[str] = []
     for k in agent_keys & ref_keys:
         if agent[k].get("enabled") != reference[k]["enabled"]:
-            wrong.append(f"{k}: enabled {agent[k].get('enabled')} vs ref {reference[k]['enabled']}")
+            wrong.append(f"{k}: enabled mismatch")
         elif agent[k].get("toggle_count") != reference[k]["toggle_count"]:
-            wrong.append(f"{k}: toggle_count {agent[k].get('toggle_count')} vs ref {reference[k]['toggle_count']}")
+            wrong.append(f"{k}: toggle_count mismatch")
 
     if missing or extra or wrong:
         parts = []

--- a/problems/artifact/stateful_reasoning/rate_limiter_replay/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/rate_limiter_replay/grader/hidden.py
@@ -92,7 +92,7 @@ def grade(scratch_dir: Path) -> GradeResult:
     if len(agent) != len(ref):
         return GradeResult(False,
                            round(0.0, 4),
-                           f"output has {len(agent)} lines, expected {len(ref)}")
+                           f"output line count mismatch: got {len(agent)}")
 
     mismatches = 0
     sample = []
@@ -100,18 +100,18 @@ def grade(scratch_dir: Path) -> GradeResult:
         if a.get("request_id") != r["request_id"]:
             mismatches += 1
             if len(sample) < 3:
-                sample.append(f"line {i+1}: request_id {a.get('request_id')!r} vs ref {r['request_id']!r}")
+                sample.append(f"line {i+1}: request_id {a.get('request_id')!r} mismatch")
             continue
         if a.get("decision") != r["decision"]:
             mismatches += 1
             if len(sample) < 3:
-                sample.append(f"{r['request_id']}: decision {a.get('decision')!r} vs ref {r['decision']!r}")
+                sample.append(f"{r['request_id']}: decision {a.get('decision')!r} mismatch")
             continue
         if r["decision"] == "rejected":
             if a.get("reason") != r["reason"]:
                 mismatches += 1
                 if len(sample) < 3:
-                    sample.append(f"{r['request_id']}: reason {a.get('reason')!r} vs ref {r['reason']!r}")
+                    sample.append(f"{r['request_id']}: reason {a.get('reason')!r} mismatch")
 
     if mismatches:
         correct = len(ref) - mismatches

--- a/problems/artifact/stateful_reasoning/session_fsm/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/session_fsm/grader/hidden.py
@@ -175,7 +175,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             continue
         for k in required_keys:
             if av[k] != ref_val[k]:
-                wrong.append(f"{sid}.{k}: {av[k]!r} vs ref {ref_val[k]!r}")
+                wrong.append(f"{sid}.{k}: {av[k]!r} mismatch")
                 break
 
     if missing or wrong:

--- a/problems/artifact/verification_heavy/cron_next_fire/grader/hidden.py
+++ b/problems/artifact/verification_heavy/cron_next_fire/grader/hidden.py
@@ -83,7 +83,7 @@ def grade(scratch_dir: Path) -> GradeResult:
         if not isinstance(got, datetime):
             failures.append(f"  next_fire({expr!r}, {after}): expected datetime, got {type(got).__name__}")
         elif got != expected:
-            failures.append(f"  next_fire({expr!r}, {after}): expected {expected}, got {got}")
+            failures.append(f"  next_fire({expr!r}, {after}): got {got}, wrong")
 
     n_pass = len(_TESTS) - len(failures)
     if failures:

--- a/problems/artifact/verification_heavy/iban_validator/grader/hidden.py
+++ b/problems/artifact/verification_heavy/iban_validator/grader/hidden.py
@@ -92,7 +92,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             failures.append(f"  validate_iban({inp!r}): raised {type(exc).__name__}: {exc}")
             continue
         if got is not expected:  # strict True/False (not truthy)
-            failures.append(f"  validate_iban({inp!r}): expected {expected}, got {got!r}")
+            failures.append(f"  validate_iban({inp!r}): got {got!r}, wrong")
 
     n_pass = len(_TESTS) - len(failures)
     if failures:

--- a/problems/artifact/verification_heavy/lru_cache_impl/grader/hidden.py
+++ b/problems/artifact/verification_heavy/lru_cache_impl/grader/hidden.py
@@ -44,7 +44,7 @@ def _run_tests(LRUCache) -> list[str]:  # noqa: N803
 
     def check(name: str, got, expected):
         if got != expected:
-            failures.append(f"  [{name}] expected {expected!r}, got {got!r}")
+            failures.append(f"  [{name}] got {got!r}, wrong")
 
     # ── Group 1: basic put/get ────────────────────────────────────────────
     c = LRUCache(3)
@@ -141,7 +141,7 @@ def _run_tests(LRUCache) -> list[str]:  # noqa: N803
             expected = ref_get(key)
             if got != expected:
                 failures.append(
-                    f"  [g7-random] after {ops}: get({key})={got!r}, expected {expected!r}"
+                    f"  [g7-random] after {len(ops)} ops: get({key})={got!r}, wrong"
                 )
                 break
             ops.append(f"get({key})->{got}")
@@ -182,7 +182,7 @@ def _run_tests(LRUCache) -> list[str]:  # noqa: N803
             expected = ref_get2(key)
             if got != expected:
                 failures.append(
-                    f"  [g8-random] after {ops2}: get({key})={got!r}, expected {expected!r}"
+                    f"  [g8-random] after {len(ops2)} ops: get({key})={got!r}, wrong"
                 )
                 break
             ops2.append(f"get({key})->{got}")

--- a/problems/artifact/verification_heavy/semver_compare/grader/hidden.py
+++ b/problems/artifact/verification_heavy/semver_compare/grader/hidden.py
@@ -91,7 +91,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             continue
         norm = -1 if got < 0 else (1 if got > 0 else 0)
         if norm != expected:
-            failures.append(f"  compare_semver({a!r},{b!r}): expected {expected}, got {got}")
+            failures.append(f"  compare_semver({a!r},{b!r}): got {got}, wrong")
 
     n_pass = len(_TESTS) - len(failures)
     if failures:

--- a/tools/check_grader_leaks.py
+++ b/tools/check_grader_leaks.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Lint that flags answer leaks in artifact-graded grader detail strings.
+
+SCHEMA_ARTIFACT.md §3.3 forbids embedding the reference value in the
+``detail`` field of a ``GradeResult``:
+
+    Not acceptable: ``expected 42, got 41`` if the reference value is itself
+    the answer.
+
+This lint walks ``problems/artifact/*/grader/hidden.py`` and uses Python's
+``ast`` module to inspect every string passed to a ``GradeResult`` constructor
+(positionally or as the ``detail=`` keyword). For each f-string, it inspects
+the literal-text segments only — not the interpolated values — and flags any
+literal text that contains a "leak token" immediately followed (within 4
+characters) by a curly brace.
+
+The leak tokens are: ``expected``, ``optimal``, ``truth``, ``reference``,
+``want``, and ``ref``. The match is case-insensitive.
+
+Allowed exceptions:
+- Type complaints: ``expected int, got list``, ``want list, got str``. The
+  rule does NOT trigger when the next interpolated value resolves to a
+  ``type(...).__name__`` expression OR the literal text after the brace is
+  ``.__name__`` / ``).__name__``.
+- Bare type-name interpolations like ``f"{type(x).__name__}"`` in failure
+  messages are allowed.
+
+Exit code:
+    0  — no violations
+    1  — at least one violation (also printed to stderr)
+
+Usage:
+    python tools/check_grader_leaks.py [--root path/to/onlycodes]
+    python tools/check_grader_leaks.py --self-test    # run unit tests
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator, NamedTuple
+
+
+LEAK_TOKENS = ("expected", "optimal", "truth", "reference", "want", "ref")
+
+# Match a leak token anywhere in the literal segment that immediately
+# precedes an interpolation. We do NOT require a brace adjacency in the
+# regex; instead the AST scan only considers segments that are followed
+# by a FormattedValue, and only the last 30 chars of those segments.
+_LEAK_TOKEN_RE = re.compile(
+    r"\b(?P<token>" + "|".join(LEAK_TOKENS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+class Violation(NamedTuple):
+    file: Path
+    line: int
+    col: int
+    snippet: str
+    reason: str
+
+
+def _is_grade_result_call(call: ast.Call) -> bool:
+    """Return True if `call` is a ``GradeResult(...)`` constructor."""
+    f = call.func
+    if isinstance(f, ast.Name) and f.id == "GradeResult":
+        return True
+    if isinstance(f, ast.Attribute) and f.attr == "GradeResult":
+        return True
+    return False
+
+
+def _detail_args(call: ast.Call) -> Iterator[ast.expr]:
+    """Yield the AST node(s) corresponding to the ``detail`` argument.
+
+    GradeResult has signature ``(passed, score, detail)``; detail is positional
+    arg index 2 OR keyword arg ``detail=...``.
+    """
+    if len(call.args) >= 3:
+        yield call.args[2]
+    for kw in call.keywords:
+        if kw.arg == "detail":
+            yield kw.value
+
+
+def _next_typed_segment(parts: list[ast.expr], idx: int) -> bool:
+    """Return True if the FormattedValue at index ``idx`` is a type-name expr.
+
+    Examples: ``type(x).__name__``, ``type(x).__qualname__``, ``x.__class__.__name__``.
+    """
+    if idx >= len(parts):
+        return False
+    node = parts[idx]
+    if not isinstance(node, ast.FormattedValue):
+        return False
+    val = node.value
+    # Walk the expression and look for `__name__` or `__qualname__` attribute.
+    for sub in ast.walk(val):
+        if isinstance(sub, ast.Attribute) and sub.attr in (
+            "__name__",
+            "__qualname__",
+        ):
+            return True
+    return False
+
+
+def _scan_joined_str(
+    node: ast.JoinedStr,
+    file: Path,
+) -> Iterator[Violation]:
+    """Walk an f-string and flag literal segments that introduce a non-typed
+    interpolation with a leak token nearby.
+
+    Rule: for each FormattedValue at index i (i >= 1), look at the preceding
+    Constant string segment. If that segment contains a leak token within the
+    last 30 characters AND the FormattedValue is NOT a type-name expression,
+    flag it.
+    """
+    parts = list(node.values)
+    for i, part in enumerate(parts):
+        if not isinstance(part, ast.FormattedValue):
+            continue
+        # Type-name interpolations are an allowed exception.
+        if _next_typed_segment(parts, i):
+            continue
+        if i == 0:
+            continue
+        prev = parts[i - 1]
+        if not isinstance(prev, ast.Constant) or not isinstance(prev.value, str):
+            continue
+        # Only the last 30 characters of the preceding literal matter — far-away
+        # tokens are typically descriptive, not adjacent to the value.
+        suffix = prev.value[-30:]
+        m = _LEAK_TOKEN_RE.search(suffix)
+        if not m:
+            continue
+        yield Violation(
+            file=file,
+            line=node.lineno,
+            col=node.col_offset,
+            snippet=prev.value.strip()[-60:],
+            reason=(
+                f"detail contains '{m.group('token')}' adjacent to an "
+                f"interpolated value (SCHEMA §3.3)"
+            ),
+        )
+
+
+def _scan_constant(node: ast.Constant, file: Path) -> Iterator[Violation]:
+    """Walk a plain str constant. A pure literal can't interpolate but it can
+    leak via .format() / %s — flag patterns where a leak token sits next to a
+    formatting placeholder."""
+    if not isinstance(node.value, str):
+        return
+    text = node.value
+    # Look for leak token followed within 4 chars by `{`, `%s`, `%d`, etc.
+    pattern = re.compile(
+        r"\b(" + "|".join(LEAK_TOKENS) + r")\b[^a-zA-Z]{0,4}"
+        r"(\{|%[sdrf]|\{[^}]*\})",
+        re.IGNORECASE,
+    )
+    if pattern.search(text):
+        yield Violation(
+            file=file,
+            line=node.lineno,
+            col=node.col_offset,
+            snippet=text.strip()[:80],
+            reason="detail string contains leak token adjacent to a placeholder",
+        )
+
+
+def scan_file(path: Path) -> list[Violation]:
+    """Return all violations in a single grader file."""
+    src = path.read_text()
+    tree = ast.parse(src)
+    out: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_grade_result_call(node):
+            continue
+        for detail in _detail_args(node):
+            if isinstance(detail, ast.JoinedStr):
+                out.extend(_scan_joined_str(detail, path))
+            elif isinstance(detail, ast.Constant):
+                out.extend(_scan_constant(detail, path))
+            # Other forms (variable, function call) — we can't statically
+            # check them. Authors should use literal/f-string detail.
+    return out
+
+
+def find_graders(root: Path) -> list[Path]:
+    return sorted(root.glob("problems/artifact/*/*/grader/hidden.py"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repo root (default: parent of tools/)",
+    )
+    p.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run unit tests against handcrafted leaky / clean snippets",
+    )
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    files = find_graders(args.root)
+    if not files:
+        print(f"no grader files found under {args.root}", file=sys.stderr)
+        return 2
+
+    violations: list[Violation] = []
+    for f in files:
+        violations.extend(scan_file(f))
+
+    if violations:
+        print(f"FAIL: {len(violations)} answer-leak violation(s) in "
+              f"{len({v.file for v in violations})} grader file(s):",
+              file=sys.stderr)
+        for v in violations:
+            rel = v.file.relative_to(args.root)
+            print(f"  {rel}:{v.line}: {v.reason}", file=sys.stderr)
+            print(f"      snippet: {v.snippet!r}", file=sys.stderr)
+        return 1
+
+    print(f"OK: scanned {len(files)} grader file(s); no leaks found")
+    return 0
+
+
+# ────────────────────────────── self-test ─────────────────────────────────
+
+_LEAKY_SAMPLES = [
+    # Failure-path leaks
+    'GradeResult(False, 0.0, f"min_coins {x} is not optimal (optimal={opt})")',
+    'GradeResult(False, 0.0, f"endpoint {ep}: count {c}, want {true_count}")',
+    'GradeResult(False, 0.0, f"value {v} != expected {wanted}")',
+    'GradeResult(False, 0.0, f"got {x}, vs ref {ref_x}")',
+    'GradeResult(False, 0.0, f"truth was {truth_v}, got {got}")',
+    # Success-path leak
+    'GradeResult(True, 1.0, f"optimal num_bins={optimal}")',
+    # Keyword argument
+    'GradeResult(passed=False, score=0.0, detail=f"size {s} != expected {wanted}")',
+]
+
+_CLEAN_SAMPLES = [
+    # Type complaints (allowed)
+    'GradeResult(False, 0.0, f"min_coins must be int, got {type(x).__name__}")',
+    'GradeResult(False, 0.0, f"value must be a number, got {type(v).__name__}")',
+    'GradeResult(False, 0.0, f"expected int, got {type(got).__name__} {got!r}")',
+    # Generic mismatch messages (allowed)
+    'GradeResult(False, 0.0, f"min_coins {x} is not optimal")',
+    'GradeResult(False, 0.0, "endpoint mismatch")',
+    'GradeResult(False, 0.0, f"row {i}: count {c} mismatch")',
+    # Plain success
+    'GradeResult(True, 1.0, "all balances correct")',
+    # Detail with key/index in message (no leak token before brace)
+    'GradeResult(False, 0.0, f"row {i}: bad shape")',
+]
+
+
+def _scan_str_module(src: str) -> list[Violation]:
+    tree = ast.parse(src)
+    out: list[Violation] = []
+    fake_path = Path("<test>")
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_grade_result_call(node):
+            continue
+        for detail in _detail_args(node):
+            if isinstance(detail, ast.JoinedStr):
+                out.extend(_scan_joined_str(detail, fake_path))
+            elif isinstance(detail, ast.Constant):
+                out.extend(_scan_constant(detail, fake_path))
+    return out
+
+
+def _self_test() -> int:
+    failed = 0
+    for src in _LEAKY_SAMPLES:
+        v = _scan_str_module(src)
+        if not v:
+            print(f"FAIL: leaky sample not flagged: {src}", file=sys.stderr)
+            failed += 1
+    for src in _CLEAN_SAMPLES:
+        v = _scan_str_module(src)
+        if v:
+            print(f"FAIL: clean sample falsely flagged: {src}\n  -> {v}", file=sys.stderr)
+            failed += 1
+    if failed:
+        print(f"\n{failed} self-test failure(s)", file=sys.stderr)
+        return 1
+    print(f"OK: self-test passed ({len(_LEAKY_SAMPLES)} leaky + "
+          f"{len(_CLEAN_SAMPLES)} clean samples)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Resolves #165. Strips reference values from grader detail strings across all 26 leaky graders, and adds `tools/check_grader_leaks.py` to enforce SCHEMA §3.3 going forward.

## What changed

**Grader detail-string sweep (26 files, both failure and success paths):**

| Category | Files patched |
|---|---|
| `algorithmic/` | 8 / 8 |
| `data_processing/` | 8 / 8 |
| `enumeration/` | 1 (`permutations_fixed_points`) |
| `stateful_reasoning/` | 5 (`counter_replay`, `event_ledger`, `feature_flag_timeline`, `rate_limiter_replay`, `session_fsm`) |
| `verification_heavy/` | 4 (`cron_next_fire`, `iban_validator`, `lru_cache_impl`, `semver_compare`) |

Examples of the change pattern:

```diff
- f"min_coins {agent_mc} is not optimal (optimal={optimal})"
+ f"min_coins {agent_mc} is not optimal"

- f"optimal num_bins={optimal}"
+ "num_bins is optimal"

- f"  validate_iban({inp!r}): expected {expected}, got {got!r}"
+ f"  validate_iban({inp!r}): got {got!r}, wrong"

- f"{key}: {field} {gv} != expected ~{want[field]}"
+ f"{key}: {field} {gv} out of tolerance"

- f"{k}: enabled {agent[k]} vs ref {reference[k]['enabled']}"
+ f"{k}: enabled mismatch"
```

The success-path leaks were just as systemic — every algorithmic grader's success detail used to echo the optimum (e.g. `f"optimal min_coins={optimal}"`); these are now generic confirmations (`"min_coins is optimal"`).

**New lint:** `tools/check_grader_leaks.py`

- Walks `problems/artifact/*/*/grader/hidden.py` via the AST.
- For each `GradeResult(...)` constructor, inspects the `detail` argument (positional or keyword).
- Flags any literal segment that contains `expected`, `optimal`, `truth`, `reference`, `want`, or `ref` near (within 30 chars of) an immediately-following non-typed interpolation.
- Allows the schema's documented exception: type complaints like `f"got {type(x).__name__}"` are not flagged.
- Includes a `--self-test` mode with 7 leaky and 8 clean handcrafted samples.

```
$ python tools/check_grader_leaks.py --self-test
OK: self-test passed (7 leaky + 8 clean samples)

$ python tools/check_grader_leaks.py --root .
OK: scanned 48 grader file(s); no leaks found
```

## Verification

- Lint self-test passes (7 leaky / 8 clean handcrafted samples) ✅
- Lint reports 0 violations across all 48 grader files ✅
- Spot-check on `algorithmic/coin_change_min` failure mode: detail is now `'min_coins 999 is not optimal'` (was `'min_coins 999 is not optimal (optimal=4)'`) ✅
- All 8 algorithmic graders verified to still grade their `reference_output.json` as `passed=True, score=1.0` ✅. data_processing / stateful_reasoning generators were not run locally; their reference outputs are committed to the repo and the grading *shape* is unchanged — only the detail strings.

## Test plan

- [ ] CI lint step running `python tools/check_grader_leaks.py --root .` returns 0
- [ ] Pre-merge sanity check (existing) confirms `grade(reference_output) → passed=True, score=1.0` for all 48 tasks
- [ ] Manual spot-check: run a deliberately-wrong artifact through one or two graders and confirm `detail` is informative without quoting the reference value

## Out of scope

- Aligning prompt requirements with grader checks (covered by #166)
- Adding negative pre-merge sanity tests (covered by #171)
- Empty-output false-negatives in `upgrade_impact` / `unreachable_functions` (separate, lower-priority follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)