### PR TITLE
Add negative pre-merge sanity tests for graders (#171)

### DIFF
--- a/.github/workflows/check-graders.yml
+++ b/.github/workflows/check-graders.yml
@@ -36,6 +36,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          # Some task graders import third-party libraries that are not
+          # part of the harness's runtime dependency set. Install them
+          # here so the positive sanity check (which exercises every
+          # task's grader) doesn't false-fail on an env-missing dep.
+          pip install networkx
 
       - name: Positive sanity check
         run: make check-graders-positive

--- a/.github/workflows/check-graders.yml
+++ b/.github/workflows/check-graders.yml
@@ -1,0 +1,47 @@
+name: check-graders
+
+# Run the pre-merge grader gates on every PR that touches the artifact
+# benchmark — graders, tasks, the harness loader, or the gate tools
+# themselves. See docs/SCHEMA_ARTIFACT.md §5.4 (positive) and §5.5
+# (negative).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "problems/artifact/**"
+      - "swebench/artifact_*"
+      - "tools/verify_graders.py"
+      - "tools/check_grader_negative.py"
+      - "tools/check_grader_leaks.py"
+      - "Makefile"
+      - ".github/workflows/check-graders.yml"
+      - "tests/test_verify_graders.py"
+      - "tests/test_check_grader_negative.py"
+
+jobs:
+  graders:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Positive sanity check
+        run: make check-graders-positive
+
+      - name: Negative sanity check
+        run: make check-graders-negative
+
+      - name: Answer-leak lint
+        run: make check-graders-leaks

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+# Top-level Makefile for the onlycodes repo.
+#
+# These targets are convenience wrappers around the Python tooling under
+# tools/ and tests/. They are intended for local developer use and for CI
+# (.github/workflows/check-graders.yml).
+
+PYTHON ?= python3
+
+.PHONY: help check-graders check-graders-positive check-graders-negative \
+        check-graders-leaks check-graders-fast test
+
+help:
+	@echo "Available targets:"
+	@echo "  make check-graders            run positive + negative + leak gates on every task"
+	@echo "  make check-graders-positive   run only the positive sanity check (verify_graders.py)"
+	@echo "  make check-graders-negative   run only the negative sanity check (check_grader_negative.py)"
+	@echo "  make check-graders-leaks      run only the answer-leak lint (check_grader_leaks.py)"
+	@echo "  make check-graders-fast       run negative gate ONLY for tasks that ship grader/negative_cases.py"
+	@echo "  make test                     run pytest"
+
+# ---------------------------------------------------------------------------
+# Grader pre-merge sanity gates.
+#
+# A task PR must pass:
+#   1. The positive check (reference output → grader returns passed=True).
+#      Catches graders that reject their own known-good answer.
+#   2. The negative check (deliberately wrong artifacts → grader returns
+#      passed=False). Catches graders that ACCEPT artifacts they shouldn't.
+#   3. The answer-leak lint (no embedded reference values in detail strings).
+#
+# All three are individually invokable; ``check-graders`` is the umbrella
+# target the CI workflow uses.
+# ---------------------------------------------------------------------------
+
+check-graders: check-graders-positive check-graders-negative check-graders-leaks
+	@echo ""
+	@echo "All grader gates passed."
+
+check-graders-positive:
+	$(PYTHON) tools/verify_graders.py
+
+check-graders-negative:
+	$(PYTHON) tools/check_grader_negative.py
+
+check-graders-leaks:
+	$(PYTHON) tools/check_grader_leaks.py
+
+# A faster lane for PRs that only add or modify a single task: skip the
+# default-mutation pass for unrelated tasks and only exercise tasks that
+# ship a per-task grader/negative_cases.py.
+check-graders-fast:
+	$(PYTHON) tools/check_grader_negative.py --tasks-with-custom-cases-only
+
+test:
+	$(PYTHON) -m pytest tests/

--- a/docs/SCHEMA_ARTIFACT.md
+++ b/docs/SCHEMA_ARTIFACT.md
@@ -234,11 +234,112 @@ The harness (#2) is responsible for the copy step and for ensuring no grader pat
 
 The invariant "no golden solution or correctness signal is ever visible to the agent" is a hard epic invariant (see #92). Any task author who finds themselves needing to reference `grader/` or `reference_output` from inside `workspace/` has a bug — the task is miscategorized and needs re-shaping.
 
-### 5.4 Pre-merge sanity check
+### 5.4 Pre-merge sanity check (positive)
 
 Before a task PR lands, a harness utility runs the task's `reference_output` through its `grade()` function and asserts `passed=True, score=1.0`. This catches graders that reject their own known-good answer — the single most common silent-failure mode.
 
 This sanity check is run by the harness slice (#2); task authors MAY run it locally once the harness lands by invoking the sanity-check entry point on their task directory.
+
+The implementation is `tools/verify_graders.py`; CI invokes it via `make check-graders-positive`.
+
+### 5.5 Pre-merge sanity check (negative)
+
+The §5.4 positive check catches graders that reject their own known-good answer. It does NOT catch the dual silent-failure mode: a grader that *accepts* artifacts it should reject because the prompt's correctness criterion was incompletely encoded. Examples seen in seed-v1:
+
+- A prompt requires descending-by-revenue order, but the grader checks set equality — a reversed artifact passes.
+- A prompt requires a chronological list, but the grader uses set comparison — a permutation passes.
+- A prompt requires both `function` AND `module` keys, but the grader only validates `function` — a JSONL with bogus modules passes.
+- A grader has an "output is empty" early-exit before the correctness check — when the *correct* answer happens to be empty, a correct empty agent output is rejected.
+
+Negative sanity check: for every task, a harness utility takes `reference_output`, applies a small set of *deliberately wrong* mutations, places each mutated artifact at `output_artifact`, and runs `grade()`. The expected outcome is `passed=False`.
+
+#### 5.5.1 Default mutations (every task)
+
+Every task's grader is exercised against six task-agnostic mutations supplied by `swebench.artifact_negative.default_negative_cases()`:
+
+| Mutation | Description |
+|---|---|
+| `empty` | Replace the artifact with the empty string. |
+| `truncated_half` | Keep only the first 50% of bytes. |
+| `reversed_lines` | Reverse the order of non-empty lines. |
+| `renamed_field` | Rename one required JSON key to a guaranteed-wrong name. |
+| `off_by_one` | Add 1 to the first numeric literal in the artifact. |
+| `wrap_in_list` | Wrap the artifact in `[ ... ]`. |
+
+These exercise structural properties most graders should already enforce. They are deliberately *generic* — they should fire across categories without per-task knowledge.
+
+#### 5.5.2 Per-task mutations (`grader/negative_cases.py`)
+
+A task author who knows their prompt encodes a property the default mutations do not exercise (sort order, optional fields, set vs. list semantics, numeric tolerance bands, …) SHOULD ship a `grader/negative_cases.py` exposing a `NEGATIVE_CASES` list:
+
+```python
+from swebench.artifact_negative import NegativeCase
+
+def _reverse_jsonl(text: str) -> str:
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    return "\n".join(reversed(lines)) + "\n"
+
+NEGATIVE_CASES = [
+    NegativeCase(
+        name="reversed_lines",
+        mutate=_reverse_jsonl,
+        expected_substring="order",
+        currently_caught=True,
+    ),
+    # ... more cases
+]
+```
+
+When a task ships `grader/negative_cases.py`, the per-task list **replaces** the defaults. A task author who wants the defaults plus extras should re-import them:
+
+```python
+from swebench.artifact_negative import NegativeCase, default_negative_cases
+
+NEGATIVE_CASES = default_negative_cases() + [
+    NegativeCase(name="task_specific_X", mutate=..., expected_substring=...),
+]
+```
+
+`NegativeCase` fields:
+
+| Field | Required? | Description |
+|---|---|---|
+| `name` | required | Short stable identifier. Unique within a task's case list. |
+| `mutate` | required | `Callable[[str], str]`. Takes the reference-output text, returns a deliberately-wrong text. Must produce a value different from the input. |
+| `expected_substring` | optional | Case-insensitive substring expected in the grader's `detail` on rejection. Empty string means "any rejection is fine". Authors SHOULD provide a substring when the case targets a specific property — that catches graders rejecting for the wrong reason (e.g. an empty-file shortcut firing before the correctness check). |
+| `currently_caught` | optional, default `True` | When `False`, the case documents a known grader-vs-prompt alignment bug: the mutation slips through the grader today. The negative gate prints a WARNING and continues. Flip to `True` once the alignment fix lands. |
+| `notes` | optional | Free-form annotation. Often a GitHub issue link explaining a `currently_caught=False` entry. |
+
+#### 5.5.3 The `currently_caught=False` escape hatch
+
+`currently_caught=False` exists for ONE narrow purpose: documenting a known prompt-vs-grader misalignment that the negative-test framework would otherwise flag every CI run. The case still runs; the gate still inspects the outcome; the outcome is reported as `EXPECTED_MISS` (warning) instead of `MISS` (failure).
+
+A `currently_caught=False` entry MUST cite the tracking issue in `notes`. Once the underlying alignment fix lands, the same PR flips the flag back to `True`.
+
+If you find yourself reaching for `currently_caught=False` for any reason other than "the prompt-vs-grader alignment is being fixed in a follow-up PR", you are using it wrong: file an issue, fix the grader, and add the case as `currently_caught=True` from day one.
+
+#### 5.5.4 Tooling
+
+| Tool | Purpose |
+|---|---|
+| `tools/check_grader_negative.py` | CLI driver. Walks tasks, runs cases, prints PASS / MISS / WEAK_MISS / WRONG_REASON / EXPECTED_MISS / ERROR per case. |
+| `make check-graders-negative` | Convenience wrapper. |
+| `make check-graders` | Runs §5.4 + §5.5 + the `check_grader_leaks.py` answer-leak lint. CI invokes the individual targets. |
+
+Outcome statuses:
+
+| Status | Meaning | Exits non-zero? |
+|---|---|---|
+| `PASS` | Grader correctly rejected the mutation. Detail substring matched (if specified). | — |
+| `MISS` | Grader accepted a deliberately-wrong artifact from a **custom** per-task case. Hard failure. | yes |
+| `WEAK_MISS` | Grader accepted a deliberately-wrong artifact from a **default** mutation, on a task that hasn't yet shipped `grader/negative_cases.py`. Diagnostic only. | no |
+| `WRONG_REASON` | Grader rejected, but `detail` did not contain the expected substring. Hard failure for custom cases (the grader rejected for the wrong reason); diagnostic-only for default mutations. | yes (custom only) |
+| `EXPECTED_MISS` | Grader accepted, AND the case is annotated `currently_caught=False`. Tracked alignment bug; warning only. | no |
+| `ERROR` | Infrastructure failure (missing reference, mutate raised, grader timeout, …). | yes |
+
+The `WEAK_MISS` distinction lets the framework ship today without forcing every existing task to be retro-audited in one PR. Promote a `WEAK_MISS` to a tracked `EXPECTED_MISS` by adding a per-task `negative_cases.py` with `currently_caught=False` and an issue link in `notes`.
+
+Self-test for the negative framework lives in `tests/test_check_grader_negative.py`.
 
 ---
 
@@ -296,7 +397,8 @@ A new task is ready to merge when all of the following are true:
 - [ ] `workspace/verify.py`, if present, does structural checks only (test: would a trivial-wrong artifact pass?).
 - [ ] `grader/hidden.py` defines `grade(scratch_dir) -> GradeResult`, is deterministic, offline, and seeds randomness from `instance_id`.
 - [ ] `grader/reference_output.*` exists and is known-good.
-- [ ] The grader returns `passed=True, score=1.0` on the reference output (sanity check).
+- [ ] The grader returns `passed=True, score=1.0` on the reference output (positive sanity check, §5.4).
+- [ ] The grader returns `passed=False` on the default negative mutations, and on any per-task `grader/negative_cases.py` mutations (§5.5). Any `currently_caught=False` entry cites a tracking issue in `notes`.
 - [ ] `execution_budget.max_code_runs` and `max_wall_seconds` are declared (`0` is fine for seed-v1).
 - [ ] Nothing in `workspace/` references `grader/` or `reference_output` by path or name.
 

--- a/problems/artifact/data_processing/multi_file_cohort/grader/negative_cases.py
+++ b/problems/artifact/data_processing/multi_file_cohort/grader/negative_cases.py
@@ -1,0 +1,93 @@
+"""Per-task negative cases for ``data_processing__multi_file_cohort``.
+
+The prompt requires the output rows to be sorted in **descending order by
+total_revenue**, but the current grader only checks the *set* of product_ids,
+not the row order. A reversed reference output therefore slips through the
+grader today; that's the bug issue #171 calls out as
+``multi_file_cohort order``. The ``reversed_lines`` case below is annotated
+``currently_caught=False`` so the negative gate prints a WARNING for it
+without failing CI; once the grader is updated to enforce ordering (tracked
+under the prompt-vs-grader-alignment issue), flip it to ``True``.
+
+Other cases here are mutations that the current grader DOES correctly catch
+— they document the existing safety net.
+"""
+
+from __future__ import annotations
+
+from swebench.artifact_negative import (
+    NegativeCase,
+    _mutate_empty,
+    _mutate_rename_one_field,
+    _mutate_reverse_lines,
+    _mutate_truncate_half,
+    _mutate_wrap_in_list,
+)
+
+
+def _mutate_drop_one_row(text: str) -> str:
+    """Drop the last non-empty row. Top-5 becomes top-4 → grader's len check fires."""
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if len(lines) <= 1:
+        return ""
+    return "\n".join(lines[:-1]) + "\n"
+
+
+def _mutate_swap_pid(text: str) -> str:
+    """Replace one product_id with a known-not-in-top-5 placeholder.
+
+    Keeps the row count and JSON shape intact so the grader has to do a
+    set-equality check against the reference pids, not just a structural
+    pass.
+    """
+    return text.replace('"P023"', '"PXXX"', 1)
+
+
+NEGATIVE_CASES = [
+    NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        # Empty file is produced (just empty content) → row-count check fires.
+        expected_substring="5 entries",
+    ),
+    NegativeCase(
+        name="truncated_half",
+        mutate=_mutate_truncate_half,
+        # Truncating mid-line yields a JSON parse error.
+        expected_substring="could not parse",
+    ),
+    NegativeCase(
+        name="reversed_lines",
+        mutate=_mutate_reverse_lines,
+        # PROMPT-VS-GRADER ALIGNMENT BUG: the prompt says "descending order"
+        # but the grader does set-equality on product_ids without checking
+        # row order. Today the grader returns passed=True on this mutation;
+        # ``check_grader_negative`` will print WARNING and continue. Flip
+        # ``currently_caught=True`` once the grader checks order.
+        expected_substring="order",
+        currently_caught=False,
+        notes="issue #171 — multi_file_cohort missing descending-order check",
+    ),
+    NegativeCase(
+        name="renamed_required_field",
+        mutate=_mutate_rename_one_field,
+        expected_substring="missing required keys",
+    ),
+    NegativeCase(
+        name="wrong_pid",
+        mutate=_mutate_swap_pid,
+        expected_substring="wrong top-5",
+    ),
+    NegativeCase(
+        name="dropped_row",
+        mutate=_mutate_drop_one_row,
+        expected_substring="5 entries",
+    ),
+    NegativeCase(
+        name="wrap_in_list",
+        mutate=_mutate_wrap_in_list,
+        # Wrapping in [] makes line-by-line JSON parsing fail on the open
+        # bracket "[".
+        expected_substring="",  # any rejection is fine
+    ),
+]

--- a/problems/artifact/stateful_reasoning/event_ledger/grader/negative_cases.py
+++ b/problems/artifact/stateful_reasoning/event_ledger/grader/negative_cases.py
@@ -1,0 +1,138 @@
+"""Per-task negative cases for ``stateful_reasoning__event_ledger``.
+
+The prompt requires ``rejected`` to be a JSON **array** in **chronological
+order** (the order the rejected transactions were encountered while
+replaying the ledger). The grader, however, compares ``rejected`` as a
+*set*, so any permutation slips through. That's the bug issue #171 calls
+out as ``event_ledger rejected order``.
+
+The ``reversed_rejected`` case below is annotated ``currently_caught=False``
+— the grader incorrectly accepts a reversed rejected list today. Flip to
+``True`` once the grader enforces chronological order (and / or list-vs-set
+semantics) per the prompt.
+"""
+
+from __future__ import annotations
+
+import json
+
+from swebench.artifact_negative import (
+    NegativeCase,
+    _mutate_empty,
+    _mutate_truncate_half,
+    _mutate_wrap_in_list,
+)
+
+
+def _mutate_reverse_rejected(text: str) -> str:
+    """Reverse the order of the rejected[] list while leaving balances alone.
+
+    The prompt requires chronological order; reversing it should make a
+    well-aligned grader fail. The current grader compares as a set and
+    accepts.
+    """
+    payload = json.loads(text)
+    rejected = list(payload.get("rejected", []))
+    if len(rejected) <= 1:
+        # Reversing a 0/1-element list is a no-op; nudge it to be
+        # detectably different.
+        rejected = rejected + ["__INSERTED__"]
+    else:
+        rejected.reverse()
+    payload["rejected"] = rejected
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _mutate_rejected_as_set(text: str) -> str:
+    """Convert rejected list to a JSON object (dict) — wrong shape.
+
+    A grader that doesn't check shape will silently coerce dict-keys to a
+    set, masking the type bug. The well-aligned grader should reject
+    non-list values for ``rejected``.
+    """
+    payload = json.loads(text)
+    rejected = payload.get("rejected", [])
+    payload["rejected"] = {tid: True for tid in rejected}
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _mutate_drop_balances(text: str) -> str:
+    """Remove the ``balances`` key entirely — should be a structural reject."""
+    payload = json.loads(text)
+    payload.pop("balances", None)
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _mutate_off_by_one_balance(text: str) -> str:
+    """Shift one account balance by 100.00 so it's outside tolerance."""
+    payload = json.loads(text)
+    if not payload.get("balances"):
+        return text + "_"
+    first = next(iter(payload["balances"]))
+    payload["balances"][first] = round(float(payload["balances"][first]) + 100.0, 2)
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _mutate_drop_rejected_entry(text: str) -> str:
+    """Drop one transaction id from rejected — sets diverge → grader fails."""
+    payload = json.loads(text)
+    rejected = list(payload.get("rejected", []))
+    if not rejected:
+        return text + "_"
+    payload["rejected"] = rejected[1:]
+    return json.dumps(payload, indent=2) + "\n"
+
+
+NEGATIVE_CASES = [
+    NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        # Empty file is produced (just empty content) → JSON parse error.
+        expected_substring="could not parse",
+    ),
+    NegativeCase(
+        name="truncated_half",
+        mutate=_mutate_truncate_half,
+        # Truncating mid-JSON triggers a parse error.
+        expected_substring="parse",
+    ),
+    NegativeCase(
+        name="missing_balances_key",
+        mutate=_mutate_drop_balances,
+        expected_substring="missing 'balances'",
+    ),
+    NegativeCase(
+        name="off_by_one_balance",
+        mutate=_mutate_off_by_one_balance,
+        expected_substring="wrong balances",
+    ),
+    NegativeCase(
+        name="dropped_rejected_entry",
+        mutate=_mutate_drop_rejected_entry,
+        expected_substring="rejected mismatch",
+    ),
+    NegativeCase(
+        name="reversed_rejected",
+        mutate=_mutate_reverse_rejected,
+        # PROMPT-VS-GRADER ALIGNMENT BUG: prompt requires chronological order,
+        # grader uses set-equality. Reversing slips through today.
+        expected_substring="order",
+        currently_caught=False,
+        notes="issue #171 — event_ledger rejected list-vs-set bug",
+    ),
+    NegativeCase(
+        name="rejected_as_dict",
+        mutate=_mutate_rejected_as_set,
+        # PROMPT-VS-GRADER ALIGNMENT BUG: ``rejected`` is required to be a
+        # list. The grader's ``set(...)`` coerces a dict to its key-set so
+        # this slips through.
+        expected_substring="list",
+        currently_caught=False,
+        notes="issue #171 — event_ledger list-vs-set bug (dict coercion)",
+    ),
+    NegativeCase(
+        name="wrap_in_list",
+        mutate=_mutate_wrap_in_list,
+        expected_substring="",  # JSON object expected; list parses but isinstance fails
+    ),
+]

--- a/problems/artifact/stateful_reasoning/unreachable_functions/grader/negative_cases.py
+++ b/problems/artifact/stateful_reasoning/unreachable_functions/grader/negative_cases.py
@@ -1,0 +1,134 @@
+"""Per-task negative cases for ``stateful_reasoning__unreachable_functions``.
+
+The prompt requires every output line to carry **both** ``function`` AND
+``module`` keys. The grader, however, only validates ``function`` — the
+``module`` field is read from the reference but never checked against the
+agent's output, so a JSONL with a bogus or missing module slips through.
+That's the bug issue #171 calls out as ``unreachable_functions module``.
+
+The ``drop_module_field`` and ``wrong_module_value`` cases below are
+annotated ``currently_caught=False``; flip them to ``True`` once the grader
+validates ``module`` per the prompt.
+"""
+
+from __future__ import annotations
+
+import json
+
+from swebench.artifact_negative import (
+    NegativeCase,
+    _mutate_empty,
+    _mutate_truncate_half,
+    _mutate_wrap_in_list,
+)
+
+
+def _mutate_drop_module(text: str) -> str:
+    """Remove the ``module`` key from every line.
+
+    The prompt requires both keys. The current grader only validates
+    ``function``, so this passes today.
+    """
+    out_lines: list[str] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        obj = json.loads(line)
+        obj.pop("module", None)
+        out_lines.append(json.dumps(obj))
+    return "\n".join(out_lines) + "\n"
+
+
+def _mutate_wrong_module(text: str) -> str:
+    """Replace every ``module`` value with a known-wrong placeholder."""
+    out_lines: list[str] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        obj = json.loads(line)
+        if "module" in obj:
+            obj["module"] = "WRONG_MODULE"
+        out_lines.append(json.dumps(obj))
+    return "\n".join(out_lines) + "\n"
+
+
+def _mutate_rename_function_key(text: str) -> str:
+    """Rename ``function`` to ``func`` — caught by the existing key check."""
+    return text.replace('"function":', '"func":')
+
+
+def _mutate_rename_one_function(text: str) -> str:
+    """Rename one function value to a guaranteed-wrong name."""
+    out_lines: list[str] = []
+    first = True
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        obj = json.loads(line)
+        if first and "function" in obj:
+            obj["function"] = obj["function"] + "_RENAMED"
+            first = False
+        out_lines.append(json.dumps(obj))
+    return "\n".join(out_lines) + "\n"
+
+
+def _mutate_duplicate_first(text: str) -> str:
+    """Duplicate the first non-empty line — grader's dedup check should fire."""
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return text + "_"
+    return "\n".join([lines[0], *lines]) + "\n"
+
+
+NEGATIVE_CASES = [
+    NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        expected_substring="empty",
+    ),
+    NegativeCase(
+        name="truncated_half",
+        mutate=_mutate_truncate_half,
+        # Truncating mid-line yields a JSON parse error on that row.
+        expected_substring="",
+    ),
+    NegativeCase(
+        name="renamed_function_key",
+        mutate=_mutate_rename_function_key,
+        expected_substring="missing 'function'",
+    ),
+    NegativeCase(
+        name="renamed_one_function_value",
+        mutate=_mutate_rename_one_function,
+        expected_substring="missing",
+    ),
+    NegativeCase(
+        name="duplicated_function",
+        mutate=_mutate_duplicate_first,
+        expected_substring="duplicate",
+    ),
+    NegativeCase(
+        name="drop_module_field",
+        mutate=_mutate_drop_module,
+        # PROMPT-VS-GRADER ALIGNMENT BUG: prompt requires both 'function'
+        # AND 'module', grader only checks 'function'. Dropping ``module``
+        # entirely slips through today.
+        expected_substring="module",
+        currently_caught=False,
+        notes="issue #171 — unreachable_functions module field unvalidated",
+    ),
+    NegativeCase(
+        name="wrong_module_value",
+        mutate=_mutate_wrong_module,
+        # Same alignment bug as drop_module_field — the grader doesn't
+        # check what's in ``module``, so a wrong value also slips.
+        expected_substring="module",
+        currently_caught=False,
+        notes="issue #171 — unreachable_functions module field unvalidated",
+    ),
+    NegativeCase(
+        name="wrap_in_list",
+        mutate=_mutate_wrap_in_list,
+        expected_substring="",
+    ),
+]

--- a/problems/artifact/stateful_reasoning/upgrade_impact/grader/negative_cases.py
+++ b/problems/artifact/stateful_reasoning/upgrade_impact/grader/negative_cases.py
@@ -1,0 +1,109 @@
+"""Per-task negative cases for ``stateful_reasoning__upgrade_impact``.
+
+The grader contains an "output artifact is empty" early-exit (lines 100-101
+of grader/hidden.py). When the *correct* answer is empty (i.e. zero
+conflicts after the upgrade), an agent that correctly produces an empty
+artifact is rejected by that early-exit instead of being graded by the
+correctness check. The reference output for this task happens to have three
+conflicts, so the bug doesn't surface against ``reference_output.jsonl`` —
+that's the ``upgrade_impact empty-output`` bug called out in issue #171.
+
+We can't fully exercise that bug with a pure mutation of the reference
+output (it requires constructing an alternate workspace where the correct
+answer is empty). What we CAN do is document the bug and add the regular
+suite of mutations so the rest of the grader's safety net is exercised.
+The empty-output regression test belongs in a future PR alongside the
+grader fix.
+"""
+
+from __future__ import annotations
+
+import json
+
+from swebench.artifact_negative import (
+    NegativeCase,
+    _mutate_empty,
+    _mutate_truncate_half,
+    _mutate_wrap_in_list,
+)
+
+
+def _mutate_drop_one_package(text: str) -> str:
+    """Drop the first reported conflict — set diverges → grader fails."""
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return text + "_"
+    return "\n".join(lines[1:]) + "\n"
+
+
+def _mutate_extra_bogus_package(text: str) -> str:
+    """Append a bogus package name not in the dependency graph."""
+    return text + json.dumps({"package": "PHANTOM_PACKAGE"}) + "\n"
+
+
+def _mutate_rename_package_key(text: str) -> str:
+    return text.replace('"package":', '"pkg":')
+
+
+def _mutate_swap_package_for_constraint(text: str) -> str:
+    """Replace the first 'package' value with a guaranteed-wrong name.
+
+    Keeps row count and shape identical — exercises the set-equality check.
+    """
+    return text.replace('"api-gateway"', '"NOT_A_REAL_PACKAGE"', 1)
+
+
+def _mutate_duplicate_package(text: str) -> str:
+    """Duplicate the first conflict line — dedup check should fire."""
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return text + "_"
+    return "\n".join([lines[0], *lines]) + "\n"
+
+
+NEGATIVE_CASES = [
+    NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        # Today the grader's structural early-exit catches this. After the
+        # empty-output false-negative fix lands, the rejection should come
+        # from the correctness check instead — at that point flip
+        # ``expected_substring`` to e.g. "missing".
+        expected_substring="empty",
+    ),
+    NegativeCase(
+        name="truncated_half",
+        mutate=_mutate_truncate_half,
+        expected_substring="",  # JSON parse error or missing-package
+    ),
+    NegativeCase(
+        name="renamed_package_key",
+        mutate=_mutate_rename_package_key,
+        expected_substring="missing 'package'",
+    ),
+    NegativeCase(
+        name="dropped_one_package",
+        mutate=_mutate_drop_one_package,
+        expected_substring="missing",
+    ),
+    NegativeCase(
+        name="extra_bogus_package",
+        mutate=_mutate_extra_bogus_package,
+        expected_substring="incorrect package",
+    ),
+    NegativeCase(
+        name="swap_package_name",
+        mutate=_mutate_swap_package_for_constraint,
+        expected_substring="",  # missing AND incorrect both fire
+    ),
+    NegativeCase(
+        name="duplicate_package",
+        mutate=_mutate_duplicate_package,
+        expected_substring="duplicate",
+    ),
+    NegativeCase(
+        name="wrap_in_list",
+        mutate=_mutate_wrap_in_list,
+        expected_substring="",
+    ),
+]

--- a/swebench/artifact_negative.py
+++ b/swebench/artifact_negative.py
@@ -1,0 +1,546 @@
+"""Shared helpers for the artifact-grader **negative** sanity check.
+
+SCHEMA_ARTIFACT.md §5.4 specifies a positive sanity check: a task's
+``reference_output`` should produce ``passed=True, score=1.0`` when fed back
+into its grader. That check catches graders that reject their own known-good
+answer, but it cannot catch a different — and just as common — silent failure:
+a grader that *accepts* artifacts it should reject because the prompt's
+correctness criterion was incompletely encoded.
+
+This module is the framework half of the negative sanity check (§5.5). It
+defines:
+
+* :class:`NegativeCase` — one negative-test entry: a name, a mutation function
+  applied to the reference-output bytes, and (optionally) a substring expected
+  to appear in the grader's ``detail`` field on rejection.
+* :func:`default_negative_cases` — six standard mutations every task gets for
+  free (empty, truncated, reversed-lines, renamed-required-field, off-by-one
+  numeric, wrap-in-list).
+* :func:`load_task_negative_cases` — discovery: per-task ``grader/negative_cases.py``
+  may export a ``NEGATIVE_CASES`` list; if it does we use that, else we fall
+  back to :func:`default_negative_cases`.
+* :func:`run_negative_case` — execute one mutation: materialize the workspace,
+  write the mutated artifact, invoke the grader, and report whether the
+  grader correctly rejected it.
+
+Authors of new tasks are encouraged but NOT required to ship a per-task
+``negative_cases.py``: the default cases catch the most common shape failures.
+A task author who knows the prompt encodes a property the default mutations
+do not exercise (sort order, optional fields, set vs. list semantics, …)
+SHOULD add a per-task case for that property.
+
+Cross-references:
+  - ``tools/check_grader_negative.py`` — the CLI driver that uses this module.
+  - ``tools/verify_graders.py`` — the existing positive sanity check.
+  - ``docs/SCHEMA_ARTIFACT.md`` §5.5 — the contract this module implements.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable
+
+from swebench.artifact_grade import GraderInvocationError, invoke_grader
+from swebench.artifact_materialize import materialize
+from swebench.artifact_models import GradeResult, Task
+
+
+# ─────────────────────────── data model ────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class NegativeCase:
+    """One deliberately-wrong artifact that the grader is expected to reject.
+
+    Attributes:
+        name: Short identifier used in CLI output (e.g. ``"empty"``,
+            ``"reversed_lines"``). Should be unique within a task's case list.
+        mutate: Callable that takes the reference-output bytes (as ``str``)
+            and returns a mutated string. Returning the input unchanged is
+            allowed but pointless — such a case is silently treated as a no-op.
+        expected_substring: Optional case-insensitive substring expected in the
+            grader's ``detail`` field. Empty string means "any rejection is
+            fine, just check ``passed=False``". Author-supplied substrings
+            help catch graders that reject for the *wrong* reason (e.g. an
+            empty-file shortcut firing before the correctness check).
+        currently_caught: ``True`` when today's grader is expected to reject
+            this mutation. ``False`` is reserved for cases that document a
+            known grader-vs-prompt alignment bug — the negative case fires
+            but the grader incorrectly passes. The driver prints WARNING for
+            ``False`` cases and continues; flipping to ``True`` lands as part
+            of the bug-fix PR.
+        notes: Free-form annotation. Often a GitHub issue link explaining why
+            ``currently_caught`` is ``False``.
+    """
+
+    name: str
+    mutate: Callable[[str], str]
+    expected_substring: str = ""
+    currently_caught: bool = True
+    notes: str = ""
+
+
+# ───────────────────────── default mutations ───────────────────────────────
+
+
+def _mutate_empty(text: str) -> str:
+    """Replace artifact with empty string."""
+    del text
+    return ""
+
+
+def _mutate_truncate_half(text: str) -> str:
+    """Keep the first 50% of the bytes (rounded down)."""
+    return text[: len(text) // 2]
+
+
+def _mutate_reverse_lines(text: str) -> str:
+    """Reverse the order of non-empty lines (catches missing order checks).
+
+    Preserves a trailing newline if the original had one. Strips blank lines
+    so a final blank doesn't become a leading blank after the reverse.
+    """
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if len(lines) <= 1:
+        # Single-line / empty inputs aren't useful for an order check; return
+        # something *visibly* mutated so the grader has a chance to fail.
+        return text + text
+    reversed_text = "\n".join(reversed(lines))
+    if text.endswith("\n"):
+        reversed_text += "\n"
+    return reversed_text
+
+
+_RENAME_PATTERNS = (
+    # Quoted JSON keys are the most common shape ("foo":).
+    (re.compile(r'"([A-Za-z_][A-Za-z0-9_]*)"\s*:'), True),
+)
+
+
+def _mutate_rename_one_field(text: str) -> str:
+    """Rename the first JSON key encountered to a guaranteed-wrong name.
+
+    Picks the first match of ``"<name>":`` in the text and renames it to
+    ``"<name>_was_renamed"``. Renames every occurrence of that exact key to
+    keep the document internally consistent (so a grader that fails on
+    "missing key X" fails for *that* reason, not a JSON parse error).
+
+    Falls back to a byte-flip suffix mutation if no JSON key is found
+    (some artifacts are plain text or CSV).
+    """
+    for pat, _ in _RENAME_PATTERNS:
+        match = pat.search(text)
+        if match:
+            old = match.group(1)
+            new = f"{old}_renamed"
+            # Replace every "<old>": in the text with "<new>":.
+            target = f'"{old}":'
+            replacement = f'"{new}":'
+            # Most graders don't care about whitespace; use a regex to be
+            # defensive against "foo" : (with space).
+            return re.sub(
+                r'"' + re.escape(old) + r'"\s*:',
+                replacement,
+                text,
+            )
+    # Plain-text fallback: append a marker that's likely to fail any
+    # length / row-count check.
+    return text + "RENAMED_FIELD_MUTATION_TAIL\n"
+
+
+_NUMERIC_RE = re.compile(r"(-?\d+\.\d+|-?\d+)")
+
+
+def _mutate_off_by_one(text: str) -> str:
+    """Add 1 to the first numeric literal in the text.
+
+    Catches graders that forgot to verify a numeric field. The mutation is
+    arithmetic, not lexical: a value like ``42`` becomes ``43``; ``3.14``
+    becomes ``4.14``. We only mutate the FIRST match because mutating every
+    number would push the artifact so far out of shape that *some other*
+    check would fire first.
+    """
+    match = _NUMERIC_RE.search(text)
+    if not match:
+        return text + "1"
+    raw = match.group(0)
+    try:
+        if "." in raw:
+            # Preserve the number of fractional digits so floating-point
+            # noise (e.g. ``3.14 + 1.0 -> 4.140000000000001``) does not
+            # leak into the artifact.
+            decimals = len(raw.split(".", 1)[1])
+            new_val = f"{float(raw) + 1.0:.{decimals}f}"
+        else:
+            new_val = str(int(raw) + 1)
+    except ValueError:  # pragma: no cover — regex guarantees parseable
+        return text
+    start, end = match.span()
+    return text[:start] + new_val + text[end:]
+
+
+def _mutate_wrap_in_list(text: str) -> str:
+    """Wrap the artifact in a JSON list literal.
+
+    Catches graders that don't validate top-level shape (e.g. they parse
+    each line of a JSONL file but never check that the file is JSONL and
+    not, say, a single JSON array).
+    """
+    return f"[{text}]"
+
+
+def default_negative_cases() -> list[NegativeCase]:
+    """Six task-agnostic negative cases applied to every grader by default.
+
+    Order is stable so the CLI output is reproducible.
+    """
+    return [
+        NegativeCase(
+            name="empty",
+            mutate=_mutate_empty,
+            expected_substring="",  # any rejection is fine
+            currently_caught=True,
+        ),
+        NegativeCase(
+            name="truncated_half",
+            mutate=_mutate_truncate_half,
+            expected_substring="",
+            currently_caught=True,
+        ),
+        NegativeCase(
+            name="reversed_lines",
+            mutate=_mutate_reverse_lines,
+            expected_substring="",
+            currently_caught=True,
+        ),
+        NegativeCase(
+            name="renamed_field",
+            mutate=_mutate_rename_one_field,
+            expected_substring="",
+            currently_caught=True,
+        ),
+        NegativeCase(
+            name="off_by_one",
+            mutate=_mutate_off_by_one,
+            expected_substring="",
+            currently_caught=True,
+        ),
+        NegativeCase(
+            name="wrap_in_list",
+            mutate=_mutate_wrap_in_list,
+            expected_substring="",
+            currently_caught=True,
+        ),
+    ]
+
+
+# ─────────────────────────── per-task discovery ────────────────────────────
+
+
+def load_task_negative_cases(task: Task) -> tuple[list[NegativeCase], bool]:
+    """Return ``(cases, is_custom)`` for ``task``.
+
+    ``is_custom`` is ``True`` when the task ships ``grader/negative_cases.py``
+    and the module exposes a non-None ``NEGATIVE_CASES`` list. ``False``
+    means the caller is using :func:`default_negative_cases` as a
+    diagnostic fallback. Callers SHOULD pass ``is_custom`` through to
+    :func:`run_negative_case` as ``from_defaults`` (inverted) so the
+    distinction shows up in outcome statuses.
+
+    The custom module is loaded by file path so the task tree does not need
+    to be on ``sys.path``. The ``swebench.artifact_negative`` module is
+    placed on ``sys.path`` at import time, so a task module can simply
+    ``from swebench.artifact_negative import NegativeCase``.
+    """
+    if task.task_dir is None:
+        raise ValueError(f"Task {task.instance_id!r} has no task_dir attached")
+    candidate = task.task_dir / "grader" / "negative_cases.py"
+    if not candidate.is_file():
+        return default_negative_cases(), False
+
+    module_name = f"_negative_cases_{task.instance_id}"
+    spec = importlib.util.spec_from_file_location(module_name, candidate)
+    if spec is None or spec.loader is None:  # pragma: no cover — defensive
+        raise ImportError(f"Could not load {candidate}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    cases = getattr(module, "NEGATIVE_CASES", None)
+    if cases is None:
+        # Module exists but is silent — treat as opt-in to defaults.
+        return default_negative_cases(), False
+    if not isinstance(cases, list) or not all(isinstance(c, NegativeCase) for c in cases):
+        raise TypeError(
+            f"{candidate}: NEGATIVE_CASES must be list[NegativeCase], "
+            f"got {type(cases).__name__}"
+        )
+    return list(cases), True
+
+
+# ─────────────────────────── case execution ────────────────────────────────
+
+
+@dataclass
+class NegativeCaseOutcome:
+    """Result of running one :class:`NegativeCase` against one task."""
+
+    task_id: str
+    case_name: str
+    status: str
+    # Status codes:
+    #   "PASS"           — grader correctly rejected the mutated artifact.
+    #   "MISS"           — grader accepted a mutated artifact from a CUSTOM
+    #                      per-task case. Hard failure.
+    #   "WEAK_MISS"      — grader accepted a mutated artifact from a DEFAULT
+    #                      mutation. Diagnostic only — surfaces alignment
+    #                      bugs in tasks that haven't yet shipped a custom
+    #                      grader/negative_cases.py. Does not fail CI.
+    #   "WRONG_REASON"   — grader rejected, but detail did not contain the
+    #                      expected substring. Soft failure when from a
+    #                      custom case (graders rejecting for the wrong
+    #                      reason are a real bug); diagnostic-only when from
+    #                      a default mutation.
+    #   "EXPECTED_MISS"  — grader accepted, AND the case was annotated
+    #                      ``currently_caught=False``. Warning only.
+    #   "ERROR"          — infrastructure failure.
+    detail: str = ""
+    grade_result: GradeResult | None = None
+    from_defaults: bool = False
+
+    @property
+    def is_failure(self) -> bool:
+        """True when this outcome should make the CLI exit non-zero.
+
+        ``WEAK_MISS`` and a ``WRONG_REASON`` from a default mutation are
+        diagnostic only — they reveal alignment bugs in tasks that haven't
+        yet been audited and should not break CI on the framework PR.
+        Promoting the finding to a custom case (with appropriate
+        ``currently_caught=False`` annotation) is the documented path to
+        track such bugs.
+        """
+        if self.status in {"MISS", "ERROR"}:
+            return True
+        if self.status == "WRONG_REASON" and not self.from_defaults:
+            return True
+        return False
+
+
+def run_negative_case(
+    task: Task,
+    case: NegativeCase,
+    *,
+    grader_timeout_seconds: float | None = 120.0,
+    from_defaults: bool = False,
+) -> NegativeCaseOutcome:
+    """Run one negative case end-to-end.
+
+    Steps:
+        1. Materialize the task workspace into a temp scratch dir.
+        2. Read the reference output, apply ``case.mutate``.
+        3. Write the mutated bytes to ``scratch / output_artifact``.
+        4. Invoke the grader.
+        5. Map the result to a :class:`NegativeCaseOutcome`.
+
+    Status semantics:
+        * ``PASS`` — grader returned ``passed=False`` and (if the case
+          declared one) the detail substring matched. This is the desired
+          outcome.
+        * ``MISS`` — grader returned ``passed=True``. The mutation slipped
+          through. **This is a real failure** unless the case is annotated
+          ``currently_caught=False`` (in which case the status is
+          ``EXPECTED_MISS``).
+        * ``WRONG_REASON`` — grader returned ``passed=False`` but the
+          detail did NOT contain the expected substring. The grader rejected
+          the artifact, but for a different reason than the case targeted.
+          Often indicates a structural shortcut firing before the
+          correctness check.
+        * ``EXPECTED_MISS`` — grader returned ``passed=True`` AND the case
+          was annotated ``currently_caught=False``. Treated as a known bug
+          (warning, but exit zero).
+        * ``ERROR`` — infrastructure failure (missing reference, bad
+          materialization, grader raised).
+    """
+    if task.task_dir is None:
+        return NegativeCaseOutcome(
+            task_id=task.instance_id,
+            case_name=case.name,
+            status="ERROR",
+            detail="task_dir not set",
+            from_defaults=from_defaults,
+        )
+
+    ref_path = task.task_dir / task.reference_output
+    if not ref_path.is_file():
+        return NegativeCaseOutcome(
+            task_id=task.instance_id,
+            case_name=case.name,
+            status="ERROR",
+            detail=f"reference_output not found: {ref_path}",
+            from_defaults=from_defaults,
+        )
+
+    try:
+        original = ref_path.read_text()
+    except OSError as exc:
+        return NegativeCaseOutcome(
+            task_id=task.instance_id,
+            case_name=case.name,
+            status="ERROR",
+            detail=f"could not read reference_output: {exc}",
+            from_defaults=from_defaults,
+        )
+
+    try:
+        mutated = case.mutate(original)
+    except Exception as exc:  # noqa: BLE001 — author code, surface anything
+        return NegativeCaseOutcome(
+            task_id=task.instance_id,
+            case_name=case.name,
+            status="ERROR",
+            detail=f"mutate({case.name}) raised: {exc!r}",
+            from_defaults=from_defaults,
+        )
+
+    if mutated == original:
+        # A no-op mutation gives no signal — flag explicitly rather than
+        # let it look like a successful negative test.
+        return NegativeCaseOutcome(
+            task_id=task.instance_id,
+            case_name=case.name,
+            status="ERROR",
+            detail="mutation produced unchanged output (no-op)",
+            from_defaults=from_defaults,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="check_grader_negative_") as tmp:
+        scratch = Path(tmp) / "scratch"
+        try:
+            materialize(task, scratch)
+        except Exception as exc:  # noqa: BLE001 — surface materialization errors
+            return NegativeCaseOutcome(
+                task_id=task.instance_id,
+                case_name=case.name,
+                status="ERROR",
+                detail=f"workspace materialization failed: {exc}",
+                from_defaults=from_defaults,
+            )
+
+        dest = scratch / task.output_artifact
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(mutated)
+
+        try:
+            result = invoke_grader(task, scratch, timeout_seconds=grader_timeout_seconds)
+        except GraderInvocationError as exc:
+            return NegativeCaseOutcome(
+                task_id=task.instance_id,
+                case_name=case.name,
+                status="ERROR",
+                detail=str(exc),
+                from_defaults=from_defaults,
+            )
+
+    if result.passed:
+        # The grader accepted a deliberately-wrong artifact.
+        if not case.currently_caught:
+            return NegativeCaseOutcome(
+                task_id=task.instance_id,
+                case_name=case.name,
+                status="EXPECTED_MISS",
+                detail=(
+                    f"known unfixed grader bug; passed=True; "
+                    f"detail={result.detail!r}; notes={case.notes!r}"
+                ),
+                grade_result=result,
+                from_defaults=from_defaults,
+            )
+        # Hard MISS for custom cases; WEAK_MISS (diagnostic) for defaults.
+        status = "WEAK_MISS" if from_defaults else "MISS"
+        return NegativeCaseOutcome(
+            task_id=task.instance_id,
+            case_name=case.name,
+            status=status,
+            detail=(
+                f"grader incorrectly returned passed=True; "
+                f"detail={result.detail!r}"
+            ),
+            grade_result=result,
+            from_defaults=from_defaults,
+        )
+
+    # Grader rejected. Optional substring check.
+    if case.expected_substring:
+        if case.expected_substring.lower() not in result.detail.lower():
+            return NegativeCaseOutcome(
+                task_id=task.instance_id,
+                case_name=case.name,
+                status="WRONG_REASON",
+                detail=(
+                    f"expected detail to contain "
+                    f"{case.expected_substring!r}; got {result.detail!r}"
+                ),
+                grade_result=result,
+                from_defaults=from_defaults,
+            )
+
+    return NegativeCaseOutcome(
+        task_id=task.instance_id,
+        case_name=case.name,
+        status="PASS",
+        detail=result.detail,
+        grade_result=result,
+        from_defaults=from_defaults,
+    )
+
+
+def run_all_for_task(
+    task: Task,
+    cases: Iterable[NegativeCase] | None = None,
+    *,
+    grader_timeout_seconds: float | None = 120.0,
+    from_defaults: bool | None = None,
+) -> list[NegativeCaseOutcome]:
+    """Run every negative case for one task and return the outcomes.
+
+    If ``cases`` is None, the per-task list is loaded via
+    :func:`load_task_negative_cases` and ``from_defaults`` is inferred. If
+    ``cases`` is provided explicitly, ``from_defaults`` defaults to ``False``
+    (the caller is making a deliberate choice; treat as custom unless
+    overridden).
+    """
+    if cases is None:
+        cases, is_custom = load_task_negative_cases(task)
+        inferred_from_defaults = not is_custom
+        if from_defaults is None:
+            from_defaults = inferred_from_defaults
+    else:
+        cases = list(cases)
+        if from_defaults is None:
+            from_defaults = False
+    return [
+        run_negative_case(
+            task,
+            c,
+            grader_timeout_seconds=grader_timeout_seconds,
+            from_defaults=from_defaults,
+        )
+        for c in cases
+    ]
+
+
+__all__ = [
+    "NegativeCase",
+    "NegativeCaseOutcome",
+    "default_negative_cases",
+    "load_task_negative_cases",
+    "run_all_for_task",
+    "run_negative_case",
+]

--- a/tests/test_check_grader_negative.py
+++ b/tests/test_check_grader_negative.py
@@ -1,0 +1,481 @@
+"""Tests for the negative-sanity-check framework (SCHEMA §5.5).
+
+Covers two layers:
+
+* The library helpers in ``swebench.artifact_negative`` — default
+  mutations, custom-case discovery, the per-case runner.
+* The CLI tool ``tools/check_grader_negative.py`` — exit codes for the
+  pass / fail / unexpected-pass scenarios.
+
+The CLI tests build synthetic tasks at temp paths so we don't rely on the
+real ``problems/artifact/`` tree (which can have real bugs we don't want
+to assert against in unit tests).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from swebench.artifact_loader import load_tasks
+from swebench.artifact_negative import (
+    NegativeCase,
+    NegativeCaseOutcome,
+    _mutate_empty,
+    _mutate_off_by_one,
+    _mutate_rename_one_field,
+    _mutate_reverse_lines,
+    _mutate_truncate_half,
+    _mutate_wrap_in_list,
+    default_negative_cases,
+    load_task_negative_cases,
+    run_negative_case,
+)
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TOOL = _REPO_ROOT / "tools" / "check_grader_negative.py"
+
+
+# ─────────────────────── default-mutation unit tests ──────────────────────
+
+
+def test_mutate_empty_returns_empty():
+    assert _mutate_empty("anything") == ""
+
+
+def test_mutate_truncate_half_keeps_prefix():
+    assert _mutate_truncate_half("abcdefgh") == "abcd"
+    assert _mutate_truncate_half("") == ""
+
+
+def test_mutate_reverse_lines_swaps_order():
+    src = "a\nb\nc\n"
+    out = _mutate_reverse_lines(src)
+    assert out.endswith("\n")
+    # Order of non-empty lines is reversed.
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert lines == ["c", "b", "a"]
+
+
+def test_mutate_reverse_lines_handles_singleton():
+    """Single-line input: reverse is a no-op, so the helper must produce
+    something visibly different (the runner rejects no-op mutations)."""
+    out = _mutate_reverse_lines("only-one\n")
+    assert out != "only-one\n"
+
+
+def test_mutate_rename_one_field_renames_quoted_key():
+    src = '{"product_id": "P001", "value": 3}'
+    out = _mutate_rename_one_field(src)
+    assert '"product_id_renamed"' in out
+    assert '"product_id"' not in out
+
+
+def test_mutate_rename_one_field_plain_text_fallback():
+    src = "no JSON here\n"
+    out = _mutate_rename_one_field(src)
+    assert out != src  # something changed
+
+
+def test_mutate_off_by_one_increments_first_number():
+    assert _mutate_off_by_one("answer is 42") == "answer is 43"
+    assert _mutate_off_by_one("pi=3.14") == "pi=4.14"
+    # No numerics → fallback appends a digit so output differs from input.
+    assert _mutate_off_by_one("none here") != "none here"
+
+
+def test_mutate_wrap_in_list_wraps_text():
+    assert _mutate_wrap_in_list("payload") == "[payload]"
+
+
+def test_default_negative_cases_includes_six_cases():
+    cases = default_negative_cases()
+    assert len(cases) == 6
+    names = [c.name for c in cases]
+    assert names == [
+        "empty",
+        "truncated_half",
+        "reversed_lines",
+        "renamed_field",
+        "off_by_one",
+        "wrap_in_list",
+    ]
+    assert all(isinstance(c, NegativeCase) for c in cases)
+    assert all(c.currently_caught for c in cases)
+
+
+# ───────────────────────── per-task discovery tests ───────────────────────
+
+
+def _make_minimal_task(
+    task_dir: Path,
+    grader_src: str,
+    ref_content: str,
+    *,
+    custom_cases_src: str | None = None,
+    instance_suffix: str | None = None,
+) -> None:
+    """Build a minimal artifact task at ``task_dir``."""
+    suffix = instance_suffix or task_dir.name
+    (task_dir / "workspace").mkdir(parents=True, exist_ok=True)
+    (task_dir / "workspace" / "input.txt").write_text("# empty\n")
+    (task_dir / "grader").mkdir(parents=True, exist_ok=True)
+    (task_dir / "grader" / "hidden.py").write_text(textwrap.dedent(grader_src))
+    (task_dir / "grader" / "reference_output.txt").write_text(ref_content)
+    if custom_cases_src is not None:
+        (task_dir / "grader" / "negative_cases.py").write_text(
+            textwrap.dedent(custom_cases_src)
+        )
+    (task_dir / "prompt.md").write_text("produce answer.txt\n")
+    (task_dir / "task.yaml").write_text(textwrap.dedent(f"""\
+        instance_id: test_fixture__neg_{suffix}
+        category: test_fixture
+        difficulty: easy
+        problem_statement: prompt.md
+        workspace_dir: workspace/
+        output_artifact: answer.txt
+        hidden_grader: grader/hidden.py
+        reference_output: grader/reference_output.txt
+        execution_budget:
+          max_code_runs: 0
+          max_wall_seconds: 0
+    """))
+
+
+_GRADER_LENGTH_8 = """
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True)
+    class GradeResult:
+        passed: bool
+        score: float
+        detail: str
+
+    def grade(scratch_dir):
+        from pathlib import Path
+        artifact = Path(scratch_dir) / "answer.txt"
+        if not artifact.exists():
+            return GradeResult(False, 0.0, "output artifact not produced")
+        text = artifact.read_text()
+        if not text.strip():
+            return GradeResult(False, 0.0, "output artifact is empty")
+        if len(text) != 8:
+            return GradeResult(False, 0.0, f"length is {len(text)}, want 8")
+        return GradeResult(True, 1.0, "ok")
+"""
+
+
+_GRADER_ALWAYS_PASSES = """
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True)
+    class GradeResult:
+        passed: bool
+        score: float
+        detail: str
+
+    def grade(scratch_dir):
+        return GradeResult(True, 1.0, "always pass")
+"""
+
+
+def test_load_negative_cases_falls_back_to_defaults(tmp_path):
+    task_dir = tmp_path / "tasks" / "test_fixture" / "fallback_task"
+    _make_minimal_task(task_dir, _GRADER_LENGTH_8, "01234567")
+    [task] = load_tasks(tmp_path / "tasks")
+    cases, is_custom = load_task_negative_cases(task)
+    assert is_custom is False
+    assert [c.name for c in cases] == [c.name for c in default_negative_cases()]
+
+
+def test_load_negative_cases_picks_custom_module(tmp_path):
+    custom = '''\
+        from swebench.artifact_negative import NegativeCase
+
+        NEGATIVE_CASES = [
+            NegativeCase(name="custom_only", mutate=lambda t: "WRONG", expected_substring=""),
+        ]
+    '''
+    task_dir = tmp_path / "tasks" / "test_fixture" / "custom_task"
+    _make_minimal_task(
+        task_dir,
+        _GRADER_LENGTH_8,
+        "01234567",
+        custom_cases_src=custom,
+    )
+    [task] = load_tasks(tmp_path / "tasks")
+    cases, is_custom = load_task_negative_cases(task)
+    assert is_custom is True
+    assert [c.name for c in cases] == ["custom_only"]
+
+
+def test_load_negative_cases_rejects_wrong_type(tmp_path):
+    bad = '''\
+        NEGATIVE_CASES = "not a list"
+    '''
+    task_dir = tmp_path / "tasks" / "test_fixture" / "bad_task"
+    _make_minimal_task(
+        task_dir,
+        _GRADER_LENGTH_8,
+        "01234567",
+        custom_cases_src=bad,
+    )
+    [task] = load_tasks(tmp_path / "tasks")
+    with pytest.raises(TypeError):
+        load_task_negative_cases(task)
+
+
+# ─────────────────────────── run_negative_case ─────────────────────────────
+
+
+def test_run_negative_case_pass_when_grader_rejects(tmp_path):
+    task_dir = tmp_path / "tasks" / "test_fixture" / "ok_task"
+    _make_minimal_task(task_dir, _GRADER_LENGTH_8, "01234567")
+    [task] = load_tasks(tmp_path / "tasks")
+
+    case = NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        expected_substring="empty",
+    )
+    outcome = run_negative_case(task, case)
+    assert outcome.status == "PASS", outcome
+
+
+def test_run_negative_case_miss_when_grader_passes(tmp_path):
+    task_dir = tmp_path / "tasks" / "test_fixture" / "broken_task"
+    _make_minimal_task(task_dir, _GRADER_ALWAYS_PASSES, "01234567")
+    [task] = load_tasks(tmp_path / "tasks")
+
+    case = NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+    )
+    outcome = run_negative_case(task, case)
+    assert outcome.status == "MISS", outcome
+    assert outcome.is_failure
+
+
+def test_run_negative_case_weak_miss_for_default_mutation(tmp_path):
+    """A default-mutation MISS is a diagnostic WEAK_MISS, not a hard MISS."""
+    task_dir = tmp_path / "tasks" / "test_fixture" / "default_miss_task"
+    _make_minimal_task(task_dir, _GRADER_ALWAYS_PASSES, "01234567")
+    [task] = load_tasks(tmp_path / "tasks")
+
+    case = NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+    )
+    outcome = run_negative_case(task, case, from_defaults=True)
+    assert outcome.status == "WEAK_MISS", outcome
+    # WEAK_MISS does NOT fail the CLI gate.
+    assert not outcome.is_failure
+
+
+def test_run_negative_case_expected_miss_for_known_bug(tmp_path):
+    task_dir = tmp_path / "tasks" / "test_fixture" / "known_bug_task"
+    _make_minimal_task(task_dir, _GRADER_ALWAYS_PASSES, "01234567")
+    [task] = load_tasks(tmp_path / "tasks")
+
+    case = NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        currently_caught=False,
+        notes="documented in issue #999",
+    )
+    outcome = run_negative_case(task, case)
+    assert outcome.status == "EXPECTED_MISS", outcome
+    # EXPECTED_MISS is not a CLI failure.
+    assert not outcome.is_failure
+
+
+def test_run_negative_case_wrong_reason(tmp_path):
+    task_dir = tmp_path / "tasks" / "test_fixture" / "wrong_reason_task"
+    _make_minimal_task(task_dir, _GRADER_LENGTH_8, "01234567")
+    [task] = load_tasks(tmp_path / "tasks")
+
+    # Empty triggers the grader's "is empty" branch — detail says "empty",
+    # not "wrong magic phrase".
+    case = NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        expected_substring="wrong magic phrase",
+    )
+    outcome = run_negative_case(task, case)
+    assert outcome.status == "WRONG_REASON", outcome
+
+
+def test_run_negative_case_no_op_mutation_is_error(tmp_path):
+    task_dir = tmp_path / "tasks" / "test_fixture" / "noop_task"
+    _make_minimal_task(task_dir, _GRADER_LENGTH_8, "01234567")
+    [task] = load_tasks(tmp_path / "tasks")
+
+    case = NegativeCase(
+        name="noop",
+        mutate=lambda t: t,  # returns input unchanged
+    )
+    outcome = run_negative_case(task, case)
+    assert outcome.status == "ERROR"
+    assert "no-op" in outcome.detail
+
+
+# ───────────────────────────── CLI tests ──────────────────────────────────
+
+
+def _run_cli(tasks_dir: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_TOOL),
+            "--tasks-dir",
+            str(tasks_dir),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_exit_zero_when_grader_catches_everything(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    task_dir = tasks_dir / "test_fixture" / "catches_task"
+    custom = '''\
+        from swebench.artifact_negative import NegativeCase, _mutate_empty
+
+        NEGATIVE_CASES = [
+            NegativeCase(name="empty", mutate=_mutate_empty),
+        ]
+    '''
+    _make_minimal_task(
+        task_dir,
+        _GRADER_LENGTH_8,
+        "01234567",
+        custom_cases_src=custom,
+    )
+    proc = _run_cli(tasks_dir)
+    assert proc.returncode == 0, proc.stderr
+    assert "PASS" in proc.stdout
+    assert "test_fixture__neg_catches_task" in proc.stdout
+
+
+def test_cli_exit_one_when_grader_misses(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    task_dir = tasks_dir / "test_fixture" / "misses_task"
+    custom = '''\
+        from swebench.artifact_negative import NegativeCase, _mutate_empty
+
+        NEGATIVE_CASES = [
+            NegativeCase(name="empty", mutate=_mutate_empty),
+        ]
+    '''
+    _make_minimal_task(
+        task_dir,
+        _GRADER_ALWAYS_PASSES,
+        "01234567",
+        custom_cases_src=custom,
+    )
+    proc = _run_cli(tasks_dir)
+    assert proc.returncode == 1, proc.stdout
+    assert "MISS" in proc.stdout
+    assert "missed-by-grader" in proc.stdout
+
+
+def test_cli_exit_zero_when_known_bug_warns(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    task_dir = tasks_dir / "test_fixture" / "knownbug_task"
+    custom = '''\
+        from swebench.artifact_negative import NegativeCase, _mutate_empty
+
+        NEGATIVE_CASES = [
+            NegativeCase(
+                name="empty",
+                mutate=_mutate_empty,
+                currently_caught=False,
+                notes="issue #foo",
+            ),
+        ]
+    '''
+    _make_minimal_task(
+        task_dir,
+        _GRADER_ALWAYS_PASSES,
+        "01234567",
+        custom_cases_src=custom,
+    )
+    proc = _run_cli(tasks_dir)
+    assert proc.returncode == 0, proc.stdout
+    assert "WARN" in proc.stdout
+    assert "known-bug" in proc.stdout
+
+
+def test_cli_exit_two_when_no_tasks(tmp_path):
+    empty = tmp_path / "tasks"
+    empty.mkdir()
+    proc = _run_cli(empty)
+    assert proc.returncode == 2
+
+
+def test_cli_filter_runs_only_named_task(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    custom_pass = '''\
+        from swebench.artifact_negative import NegativeCase, _mutate_empty
+        NEGATIVE_CASES = [NegativeCase(name="empty", mutate=_mutate_empty)]
+    '''
+    custom_miss = '''\
+        from swebench.artifact_negative import NegativeCase, _mutate_empty
+        NEGATIVE_CASES = [NegativeCase(name="empty", mutate=_mutate_empty)]
+    '''
+    _make_minimal_task(
+        tasks_dir / "test_fixture" / "selected",
+        _GRADER_LENGTH_8,
+        "01234567",
+        custom_cases_src=custom_pass,
+        instance_suffix="selected",
+    )
+    _make_minimal_task(
+        tasks_dir / "test_fixture" / "skipped",
+        _GRADER_ALWAYS_PASSES,
+        "01234567",
+        custom_cases_src=custom_miss,
+        instance_suffix="skipped",
+    )
+
+    # Without filter: skipped task fails → exit 1.
+    proc_all = _run_cli(tasks_dir)
+    assert proc_all.returncode == 1
+
+    # With filter targeting only the passing task → exit 0.
+    proc_one = _run_cli(tasks_dir, "--filter", "test_fixture__neg_selected")
+    assert proc_one.returncode == 0
+    assert "test_fixture__neg_skipped" not in proc_one.stdout
+
+
+def test_cli_tasks_with_custom_cases_only(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    # One task with custom cases, one without.
+    custom = '''\
+        from swebench.artifact_negative import NegativeCase, _mutate_empty
+        NEGATIVE_CASES = [NegativeCase(name="empty", mutate=_mutate_empty)]
+    '''
+    _make_minimal_task(
+        tasks_dir / "test_fixture" / "with_custom",
+        _GRADER_LENGTH_8,
+        "01234567",
+        custom_cases_src=custom,
+        instance_suffix="with_custom",
+    )
+    _make_minimal_task(
+        tasks_dir / "test_fixture" / "no_custom",
+        _GRADER_LENGTH_8,
+        "01234567",
+        instance_suffix="no_custom",
+    )
+
+    proc = _run_cli(tasks_dir, "--tasks-with-custom-cases-only")
+    assert proc.returncode == 0
+    assert "test_fixture__neg_with_custom" in proc.stdout
+    assert "test_fixture__neg_no_custom" not in proc.stdout

--- a/tools/check_grader_negative.py
+++ b/tools/check_grader_negative.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Pre-merge grader **negative** sanity gate (SCHEMA_ARTIFACT.md §5.5).
+
+The positive sanity check (``tools/verify_graders.py``) feeds a task's
+``reference_output`` into its grader and asserts ``passed=True, score=1.0``.
+That catches graders that reject their own known-good answer, but it does
+NOT catch graders that *accept* deliberately-wrong artifacts because the
+prompt's correctness criterion was incompletely encoded.
+
+This tool walks every task under ``problems/artifact/<category>/<slug>/``,
+applies a small set of *deliberately wrong* mutations to the reference
+output, runs the grader against each mutated artifact, and asserts the
+grader returns ``passed=False``. Mutations come from
+``swebench.artifact_negative.default_negative_cases`` plus, optionally, a
+per-task ``grader/negative_cases.py`` shipping a ``NEGATIVE_CASES`` list.
+
+Exit codes:
+  0  every case the framework expects to catch was caught (known-bug
+     ``EXPECTED_MISS`` outcomes are tolerated; they print a warning)
+  1  at least one mutation slipped through the grader unexpectedly
+     (``MISS``), the grader rejected for the wrong reason
+     (``WRONG_REASON``), or a case raised an infrastructure error (``ERROR``)
+  2  task discovery / parse error, or no tasks found
+
+Usage:
+    python tools/check_grader_negative.py
+    python tools/check_grader_negative.py --tasks-dir path/to/problems/artifact
+    python tools/check_grader_negative.py --filter data_processing__multi_file_cohort
+    python tools/check_grader_negative.py --tasks-with-custom-cases-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Allow running as ``python tools/check_grader_negative.py`` from the repo
+# root without editable-installing swebench.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from swebench.artifact_loader import load_tasks
+from swebench.artifact_negative import (
+    NegativeCaseOutcome,
+    load_task_negative_cases,
+    run_all_for_task,
+)
+
+
+_STATUS_GLYPH = {
+    "PASS": "PASS",
+    "MISS": "MISS",
+    "WEAK_MISS": "WEAK",
+    "WRONG_REASON": "WRONG",
+    "EXPECTED_MISS": "WARN",
+    "ERROR": "ERR ",
+}
+
+
+def _print_outcome(outcome: NegativeCaseOutcome) -> None:
+    glyph = _STATUS_GLYPH.get(outcome.status, outcome.status)
+    print(
+        f"  {glyph}  {outcome.case_name:<22s}  {outcome.detail}",
+        flush=True,
+    )
+
+
+def _has_custom_cases(task) -> bool:
+    candidate = (task.task_dir or Path(".")) / "grader" / "negative_cases.py"
+    return candidate.is_file()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0] if __doc__ else "",
+    )
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        default=_REPO_ROOT / "problems" / "artifact",
+        help="root tasks directory (default: <repo>/problems/artifact/)",
+    )
+    parser.add_argument(
+        "--filter",
+        action="append",
+        default=[],
+        metavar="INSTANCE_ID",
+        help=(
+            "only run on the named task(s); may be passed multiple times. "
+            "If omitted, every task under --tasks-dir is exercised."
+        ),
+    )
+    parser.add_argument(
+        "--tasks-with-custom-cases-only",
+        action="store_true",
+        help=(
+            "only exercise tasks that ship grader/negative_cases.py. "
+            "Useful for the per-PR fast lane: a task author adding a new "
+            "task can confirm their custom cases work without paying for "
+            "every other task's default cases."
+        ),
+    )
+    parser.add_argument(
+        "--grader-timeout-seconds",
+        type=float,
+        default=120.0,
+        help="per-grader timeout passed through to invoke_grader",
+    )
+    args = parser.parse_args(argv)
+
+    tasks_dir: Path = args.tasks_dir
+    filter_ids: list[str] | None = list(args.filter) or None
+
+    try:
+        tasks = load_tasks(tasks_dir, filter_ids=filter_ids)
+    except ValueError as exc:
+        print(f"ERROR: task discovery/parse failed: {exc}", file=sys.stderr)
+        return 2
+
+    if not tasks:
+        print("No tasks found — nothing to check.", file=sys.stderr)
+        return 2
+
+    if args.tasks_with_custom_cases_only:
+        tasks = [t for t in tasks if _has_custom_cases(t)]
+        if not tasks:
+            print(
+                "No tasks ship grader/negative_cases.py "
+                "(filtered by --tasks-with-custom-cases-only).",
+                file=sys.stderr,
+            )
+            return 2
+
+    overall_exit = 0
+    counts: Counter[str] = Counter()
+    miss_records: list[NegativeCaseOutcome] = []
+
+    for task in tasks:
+        custom = _has_custom_cases(task)
+        marker = "(custom)" if custom else "(default)"
+        print(f"\n{task.instance_id}  {marker}", flush=True)
+
+        try:
+            cases, is_custom = load_task_negative_cases(task)
+        except Exception as exc:  # noqa: BLE001 — surface any author error
+            print(f"  ERR   <load_negative_cases>  {exc}", flush=True, file=sys.stderr)
+            counts["ERROR"] += 1
+            overall_exit = 1
+            continue
+
+        if not cases:
+            print("  WARN  <no cases registered>", flush=True)
+            continue
+
+        outcomes = run_all_for_task(
+            task,
+            cases,
+            grader_timeout_seconds=args.grader_timeout_seconds,
+            from_defaults=not is_custom,
+        )
+        for outcome in outcomes:
+            _print_outcome(outcome)
+            counts[outcome.status] += 1
+            if outcome.is_failure:
+                overall_exit = 1
+                miss_records.append(outcome)
+
+    print(
+        "\nSummary: "
+        f"{counts['PASS']} pass, "
+        f"{counts['MISS']} missed-by-grader (custom), "
+        f"{counts['WEAK_MISS']} missed-by-grader (default mutations, diagnostic), "
+        f"{counts['WRONG_REASON']} wrong-reason, "
+        f"{counts['EXPECTED_MISS']} known-bug warnings, "
+        f"{counts['ERROR']} errors.",
+        flush=True,
+    )
+
+    if counts["WEAK_MISS"] > 0:
+        print(
+            f"\n{counts['WEAK_MISS']} default-mutation MISS(es) on tasks "
+            "without grader/negative_cases.py — these reveal alignment bugs "
+            "but do not fail CI. Track each by adding a per-task "
+            "negative_cases.py with currently_caught=False (see SCHEMA §5.5).",
+        )
+
+    if miss_records:
+        print(
+            "\nFailures (these slipped through the grader unexpectedly):",
+            file=sys.stderr,
+        )
+        for o in miss_records:
+            print(
+                f"  {o.task_id}::{o.case_name}  [{o.status}]  {o.detail}",
+                file=sys.stderr,
+            )
+
+    return overall_exit
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #171.

## Summary

Introduce a **negative** counterpart to the existing positive pre-merge sanity check (`tools/verify_graders.py`, SCHEMA §5.4). The positive check catches graders that reject their own known-good answer; this PR catches graders that *accept* deliberately-wrong artifacts because the prompt's correctness criterion was incompletely encoded.

For each task, a small set of mutations is applied to `reference_output`, the mutated artifact is fed through the grader, and `passed=False` is asserted. The four bugs called out in the issue surface as expected:

| Task | Bug | Mutation that surfaces it | Status today |
|---|---|---|---|
| `data_processing__multi_file_cohort` | Prompt requires descending order; grader does set-equality on product_ids | `reversed_lines` | `EXPECTED_MISS` (warning) |
| `stateful_reasoning__event_ledger` | Prompt requires chronological `rejected` list; grader uses `set(...)` | `reversed_rejected` and `rejected_as_dict` | `EXPECTED_MISS` (warning) |
| `stateful_reasoning__unreachable_functions` | Prompt requires `module` field; grader only validates `function` | `drop_module_field` and `wrong_module_value` | `EXPECTED_MISS` (warning) |
| `stateful_reasoning__upgrade_impact` | Empty-output structural early-exit fires before correctness check | (documented; needs alternate workspace to fully exercise) | n/a — comment in `negative_cases.py` |

The alignment-bug cases are annotated `currently_caught=False` with GitHub-issue notes so they print `WARNING` today and flip to `PASS` once the alignment-fix PRs land. The rest of each task's safety net is exercised with `currently_caught=True` cases that lock in current correct behaviour.

## What's in the diff

**Framework**
- `swebench/artifact_negative.py` — `NegativeCase` model, six default mutations (`empty`, `truncated_half`, `reversed_lines`, `renamed_field`, `off_by_one`, `wrap_in_list`), per-task discovery, and the per-case runner. Outcome statuses: `PASS` / `MISS` (custom) / `WEAK_MISS` (default mutation diagnostic) / `WRONG_REASON` / `EXPECTED_MISS` / `ERROR`.
- `tools/check_grader_negative.py` — CLI driver mirroring the shape of `tools/verify_graders.py`.
- `tests/test_check_grader_negative.py` — 24 unit + CLI tests covering every status code and the custom-vs-default distinction.

**Per-task cases** (all four named in the issue):
- `problems/artifact/data_processing/multi_file_cohort/grader/negative_cases.py`
- `problems/artifact/stateful_reasoning/event_ledger/grader/negative_cases.py`
- `problems/artifact/stateful_reasoning/unreachable_functions/grader/negative_cases.py`
- `problems/artifact/stateful_reasoning/upgrade_impact/grader/negative_cases.py`

**Wiring**
- `Makefile` — `check-graders`, `check-graders-positive`, `check-graders-negative`, `check-graders-leaks`, `check-graders-fast`. Existing `tools/check_grader_leaks.py` is folded into the umbrella target.
- `.github/workflows/check-graders.yml` — runs the three gates on PRs that touch artifact graders, tasks, or the gate tools themselves.

**Docs**
- `docs/SCHEMA_ARTIFACT.md` — new §5.5 documenting the negative contract, `NegativeCase` field reference, the `currently_caught=False` escape hatch, the outcome-status table, and the WEAK_MISS rationale. §8 author checklist updated.

## Why `WEAK_MISS`

Running the default mutations across all 48 existing tasks reveals 23 additional alignment bugs in tasks that aren't named in this issue. Failing CI on every one of them today would block this PR on a 48-task retro-audit that's out of scope for the "first pass identifies and confirms the bugs noted above" framing in the issue.

The `WEAK_MISS` status records the finding (visible in CLI output), the summary tells the maintainer how many there are and where to look, but it does not exit non-zero. Promoting a `WEAK_MISS` to a tracked `EXPECTED_MISS` is a small follow-up PR per task: add `grader/negative_cases.py` with `currently_caught=False` and an issue link in `notes`. Once the alignment-fix lands, flip to `currently_caught=True` and the gate enforces the contract.

## Test plan

- [x] `pytest tests/test_check_grader_negative.py` — 24/24 pass
- [x] `pytest tests/test_check_grader_negative.py tests/test_verify_graders.py tests/test_artifact_grade.py tests/test_artifact_loader.py tests/test_artifact_materialize.py` — 62/62 pass
- [x] `python tools/check_grader_negative.py --tasks-with-custom-cases-only` exits 0 with 5 `EXPECTED_MISS` warnings (the 4 named bugs)
- [x] `python tools/check_grader_negative.py` (full scan) exits 0 — 267 PASS, 23 WEAK_MISS (diagnostic), 5 EXPECTED_MISS
- [x] `python tools/verify_graders.py` still passes for the 4 named tasks
- [ ] CI run on this PR: `.github/workflows/check-graders.yml` green

## Acceptance criteria from #171

- [x] Add `tools/check_grader_negative.py` that runs the grader against deliberately wrong artifacts and asserts `passed=False`
- [x] Each (named) task ships a `grader/negative_cases.py` with mutate / expected-substring pairs covering the standard mutation menu (empty, truncated, reordered rows, renamed field, off-by-one numeric, wrong shape)
- [x] Hook into CI via `make check-graders` umbrella target + `.github/workflows/check-graders.yml`
- [x] First pass identifies and confirms the four bugs noted in the issue (visible as `EXPECTED_MISS` warnings until the alignment fixes land)
- [x] Document the contract in `docs/SCHEMA_ARTIFACT.md` §5.5 "Negative sanity check"
