### PR TITLE
Fix wrong-root comments and dead-branch overflow in iterative_numerical (#170)

### DIFF
--- a/problems/artifact/iterative_numerical/logistic_fit/grader/hidden.py
+++ b/problems/artifact/iterative_numerical/logistic_fit/grader/hidden.py
@@ -32,13 +32,23 @@ RMSE_THRESHOLD = 5.0
 
 
 def _model(L: float, k: float, x0: float, x: float) -> float:
-    # Numerically stable logistic
-    z = -k * (x - x0)
+    """Three-parameter logistic, evaluated without overflow for either sign of z.
+
+    Issue #170 replaced the previous implementation, which contained an
+    ``if False`` toggle that made the numerically-stable branch
+    unreachable: extreme ``k`` or ``x0`` values pushed ``math.exp(z)`` into
+    overflow, and the grader's ``OverflowError`` handler then failed the
+    agent for the grader's own bug. This version selects the safe branch
+    based on the sign of ``z`` so neither path passes a positive argument
+    to ``math.exp``.
+    """
+    z = k * (x - x0)
     if z >= 0:
-        ez = math.exp(-z)
-        return L * ez / (1.0 + ez) if False else L / (1.0 + math.exp(z))
-    # z < 0 -> exp(z) small, safe
-    return L / (1.0 + math.exp(z))
+        # exp(-z) <= 1; safe for arbitrarily large positive z.
+        return L / (1.0 + math.exp(-z))
+    # z < 0; exp(z) <= 1; safe for arbitrarily large negative z.
+    ez = math.exp(z)
+    return L * ez / (1.0 + ez)
 
 
 def _rmse(L: float, k: float, x0: float, data: list[dict]) -> float:

--- a/problems/artifact/iterative_numerical/secant_root_budgeted/workspace/black_box.py
+++ b/problems/artifact/iterative_numerical/secant_root_budgeted/workspace/black_box.py
@@ -13,12 +13,13 @@ def f1(x: float) -> float:
 
 
 def f2(x: float) -> float:
-    # Root near x = 1 (unique in [-1, 3] since derivative does not vanish there)
+    # Root near x ≈ 1.7508 in [0.1, 3.0]
+    # (f(x) = exp(x) - e*x - 1; f(1) = -1, NOT a root.)
     return math.exp(x) - math.e * x - 1.0
 
 
 def f3(x: float) -> float:
-    # Cubic with root near 0.6529... in [0, 1]
+    # Cubic with root near x ≈ 0.6823 in [0, 1]
     return x * x * x + x - 1.0
 
 

--- a/tools/check_logistic_fit_model.py
+++ b/tools/check_logistic_fit_model.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Smoke test for ``logistic_fit`` grader's ``_model`` numerical stability.
+
+Issue #170 fixed a dead-branch bug in
+``problems/artifact/iterative_numerical/logistic_fit/grader/hidden.py``
+where an ``if False`` toggle made the stable branch unreachable, causing
+``math.exp`` overflow on extreme parameter values. The grader treated the
+overflow as an agent failure rather than a grader bug.
+
+This script exercises ``_model`` at a battery of extreme ``(L, k, x0, x)``
+inputs and asserts:
+
+  * no exception is raised, AND
+  * the returned value is finite, AND
+  * the returned value lies in ``[0, L]`` (the model's mathematical range).
+
+Exit codes:
+  0 — every case passed
+  1 — at least one case raised, returned non-finite, or fell outside [0, L]
+  2 — could not load the grader module (path/permissions issue)
+
+Usage:
+    python tools/check_logistic_fit_model.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GRADER_PATH = (
+    _REPO_ROOT
+    / "problems"
+    / "artifact"
+    / "iterative_numerical"
+    / "logistic_fit"
+    / "grader"
+    / "hidden.py"
+)
+
+
+class Case(NamedTuple):
+    name: str
+    L: float
+    k: float
+    x0: float
+    x: float
+
+
+def _extreme_cases() -> Iterable[Case]:
+    """Cases that historically tripped the dead-branch overflow bug.
+
+    Each case targets a specific failure mode: very large ``k * (x - x0)``
+    in either sign, very far-apart ``x`` and ``x0``, and the boundary
+    ``z == 0``.
+    """
+    return [
+        Case("z_very_positive", L=100.0, k=10.0, x0=0.0, x=1000.0),
+        Case("z_very_negative", L=100.0, k=10.0, x0=1000.0, x=0.0),
+        Case("z_huge_positive", L=1.0, k=1.0, x0=0.0, x=10_000.0),
+        Case("z_huge_negative", L=1.0, k=1.0, x0=10_000.0, x=0.0),
+        Case("k_extreme_positive", L=1.0, k=1e6, x0=0.0, x=1.0),
+        Case("k_extreme_with_negative_z", L=1.0, k=1e6, x0=1.0, x=0.0),
+        Case("zero_z", L=1.0, k=1.0, x0=0.0, x=0.0),
+        Case("modest_signal", L=200.0, k=0.4, x0=15.0, x=20.0),
+        Case("L_large_z_extreme", L=1e9, k=10.0, x0=0.0, x=1000.0),
+        Case("L_large_z_extreme_neg", L=1e9, k=10.0, x0=1000.0, x=0.0),
+    ]
+
+
+def _load_model():
+    """Load ``_model`` from the grader module by file path.
+
+    The grader directory is not on ``sys.path`` and the grader itself is
+    intentionally hidden from agent runs, so we use ``importlib`` rather
+    than a normal import. We register the module in ``sys.modules`` before
+    ``exec_module`` so that the grader's ``@dataclass`` decorator can
+    resolve forward type references (``dataclasses`` looks up the
+    decorated class's module via ``sys.modules`` and would otherwise hit
+    ``AttributeError: 'NoneType' object has no attribute '__dict__'``).
+    """
+    if not _GRADER_PATH.is_file():
+        raise FileNotFoundError(f"grader module not found: {_GRADER_PATH}")
+    module_name = "_logistic_fit_grader_for_smoke_test"
+    spec = importlib.util.spec_from_file_location(module_name, _GRADER_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover — defensive
+        raise ImportError(f"could not build spec for {_GRADER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    if not hasattr(module, "_model"):
+        raise AttributeError("grader module does not define _model")
+    return module._model
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # unused; the smoke test takes no arguments today
+    try:
+        model = _load_model()
+    except (FileNotFoundError, ImportError, AttributeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    failed = 0
+    for case in _extreme_cases():
+        try:
+            y = model(case.L, case.k, case.x0, case.x)
+        except Exception as exc:  # noqa: BLE001 — surface anything
+            print(
+                f"FAIL {case.name}: raised {type(exc).__name__}: {exc} "
+                f"(L={case.L}, k={case.k}, x0={case.x0}, x={case.x})",
+                file=sys.stderr,
+            )
+            failed += 1
+            continue
+
+        if not math.isfinite(y):
+            print(
+                f"FAIL {case.name}: non-finite return {y!r} "
+                f"(L={case.L}, k={case.k}, x0={case.x0}, x={case.x})",
+                file=sys.stderr,
+            )
+            failed += 1
+            continue
+
+        # The logistic is bounded by [0, L] for L > 0.
+        if y < -1e-9 or y > case.L + 1e-9:
+            print(
+                f"FAIL {case.name}: out of range, got {y!r} not in "
+                f"[0, {case.L}] (L={case.L}, k={case.k}, x0={case.x0}, "
+                f"x={case.x})",
+                file=sys.stderr,
+            )
+            failed += 1
+            continue
+
+        print(f"PASS {case.name}: y={y:.6e}")
+
+    if failed:
+        print(f"\n{failed} case(s) failed", file=sys.stderr)
+        return 1
+
+    print(f"\nAll {len(list(_extreme_cases()))} cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #170.

## Summary

Two unrelated bugs in `iterative_numerical/`, fixed in a single PR per the issue's framing.

### A. `secant_root_budgeted/workspace/black_box.py` — wrong root-location comments

The comments next to two of the five functions claimed root locations that are factually wrong; they would steer any agent that reads them as initial guesses for the secant method.

| Function | Old comment | Verified actual root | New comment |
|---|---|---|---|
| `f2(x) = exp(x) - e·x - 1` | "Root near x = 1" | `f(1) = -1`; root in `[0.1, 3.0]` near `1.7508` | `# Root near x ≈ 1.7508 in [0.1, 3.0]` |
| `f3(x) = x³ + x - 1` | "Root near 0.6529…" | `f(0.6529) ≈ -0.069`; root in `[0, 1]` near `0.6823` | `# Cubic with root near x ≈ 0.6823 in [0, 1]` |

Audited `f1`, `f4`, `f5` per the acceptance criteria — all three are correct (`sqrt(2)`, `pi/4`, `ln(5)` respectively, each accurate to roundoff). Only `f2` and `f3` needed updating.

### B. `logistic_fit/grader/hidden.py` — dead-branch overflow

The original `_model()` had an `if False` toggle that made the numerically stable branch unreachable:

```python
return L * ez / (1.0 + ez) if False else L / (1.0 + math.exp(z))
```

For extreme parameter values (large `k` or far-apart `x0`/`x`), `math.exp(z)` overflowed. The grader's `OverflowError` handler then failed the agent for the grader's own bug.

Replaced with the implementation suggested in the issue — split on the sign of `z` so neither branch ever passes a positive argument to `math.exp`:

```python
z = k * (x - x0)
if z >= 0:
    return L / (1.0 + math.exp(-z))
ez = math.exp(z)
return L * ez / (1.0 + ez)
```

Added a docstring explaining what was broken and why this form is safe.

### Smoke test: `tools/check_logistic_fit_model.py`

Loads the grader's `_model` via `importlib` (registering the module in `sys.modules` first so the grader's `@dataclass` decorator can resolve forward type references via the standard lookup path) and exercises it at 10 extreme `(L, k, x0, x)` combinations — very large positive `z`, very large negative `z`, `k` near `1e6`, `L` near `1e9`, and the boundary `z == 0`. Each case asserts no exception is raised, the return value is finite, and it lies in `[0, L]` (the model's mathematical range). Exit codes mirror the existing grader-tooling convention (`0` ok, `1` test failure, `2` infrastructure error).

Locally confirmed: the smoke test passes against the new `_model` and would have raised `OverflowError` on at least 4 of the 10 cases against the old one.

## Test plan

- [x] `python tools/verify_graders.py` — both affected tasks PASS:
  - `iterative_numerical__logistic_fit  RMSE 2.5539 < threshold 5.0 …`
  - `iterative_numerical__secant_root_budgeted  all 5 roots within tol 1e-08 …`
- [x] `python tools/check_logistic_fit_model.py` — 10/10 extreme cases pass.
- [x] `pytest tests/test_check_grader_negative.py tests/test_verify_graders.py` — 29/29 pass.
- [x] `python -c` numerical verification of all 5 functions in `black_box.py` (only `f2`, `f3` had wrong comments; `f1`, `f4`, `f5` are correct).
- [ ] CI run on this PR (positive + negative + leak gates).

## Acceptance criteria from #170

- [x] Update `f2` comment to `# Root near x ≈ 1.7508 in [0.1, 3.0]` (with a parenthetical noting that `f(1) = -1`, NOT a root).
- [x] Update `f3` comment to `# Cubic with root near x ≈ 0.6823 in [0, 1]`.
- [x] Audit `f1`, `f4`, `f5` — all already correct, no change needed.
- [x] Replace `_model()` with the issue's suggested numerically-stable form.
- [x] Add a smoke test in `tools/` that calls `_model` at extreme parameter values and confirms it does not raise.
- [x] Reference outputs for both tasks still grade `passed=True, score=1.0`.