### PR TITLE
Align prompt requirements with grader checks (#166)

### DIFF
--- a/problems/artifact/algorithmic/min_cost_assignment/grader/hidden.py
+++ b/problems/artifact/algorithmic/min_cost_assignment/grader/hidden.py
@@ -4,10 +4,17 @@ Contract: ``grade(scratch_dir: Path) -> GradeResult``. See docs/SCHEMA_ARTIFACT.
 
 Correctness criterion:
 
-    The agent's output/assignment.json MUST contain an "assignment" key
-    (list of num_workers ints, assignment[worker] = task) representing a
-    perfect matching whose total cost equals the optimal minimum cost.
-    The grader accepts any optimal-cost assignment — identity is not checked.
+    The agent's output/assignment.json MUST contain:
+
+      - ``assignment``: list of num_workers ints, assignment[worker] = task,
+        representing a perfect matching whose total cost equals the optimal
+        minimum cost. The grader accepts any optimal-cost assignment —
+        identity is not checked.
+      - ``assignment_cost``: integer equal to the sum of
+        cost_matrix[i][assignment[i]] for all i, AND equal to the optimal
+        minimum cost. Issue #166 aligned this name across prompt, grader,
+        and reference output (previously: prompt said "total_cost", grader
+        ignored the field, reference said "optimal_cost").
 
     Optimal cost is computed via the Hungarian algorithm (pure Python,
     no scipy dependency — see _hungarian below).
@@ -144,7 +151,7 @@ def grade(scratch_dir: Path) -> GradeResult:
             )
         assigned_tasks.add(task)
 
-    # Compute agent's total cost
+    # Compute agent's total cost from the matching
     agent_cost = sum(cost_matrix[i][assignment[i]] for i in range(num_workers))
 
     # Compute optimal
@@ -156,4 +163,22 @@ def grade(scratch_dir: Path) -> GradeResult:
             f"assignment cost {agent_cost} is not optimal",
         )
 
-    return GradeResult(True, 1.0, "assignment cost is optimal")
+    # Issue #166: validate the agent's reported ``assignment_cost`` field
+    # (previously the prompt asked for it but the grader never read it,
+    # and the reference output used a third name, ``optimal_cost``).
+    # The reported value must (a) be present, (b) be an integer, and (c)
+    # equal the cost we just summed from the matching.
+    if "assignment_cost" not in agent_output:
+        return GradeResult(False, 0.0,
+            "output missing required key 'assignment_cost'")
+    reported = agent_output["assignment_cost"]
+    if isinstance(reported, bool) or not isinstance(reported, int):
+        return GradeResult(False, 0.0,
+            f"assignment_cost must be an integer, got {type(reported).__name__}")
+    if reported != agent_cost:
+        return GradeResult(False, 0.0,
+            f"assignment_cost {reported} disagrees with cost summed "
+            f"from the matching ({agent_cost})")
+
+    return GradeResult(True, 1.0,
+        "assignment cost is optimal and assignment_cost is consistent")

--- a/problems/artifact/algorithmic/min_cost_assignment/grader/reference_output.json
+++ b/problems/artifact/algorithmic/min_cost_assignment/grader/reference_output.json
@@ -1,5 +1,5 @@
 {
-  "optimal_cost": 170,
+  "assignment_cost": 170,
   "assignment": [
     5,
     11,

--- a/problems/artifact/algorithmic/min_cost_assignment/prompt.md
+++ b/problems/artifact/algorithmic/min_cost_assignment/prompt.md
@@ -23,13 +23,13 @@ Write `output/assignment.json`:
 ```json
 {
   "assignment": [task_for_worker_0, task_for_worker_1, ..., task_for_worker_19],
-  "total_cost": <integer>
+  "assignment_cost": <integer>
 }
 ```
 
 - `assignment`: list of 20 integers — `assignment[i]` is the 0-indexed task assigned to worker `i`
 - Every task must appear exactly once (perfect matching)
-- `total_cost`: the sum of `cost_matrix[i][assignment[i]]` for all `i`
+- `assignment_cost`: the sum of `cost_matrix[i][assignment[i]]` for all `i`
 
 ## Requirements
 

--- a/problems/artifact/data_processing/multi_file_cohort/grader/hidden.py
+++ b/problems/artifact/data_processing/multi_file_cohort/grader/hidden.py
@@ -56,4 +56,13 @@ def grade(scratch_dir: Path) -> GradeResult:
         if abs(agent_rev - expected_rev) / expected_rev > TOLERANCE:
             return GradeResult(False, 0.0, f"revenue for {pid}: got {agent_rev:.2f}, out of tolerance")
 
-    return GradeResult(True, 1.0, f"correct top-5 products identified with revenues within {TOLERANCE*100:.0f}% tolerance")
+    # Issue #166: prompt requires rows in descending order by total_revenue.
+    # Verify agent's row order matches this requirement. We check monotonic
+    # non-increasing because two products could in principle tie on revenue
+    # (though that's vanishingly rare with float arithmetic on this data).
+    agent_revs = [float(e["total_revenue"]) for e in agent_top5]
+    if agent_revs != sorted(agent_revs, reverse=True):
+        return GradeResult(False, 0.0,
+            "rows not in descending order by total_revenue")
+
+    return GradeResult(True, 1.0, f"correct top-5 products identified with revenues within {TOLERANCE*100:.0f}% tolerance, in descending order")

--- a/problems/artifact/data_processing/multi_file_cohort/grader/negative_cases.py
+++ b/problems/artifact/data_processing/multi_file_cohort/grader/negative_cases.py
@@ -1,16 +1,16 @@
 """Per-task negative cases for ``data_processing__multi_file_cohort``.
 
 The prompt requires the output rows to be sorted in **descending order by
-total_revenue**, but the current grader only checks the *set* of product_ids,
-not the row order. A reversed reference output therefore slips through the
-grader today; that's the bug issue #171 calls out as
-``multi_file_cohort order``. The ``reversed_lines`` case below is annotated
-``currently_caught=False`` so the negative gate prints a WARNING for it
-without failing CI; once the grader is updated to enforce ordering (tracked
-under the prompt-vs-grader-alignment issue), flip it to ``True``.
+total_revenue**. Originally the grader only checked the *set* of
+product_ids, not the row order, so a reversed reference output slipped
+through; that was issue #171's ``multi_file_cohort order`` bug.
 
-Other cases here are mutations that the current grader DOES correctly catch
-— they document the existing safety net.
+Issue #166 tightened the grader to verify monotonically non-increasing
+``total_revenue`` across rows. The ``reversed_lines`` case below now
+locks that behaviour in (``currently_caught=True``).
+
+Other cases here are mutations that the grader's existing structural
+checks correctly catch — they document the safety net.
 """
 
 from __future__ import annotations
@@ -59,14 +59,10 @@ NEGATIVE_CASES = [
     NegativeCase(
         name="reversed_lines",
         mutate=_mutate_reverse_lines,
-        # PROMPT-VS-GRADER ALIGNMENT BUG: the prompt says "descending order"
-        # but the grader does set-equality on product_ids without checking
-        # row order. Today the grader returns passed=True on this mutation;
-        # ``check_grader_negative`` will print WARNING and continue. Flip
-        # ``currently_caught=True`` once the grader checks order.
+        # Locked in by issue #166: grader now verifies the output is in
+        # descending order by total_revenue. A reversed reference fails.
         expected_substring="order",
-        currently_caught=False,
-        notes="issue #171 — multi_file_cohort missing descending-order check",
+        notes="issue #166 — locks descending-order requirement",
     ),
     NegativeCase(
         name="renamed_required_field",

--- a/problems/artifact/data_processing/regression_detection/grader/hidden.py
+++ b/problems/artifact/data_processing/regression_detection/grader/hidden.py
@@ -172,4 +172,21 @@ def grade(scratch_dir: Path) -> GradeResult:  # noqa: C901
             f"regression_score out of tolerance on {len(bad)} row(s): {bad}",
         )
 
-    return GradeResult(True, 1.0, f"correct top-{TOP_N} regressions identified")
+    # Issue #166: prompt requires rows in descending order of regression_score.
+    # The grader previously checked set membership only; now also check the
+    # row order matches the canonical descending-then-lex ordering computed
+    # by ``_top_n``.
+    expected_order = [ep for ep, _ in _top_n(regressions, TOP_N)]
+    agent_order = [row["endpoint"] for row in agent_rows]
+    if agent_order != expected_order:
+        # Either rows are out of order or there's a tie-break disagreement.
+        # The set check above already passed, so the elements are correct;
+        # only the order is off.
+        agent_scores = [float(row["regression_score"]) for row in agent_rows]
+        if agent_scores != sorted(agent_scores, reverse=True):
+            return GradeResult(False, 0.0,
+                "rows not in descending order by regression_score")
+        return GradeResult(False, 0.0,
+            "row order does not match canonical descending-then-lexicographic order")
+
+    return GradeResult(True, 1.0, f"correct top-{TOP_N} regressions identified, in descending order")

--- a/problems/artifact/data_processing/regression_detection/grader/negative_cases.py
+++ b/problems/artifact/data_processing/regression_detection/grader/negative_cases.py
@@ -1,0 +1,95 @@
+"""Per-task negative cases for ``data_processing__regression_detection``.
+
+Issue #166 tightened the grader to require the three rows in **descending
+order of regression_score** with ties broken lexicographically by endpoint
+(matching what the prompt says). This module locks that behaviour in: a
+reversed-rows mutation MUST be rejected.
+"""
+
+from __future__ import annotations
+
+from swebench.artifact_negative import (
+    NegativeCase,
+    _mutate_empty,
+    _mutate_reverse_lines,
+    _mutate_truncate_half,
+    _mutate_wrap_in_list,
+)
+
+
+def _mutate_drop_one_row(text: str) -> str:
+    """Drop the last row — len-check fires (3 → 2)."""
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return text + "_"
+    return "\n".join(lines[:-1]) + "\n"
+
+
+def _mutate_swap_endpoint(text: str) -> str:
+    """Replace an endpoint with a known-not-in-top-3 placeholder."""
+    return text.replace('"/api/payments"', '"/api/__BOGUS__"', 1)
+
+
+def _mutate_off_by_one_score(text: str) -> str:
+    """Bump one regression_score by 200ms (well outside REL_TOL)."""
+    # Crude but deterministic: mutate the first numeric we see after
+    # ``regression_score": ``.
+    needle = '"regression_score": '
+    idx = text.find(needle)
+    if idx == -1:
+        return text + "_"
+    start = idx + len(needle)
+    # Find the end of the number.
+    end = start
+    while end < len(text) and text[end] in "-0123456789.":
+        end += 1
+    try:
+        original = float(text[start:end])
+    except ValueError:
+        return text + "_"
+    new = round(original + 200.0, 3)
+    return text[:start] + str(new) + text[end:]
+
+
+NEGATIVE_CASES = [
+    NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        expected_substring="empty",
+    ),
+    NegativeCase(
+        name="truncated_half",
+        mutate=_mutate_truncate_half,
+        # 3 → ~1 row; len-check fires.
+        expected_substring="",
+    ),
+    NegativeCase(
+        name="reversed_lines",
+        mutate=_mutate_reverse_lines,
+        # Locked in by issue #166: rows must be in descending order of
+        # regression_score.
+        expected_substring="order",
+        notes="issue #166 — locks descending-order requirement",
+    ),
+    NegativeCase(
+        name="dropped_row",
+        mutate=_mutate_drop_one_row,
+        expected_substring="3 rows",
+    ),
+    NegativeCase(
+        name="swapped_endpoint",
+        mutate=_mutate_swap_endpoint,
+        expected_substring="incorrect endpoint",
+    ),
+    NegativeCase(
+        name="off_by_one_score",
+        mutate=_mutate_off_by_one_score,
+        expected_substring="tolerance",
+    ),
+    NegativeCase(
+        name="wrap_in_list",
+        mutate=_mutate_wrap_in_list,
+        # JSON parse error on the wrapping ``[``.
+        expected_substring="",
+    ),
+]

--- a/problems/artifact/iterative_numerical/newton_sqrt/prompt.md
+++ b/problems/artifact/iterative_numerical/newton_sqrt/prompt.md
@@ -1,10 +1,11 @@
 # Task: Compute Square Roots via Newton's Method
 
 A numerics tutorial is being put together for junior engineers and we need
-a small reference table of square roots computed iteratively rather than
-via `math.sqrt`. The teaching point is Newton's method — so please produce
-the results using that algorithm (or an equivalent iterative scheme),
-not a direct library call.
+a small reference table of square roots. The teaching point is Newton's
+method, and the **Method** section below describes the recommended
+iteration; the grader only checks numerical accuracy, so it cannot
+distinguish a Newton implementation from any other correct approach.
+Following the recommended method is on the honor system.
 
 ## Input
 

--- a/problems/artifact/stateful_reasoning/counter_replay/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/counter_replay/grader/hidden.py
@@ -96,4 +96,13 @@ def grade(scratch_dir: Path) -> GradeResult:
         score = round(correct / max(len(ref_keys), 1), 4)
         return GradeResult(False, score, "; ".join(parts))
 
-    return GradeResult(True, 1.0, f"all {len(reference)} counter values correct")
+    # Issue #166: prompt requires keys "sorted by name (alphabetical) so
+    # diffs are stable" — enforce alphabetical key order on the agent's
+    # JSON object. We compare the agent's key insertion order (which
+    # ``json.loads`` preserves on Python 3.7+) against ``sorted(...)``.
+    agent_key_order = list(agent.keys())
+    if agent_key_order != sorted(agent_key_order):
+        return GradeResult(False, 0.0,
+            "counter keys not in alphabetical order (prompt requires sorted by name)")
+
+    return GradeResult(True, 1.0, f"all {len(reference)} counter values correct, keys in alphabetical order")

--- a/problems/artifact/stateful_reasoning/counter_replay/grader/negative_cases.py
+++ b/problems/artifact/stateful_reasoning/counter_replay/grader/negative_cases.py
@@ -1,0 +1,103 @@
+"""Per-task negative cases for ``stateful_reasoning__counter_replay``.
+
+Issue #166 tightened the grader to enforce alphabetical key order on the
+agent's JSON object (the prompt says "sorted by name (alphabetical) so
+diffs are stable"). This module locks that behaviour in: a shuffled-key
+mutation MUST be rejected; a wrong-value mutation MUST also be rejected.
+"""
+
+from __future__ import annotations
+
+import json
+
+from swebench.artifact_negative import (
+    NegativeCase,
+    _mutate_empty,
+    _mutate_truncate_half,
+    _mutate_wrap_in_list,
+)
+
+
+def _mutate_reverse_key_order(text: str) -> str:
+    """Reverse the alphabetical key order so the keys appear largest-first.
+
+    The values stay correct; only the key insertion order changes. A grader
+    that ignores key order would accept this artifact; the issue #166
+    tightening rejects it.
+    """
+    payload = json.loads(text)
+    if not isinstance(payload, dict) or len(payload) <= 1:
+        return text + "_"
+    reversed_payload = {k: payload[k] for k in reversed(list(payload.keys()))}
+    return json.dumps(reversed_payload, indent=2) + "\n"
+
+
+def _mutate_off_by_one_value(text: str) -> str:
+    """Bump one counter value by 1 — caught by the value comparison."""
+    payload = json.loads(text)
+    if not isinstance(payload, dict) or not payload:
+        return text + "_"
+    first = next(iter(payload))
+    payload[first] = int(payload[first]) + 1
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _mutate_drop_one_counter(text: str) -> str:
+    """Remove one counter — caught by the missing-key check."""
+    payload = json.loads(text)
+    if not isinstance(payload, dict) or not payload:
+        return text + "_"
+    payload.pop(next(iter(payload)))
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _mutate_extra_counter(text: str) -> str:
+    """Add a phantom counter not present in the events stream."""
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        return text + "_"
+    payload["phantom.counter"] = 999
+    return json.dumps(payload, indent=2) + "\n"
+
+
+NEGATIVE_CASES = [
+    NegativeCase(
+        name="empty",
+        mutate=_mutate_empty,
+        # Empty file → JSON parse error short-circuits.
+        expected_substring="not valid JSON",
+    ),
+    NegativeCase(
+        name="truncated_half",
+        mutate=_mutate_truncate_half,
+        expected_substring="not valid JSON",
+    ),
+    NegativeCase(
+        name="reversed_key_order",
+        mutate=_mutate_reverse_key_order,
+        # Locked in by issue #166: alphabetical key order is now enforced.
+        expected_substring="alphabetical",
+        notes="issue #166 — locks alphabetical key order",
+    ),
+    NegativeCase(
+        name="off_by_one_value",
+        mutate=_mutate_off_by_one_value,
+        expected_substring="wrong values",
+    ),
+    NegativeCase(
+        name="dropped_counter",
+        mutate=_mutate_drop_one_counter,
+        expected_substring="missing",
+    ),
+    NegativeCase(
+        name="extra_counter",
+        mutate=_mutate_extra_counter,
+        expected_substring="extra",
+    ),
+    NegativeCase(
+        name="wrap_in_list",
+        mutate=_mutate_wrap_in_list,
+        # Wrapping a JSON object in [...] makes it a list, not a dict.
+        expected_substring="JSON object",
+    ),
+]

--- a/problems/artifact/stateful_reasoning/event_ledger/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/event_ledger/grader/hidden.py
@@ -67,15 +67,31 @@ def grade(scratch_dir: Path) -> GradeResult:
     if wrong_balances:
         return GradeResult(False, 0.0, f"wrong balances: {wrong_balances[:3]}")
 
-    # Check rejected list (must be exact, order-insensitive for set comparison)
-    agent_rejected = set(agent_out["rejected"])
-    expected_rejected_set = set(expected_rejected)
-    if agent_rejected != expected_rejected_set:
-        extra = agent_rejected - expected_rejected_set
-        missing_r = expected_rejected_set - agent_rejected
+    # Check rejected: per the prompt, this MUST be a JSON array in chronological
+    # order (the order rejections were encountered while replaying). Issue #166
+    # tightened the grader from set-comparison to typed-list-and-order: a wrong
+    # shape (dict, scalar, …) or a permuted list now both fail.
+    agent_rejected = agent_out["rejected"]
+    if not isinstance(agent_rejected, list):
         return GradeResult(False, 0.0,
-            f"rejected mismatch: got {len(agent_out['rejected'])} entries, "
+            f"rejected must be a JSON list (chronological order), "
+            f"got {type(agent_rejected).__name__}")
+
+    # Set-equality first — gives a precise "missing/extra" message when the
+    # agent has the wrong elements rather than just the wrong order.
+    agent_rejected_set = set(agent_rejected)
+    expected_rejected_set = set(expected_rejected)
+    if agent_rejected_set != expected_rejected_set:
+        extra = agent_rejected_set - expected_rejected_set
+        missing_r = expected_rejected_set - agent_rejected_set
+        return GradeResult(False, 0.0,
+            f"rejected mismatch: got {len(agent_rejected)} entries, "
             f"{len(extra)} extra, {len(missing_r)} missing")
 
+    # Same elements, possibly wrong order.
+    if list(agent_rejected) != list(expected_rejected):
+        return GradeResult(False, 0.0,
+            "rejected list is not in chronological order")
+
     return GradeResult(True, 1.0,
-        f"all {len(expected_balances)} balances correct, {len(expected_rejected)} rejected transactions identified")
+        f"all {len(expected_balances)} balances correct, {len(expected_rejected)} rejected transactions identified in chronological order")

--- a/problems/artifact/stateful_reasoning/event_ledger/grader/negative_cases.py
+++ b/problems/artifact/stateful_reasoning/event_ledger/grader/negative_cases.py
@@ -2,14 +2,14 @@
 
 The prompt requires ``rejected`` to be a JSON **array** in **chronological
 order** (the order the rejected transactions were encountered while
-replaying the ledger). The grader, however, compares ``rejected`` as a
-*set*, so any permutation slips through. That's the bug issue #171 calls
-out as ``event_ledger rejected order``.
+replaying the ledger). Originally the grader compared ``rejected`` as a
+*set*, so any permutation (or even a wrong-shape dict) slipped through;
+that was issue #171's ``event_ledger rejected order`` bug.
 
-The ``reversed_rejected`` case below is annotated ``currently_caught=False``
-— the grader incorrectly accepts a reversed rejected list today. Flip to
-``True`` once the grader enforces chronological order (and / or list-vs-set
-semantics) per the prompt.
+Issue #166 tightened the grader to require a list in chronological order.
+The ``reversed_rejected`` and ``rejected_as_dict`` cases now lock that
+behaviour in (``currently_caught=True``) — they would fail again if the
+grader regressed to set-comparison.
 """
 
 from __future__ import annotations
@@ -114,21 +114,18 @@ NEGATIVE_CASES = [
     NegativeCase(
         name="reversed_rejected",
         mutate=_mutate_reverse_rejected,
-        # PROMPT-VS-GRADER ALIGNMENT BUG: prompt requires chronological order,
-        # grader uses set-equality. Reversing slips through today.
+        # Locked in by issue #166: grader now compares rejected as an
+        # ordered list, so a reversed list fails the order check.
         expected_substring="order",
-        currently_caught=False,
-        notes="issue #171 — event_ledger rejected list-vs-set bug",
+        notes="issue #166 — locks chronological-order requirement",
     ),
     NegativeCase(
         name="rejected_as_dict",
         mutate=_mutate_rejected_as_set,
-        # PROMPT-VS-GRADER ALIGNMENT BUG: ``rejected`` is required to be a
-        # list. The grader's ``set(...)`` coerces a dict to its key-set so
-        # this slips through.
+        # Locked in by issue #166: grader now type-checks rejected as a
+        # list, rejecting dict-coercion.
         expected_substring="list",
-        currently_caught=False,
-        notes="issue #171 — event_ledger list-vs-set bug (dict coercion)",
+        notes="issue #166 — locks list-shape requirement",
     ),
     NegativeCase(
         name="wrap_in_list",

--- a/problems/artifact/stateful_reasoning/unreachable_functions/grader/hidden.py
+++ b/problems/artifact/stateful_reasoning/unreachable_functions/grader/hidden.py
@@ -8,8 +8,15 @@ Correctness criterion:
     are unreachable from ``main()`` in ``src/main.py`` via static call-graph
     analysis (BFS over explicit function calls, per-function not per-module).
 
+    Each row MUST carry a ``function`` key (the function name, as defined)
+    AND a ``module`` key (the Python module filename without ``.py``, e.g.
+    ``utils`` for ``src/utils.py``). The grader walks ``src/*.py``, records
+    which file each function was defined in, and validates the agent's
+    ``module`` value against that mapping.
+
     Ground truth is computed by the grader itself using AST analysis — same
-    algorithm as the reference solver. Set equality check on function names.
+    algorithm as the reference solver. Set equality on (function, module)
+    pairs.
 
 Determinism: pure AST analysis, no randomness.
 """
@@ -33,11 +40,19 @@ OUTPUT_REL = "output/unreachable.jsonl"
 SRC_REL = "src"
 
 
-def _analyze_reachability(src_dir: Path) -> set[str]:
-    """Return the set of function names unreachable from main()."""
+def _analyze_reachability(src_dir: Path) -> tuple[set[str], dict[str, str]]:
+    """Return ``(unreachable_function_names, function_to_module)``.
+
+    ``function_to_module`` maps every function name in the source tree (not
+    just the unreachable ones) to its defining module's stem (the filename
+    without the ``.py`` extension). Issue #166 added this second return
+    value so :func:`grade` can validate the agent's ``module`` field.
+    """
     func_calls: dict[str, set[str]] = {}
+    func_to_module: dict[str, str] = {}
 
     for py_file in sorted(src_dir.glob("*.py")):
+        module_name = py_file.stem
         tree = ast.parse(py_file.read_text())
         for node in ast.walk(tree):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -50,6 +65,7 @@ def _analyze_reachability(src_dir: Path) -> set[str]:
                         elif isinstance(child.func, ast.Attribute):
                             calls.add(child.func.attr)
                 func_calls[fname] = calls
+                func_to_module[fname] = module_name
 
     all_funcs = set(func_calls.keys())
 
@@ -62,7 +78,7 @@ def _analyze_reachability(src_dir: Path) -> set[str]:
                 reachable.add(called)
                 queue.append(called)
 
-    return all_funcs - reachable
+    return all_funcs - reachable, func_to_module
 
 
 def grade(scratch_dir: Path) -> GradeResult:
@@ -81,6 +97,8 @@ def grade(scratch_dir: Path) -> GradeResult:
         return GradeResult(False, 0.0, "output artifact is empty")
 
     agent_funcs: set[str] = set()
+    # function_name -> module string the agent claimed for it
+    agent_func_to_module: dict[str, str] = {}
     for lineno, line in enumerate(raw.splitlines(), start=1):
         if not line.strip():
             continue
@@ -92,14 +110,22 @@ def grade(scratch_dir: Path) -> GradeResult:
             return GradeResult(False, 0.0, f"line {lineno}: expected JSON object")
         if "function" not in obj:
             return GradeResult(False, 0.0, f"line {lineno}: missing 'function' key")
+        # Issue #166: validate the ``module`` field — previously parsed but
+        # unchecked, allowing rows with missing/wrong module values to pass.
+        if "module" not in obj:
+            return GradeResult(False, 0.0, f"line {lineno}: missing 'module' key")
         fname = obj["function"]
+        mod = obj["module"]
         if not isinstance(fname, str):
             return GradeResult(False, 0.0, f"line {lineno}: 'function' must be a string")
+        if not isinstance(mod, str):
+            return GradeResult(False, 0.0, f"line {lineno}: 'module' must be a string")
         if fname in agent_funcs:
             return GradeResult(False, 0.0, f"duplicate function name: {fname!r}")
         agent_funcs.add(fname)
+        agent_func_to_module[fname] = mod
 
-    reference = _analyze_reachability(src_dir)
+    reference, func_to_module = _analyze_reachability(src_dir)
 
     missing = reference - agent_funcs
     extra = agent_funcs - reference
@@ -116,4 +142,24 @@ def grade(scratch_dir: Path) -> GradeResult:
             "; ".join(parts),
         )
 
-    return GradeResult(True, 1.0, f"all {len(reference)} unreachable functions identified correctly")
+    # Issue #166: validate ``module`` against the file each function was
+    # defined in (collected during the AST walk above).
+    wrong_module: list[str] = []
+    for fname in sorted(reference):
+        expected_mod = func_to_module.get(fname)
+        agent_mod = agent_func_to_module.get(fname)
+        if expected_mod is None:
+            # Should not happen: ``reference`` is a subset of all_funcs, and
+            # all_funcs keys are populated from the same walk.
+            continue
+        if agent_mod != expected_mod:
+            wrong_module.append(fname)
+
+    if wrong_module:
+        return GradeResult(False, 0.0,
+            f"wrong 'module' value on {len(wrong_module)} function(s): "
+            f"{sorted(wrong_module)[:5]}")
+
+    return GradeResult(True, 1.0,
+        f"all {len(reference)} unreachable functions identified correctly, "
+        f"with matching module values")

--- a/problems/artifact/stateful_reasoning/unreachable_functions/grader/negative_cases.py
+++ b/problems/artifact/stateful_reasoning/unreachable_functions/grader/negative_cases.py
@@ -1,14 +1,16 @@
 """Per-task negative cases for ``stateful_reasoning__unreachable_functions``.
 
 The prompt requires every output line to carry **both** ``function`` AND
-``module`` keys. The grader, however, only validates ``function`` — the
-``module`` field is read from the reference but never checked against the
-agent's output, so a JSONL with a bogus or missing module slips through.
-That's the bug issue #171 calls out as ``unreachable_functions module``.
+``module`` keys. Originally the grader only validated ``function`` — the
+``module`` field was read from the reference but never checked against
+the agent's output, so a JSONL with a bogus or missing module slipped
+through; that was issue #171's ``unreachable_functions module`` bug.
 
-The ``drop_module_field`` and ``wrong_module_value`` cases below are
-annotated ``currently_caught=False``; flip them to ``True`` once the grader
-validates ``module`` per the prompt.
+Issue #166 tightened the grader to (a) require a ``module`` key and (b)
+validate it against the file each function was defined in (computed by
+the same AST walk that drives reachability). The ``drop_module_field``
+and ``wrong_module_value`` cases below now lock that behaviour in
+(``currently_caught=True``).
 """
 
 from __future__ import annotations
@@ -110,21 +112,18 @@ NEGATIVE_CASES = [
     NegativeCase(
         name="drop_module_field",
         mutate=_mutate_drop_module,
-        # PROMPT-VS-GRADER ALIGNMENT BUG: prompt requires both 'function'
-        # AND 'module', grader only checks 'function'. Dropping ``module``
-        # entirely slips through today.
+        # Locked in by issue #166: grader now requires a ``module`` key on
+        # every line.
         expected_substring="module",
-        currently_caught=False,
-        notes="issue #171 — unreachable_functions module field unvalidated",
+        notes="issue #166 — locks 'module' key requirement",
     ),
     NegativeCase(
         name="wrong_module_value",
         mutate=_mutate_wrong_module,
-        # Same alignment bug as drop_module_field — the grader doesn't
-        # check what's in ``module``, so a wrong value also slips.
+        # Locked in by issue #166: grader now validates ``module`` against
+        # the file each function was defined in.
         expected_substring="module",
-        currently_caught=False,
-        notes="issue #171 — unreachable_functions module field unvalidated",
+        notes="issue #166 — locks 'module' value validation",
     ),
     NegativeCase(
         name="wrap_in_list",


### PR DESCRIPTION
Closes #166.

## Summary

Contract-tightening sweep across 7 of the 8 prompt-vs-grader mismatches called out in the issue. For each, the choice (tighten grader vs. relax prompt) is documented in the affected file. Item 8 (`hparam_search`) is out of scope per the issue (separate tracked work).

This PR also flips the `currently_caught=False` flags introduced in PR #175 for the 5 negative-test cases that now correctly fire — the negative-test framework now **locks in** each grader fix. Two tasks (`counter_replay`, `regression_detection`) ship new per-task `negative_cases.py` files that exercise the new grader checks.

## Per-item decisions

| # | Task | Decision | Mechanism |
|---|---|---|---|
| 1 | `event_ledger` | TIGHTEN GRADER | Type-check + ordered-list comparison on `rejected` |
| 2 | `counter_replay` | TIGHTEN GRADER | `list(agent.keys()) == sorted(…)` after value check |
| 3 | `multi_file_cohort` | TIGHTEN GRADER | Monotonic-non-increasing check on `total_revenue` |
| 4 | `regression_detection` | TIGHTEN GRADER | Exact-row-order comparison vs. canonical `_top_n()` |
| 5 | `unreachable_functions` | TIGHTEN GRADER | Track `py_file.stem` during AST walk; validate `module` per row |
| 6 | `min_cost_assignment` | ALIGN ALL THREE | Pick `assignment_cost` per the issue's suggestion; align prompt + grader + reference |
| 7 | `newton_sqrt` | RELAX PROMPT | Replace unenforceable "not a direct library call" with explicit honor-system framing |
| 8 | `hparam_search` | OUT OF SCOPE | Tracked separately (replace `toy_model.py` with opaque callable) |

## Why these specific choices

**Items 1–5 are tighten-grader.** Each enforces a property the prompt explicitly asks for AND that has real correctness signal — a wrong order in `event_ledger.rejected` means the agent processed transactions out of order; a wrong `module` value in `unreachable_functions` means the agent's static-analysis output cannot be cross-referenced back to the source tree. Set-comparison would let an agent pass these tasks while having genuinely buggy logic.

**Item 6 is align-all-three.** The three-way name divergence (`total_cost` / unread / `optimal_cost`) was a pure spec bug — there's no "choice" to make about correctness. I picked `assignment_cost` because the issue suggested it and because it best describes what the field actually is (the cost of the matching the agent produced, which equals the optimal cost when correct).

**Item 7 is relax-prompt** because the grader is output-only — it sees `output/roots.json` and nothing about how the agent computed the values. A grader-side enforcement of "don't use `math.sqrt`" would require source inspection that the schema explicitly does not provide. The Method section still recommends Newton's iteration; the change makes the recommendation honor-system rather than a phantom hard constraint.

## Test plan

- [x] `python tools/verify_graders.py` passes for all 7 affected tasks (positive sanity check); reference outputs still grade `passed=True, score=1.0`.
- [x] `python tools/check_grader_negative.py` exits 0; full scan summary went from `267 PASS / 23 WEAK_MISS / 5 EXPECTED_MISS` (pre-PR) to `277 PASS / 20 WEAK_MISS / 0 EXPECTED_MISS` (post-PR).
- [x] `python tools/check_grader_negative.py --filter <each affected task>`: every previously-`EXPECTED_MISS` case now PASSes (i.e., the grader correctly rejects the deliberately-wrong artifact).
- [x] `pytest tests/test_check_grader_negative.py tests/test_verify_graders.py`: 29/29 pass.
- [ ] CI run on this PR (positive + negative + leak gates).

## Acceptance criteria from #166

- [x] **event_ledger**: compare `rejected` as a list (preferred path taken).
- [x] **counter_replay**: enforce alphabetical key order (preferred path taken).
- [x] **multi_file_cohort**: enforce descending order in the grader.
- [x] **regression_detection**: enforce descending order; tie-break disagreement also reported.
- [x] **unreachable_functions**: validate `module` against the file of definition (using the AST walk the grader already does).
- [x] **min_cost_assignment**: picked `assignment_cost`; aligned prompt + grader + reference.
- [x] **newton_sqrt**: removed the unenforceable sentence; documented that the recommended method is honor-system.
- [x] **hparam_search**: skipped (tracked separately, as the issue specifies).
- [x] Reference outputs still grade `pass=True, score=1.0` after changes.