### PR TITLE
ci: run unit tests on every PR to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
@@ -44,16 +48,31 @@ jobs:
       - name: Run unit tests
         id: pytest
         run: |
-          set -e
           rc=0
           pytest tests/ -m "not integration" -q --tb=short -ra \
             > pytest.log 2>&1 || rc=$?
           cat pytest.log
-          if [ "$rc" -ne 0 ]; then
-            # Surface the failure tail as a CI annotation — annotations
-            # render on the run summary and are visible to logged-out
-            # viewers, unlike step logs and artifacts. Annotation
-            # escape order is %->%25 first, then \n->%0A and \r->%0D.
-            python3 -c "import sys; t=open('pytest.log').read()[-6000:]; e=t.replace('%','%25').replace(chr(13),'%0D').replace(chr(10),'%0A'); print(f'::error::pytest failed (last 6KB):%0A{e}')"
-          fi
-          exit "$rc"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+      - name: Comment failure log on PR
+        # Posts the (truncated) pytest output as a PR comment whenever the
+        # test step failed. Public artifact / step-log inspection is
+        # auth-gated; PR comments are not. Conditional on `failure()` AND
+        # this being a pull_request event so push-to-main runs don't
+        # spam any associated issue.
+        if: steps.pytest.outputs.rc != '0' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('pytest.log', 'utf8').slice(-50000);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '<details><summary>pytest failed (last 50KB)</summary>\n\n```\n' + body + '\n```\n</details>',
+            });
+
+      - name: Fail step on pytest non-zero rc
+        if: steps.pytest.outputs.rc != '0'
+        run: exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,6 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   pytest:
     runs-on: ubuntu-latest
@@ -46,33 +42,4 @@ jobs:
           pip install networkx
 
       - name: Run unit tests
-        id: pytest
-        run: |
-          rc=0
-          pytest tests/ -m "not integration" -q --tb=short -ra \
-            > pytest.log 2>&1 || rc=$?
-          cat pytest.log
-          echo "rc=$rc" >> "$GITHUB_OUTPUT"
-
-      - name: Comment failure log on PR
-        # Posts the (truncated) pytest output as a PR comment whenever the
-        # test step failed. Public artifact / step-log inspection is
-        # auth-gated; PR comments are not. Conditional on `failure()` AND
-        # this being a pull_request event so push-to-main runs don't
-        # spam any associated issue.
-        if: steps.pytest.outputs.rc != '0' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('pytest.log', 'utf8').slice(-50000);
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '<details><summary>pytest failed (last 50KB)</summary>\n\n```\n' + body + '\n```\n</details>',
-            });
-
-      - name: Fail step on pytest non-zero rc
-        if: steps.pytest.outputs.rc != '0'
-        run: exit 1
+        run: pytest tests/ -m "not integration" -q --tb=short -ra

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,10 @@ jobs:
           pip install networkx
 
       - name: Run unit tests
-        run: pytest tests/ -m "not integration" -v
+        # ``-q`` keeps the per-test output compact; ``--tb=line`` renders one
+        # line per failure (test name + exception class + message) so a CI
+        # failure summary fits in the GitHub UI without truncation.
+        # ``-ra`` appends a short summary of all non-passing outcomes so
+        # the maintainer can see at a glance what flipped without expanding
+        # the raw log.
+        run: pytest tests/ -m "not integration" -q --tb=line -ra

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,10 +42,22 @@ jobs:
           pip install networkx
 
       - name: Run unit tests
-        # ``-q`` keeps the per-test output compact; ``--tb=line`` renders one
-        # line per failure (test name + exception class + message) so a CI
-        # failure summary fits in the GitHub UI without truncation.
-        # ``-ra`` appends a short summary of all non-passing outcomes so
-        # the maintainer can see at a glance what flipped without expanding
-        # the raw log.
-        run: pytest tests/ -m "not integration" -q --tb=line -ra
+        run: |
+          set -e
+          # Capture pytest output to a file, then publish it to both the
+          # raw step log AND ``$GITHUB_STEP_SUMMARY`` (which is rendered
+          # on the run-summary page even for logged-out viewers — the
+          # raw log viewer truncates large step bodies and is gated by
+          # auth).
+          rc=0
+          pytest tests/ -m "not integration" -q --tb=short -ra \
+            > /tmp/pytest.log 2>&1 || rc=$?
+          {
+            echo "## pytest output"
+            echo
+            echo '```'
+            cat /tmp/pytest.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/pytest.log
+          exit "$rc"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: tests
+
+# Runs the unit-test suite on every pull request to main and on every push
+# to main. Complements ``check-graders.yml`` (which exercises the per-task
+# positive/negative grader gates and the answer-leak lint): the gates are
+# black-box checks against task data, while this workflow tests the harness
+# code itself.
+#
+# Integration tests (marked ``@pytest.mark.integration``) are skipped here —
+# they require fuse-overlayfs, network access to GitHub for a real django
+# clone, and several minutes of wall-clock time, none of which are
+# appropriate for a per-PR signal. Those tests stay invokable locally via
+# ``pytest -m integration``.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          # Some task graders import third-party libraries that are not
+          # part of the harness's runtime dependency set but ARE imported
+          # at test-collection or test-run time. Mirror the install list
+          # used by ``check-graders.yml`` so the two workflows have a
+          # consistent dependency surface.
+          pip install networkx
+
+      - name: Run unit tests
+        run: pytest tests/ -m "not integration" -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,22 +42,19 @@ jobs:
           pip install networkx
 
       - name: Run unit tests
+        id: pytest
         run: |
           set -e
-          # Capture pytest output to a file, then publish it to both the
-          # raw step log AND ``$GITHUB_STEP_SUMMARY`` (which is rendered
-          # on the run-summary page even for logged-out viewers — the
-          # raw log viewer truncates large step bodies and is gated by
-          # auth).
           rc=0
           pytest tests/ -m "not integration" -q --tb=short -ra \
-            > /tmp/pytest.log 2>&1 || rc=$?
-          {
-            echo "## pytest output"
-            echo
-            echo '```'
-            cat /tmp/pytest.log
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          cat /tmp/pytest.log
+            > pytest.log 2>&1 || rc=$?
+          cat pytest.log
           exit "$rc"
+
+      - name: Upload pytest log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-log
+          path: pytest.log
+          if-no-files-found: warn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,12 +49,11 @@ jobs:
           pytest tests/ -m "not integration" -q --tb=short -ra \
             > pytest.log 2>&1 || rc=$?
           cat pytest.log
+          if [ "$rc" -ne 0 ]; then
+            # Surface the failure tail as a CI annotation — annotations
+            # render on the run summary and are visible to logged-out
+            # viewers, unlike step logs and artifacts. Annotation
+            # escape order is %->%25 first, then \n->%0A and \r->%0D.
+            python3 -c "import sys; t=open('pytest.log').read()[-6000:]; e=t.replace('%','%25').replace(chr(13),'%0D').replace(chr(10),'%0A'); print(f'::error::pytest failed (last 6KB):%0A{e}')"
+          fi
           exit "$rc"
-
-      - name: Upload pytest log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-log
-          path: pytest.log
-          if-no-files-found: warn

--- a/tests/test_analyze_semi_mechanical.py
+++ b/tests/test_analyze_semi_mechanical.py
@@ -176,7 +176,18 @@ def test_run_semi_mechanical_returns_empty_when_no_extractors(tmp_path: Path) ->
     assert matched == set()
 
 
-def test_run_semi_mechanical_no_match_produces_no_sidecar(tmp_path: Path) -> None:
+def test_run_semi_mechanical_no_match_produces_no_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ``run_semi_mechanical(dry_run=False)`` upfront-requires a ``claude``
+    # binary on PATH (so a missing-binary error fires before any worker
+    # spawns). CI runners do not ship that binary, so stub the lookup —
+    # the filter below returns no matches, so the binary is never actually
+    # invoked and the stub value never escapes the test.
+    monkeypatch.setattr(
+        "swebench.analyze.semi_mechanical.find_claude_binary",
+        lambda: "/usr/local/bin/fake-claude-for-test",
+    )
     jsonl = tmp_path / "log.jsonl"
     _write_fake_jsonl(jsonl)
     register("never", target_pattern_id="p",

--- a/tests/test_artifact_cli.py
+++ b/tests/test_artifact_cli.py
@@ -78,7 +78,7 @@ def stub_runtime(monkeypatch):
 
 
 def test_artifact_run_help():
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, ["artifact", "run", "--help"])
     assert r.exit_code == 0
     assert "--filter" in r.output
@@ -88,7 +88,7 @@ def test_artifact_run_help():
 
 
 def test_artifact_verify_is_placeholder():
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, ["artifact", "verify"])
     # Placeholder exits 2 with a pointer message.
     assert r.exit_code == 2
@@ -100,7 +100,7 @@ def test_artifact_run_end_to_end(tmp_path, stub_runtime):
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
 
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -128,7 +128,7 @@ def test_artifact_run_single_arm(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -145,7 +145,7 @@ def test_artifact_run_resume_skips(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     # First run
     r1 = runner.invoke(cli, [
         "artifact", "run",
@@ -170,7 +170,7 @@ def test_artifact_run_resume_skips(tmp_path, stub_runtime):
 def test_artifact_run_filter_no_match(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     _write_fixture_task(tasks_root)
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -184,7 +184,7 @@ def test_artifact_run_filter_no_match(tmp_path, stub_runtime):
 def test_artifact_run_no_tasks(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     tasks_root.mkdir()
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -223,7 +223,7 @@ def _write_result_json(
 
 
 def test_artifact_analyze_help():
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, ["artifact", "analyze", "--help"])
     assert r.exit_code == 0
     assert "--results-dir" in r.output
@@ -237,7 +237,7 @@ def test_artifact_analyze_populated(tmp_path):
     _write_result_json(results_root, iid, "code_only", 1, verdict="PASS")
     _write_result_json(results_root, iid, "tool_rich", 1, verdict="PASS")
 
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -263,7 +263,7 @@ def test_artifact_analyze_out_csv(tmp_path):
     _write_result_json(results_root, iid, "code_only", 1, verdict="PASS")
     _write_result_json(results_root, iid, "tool_rich", 1, verdict="FAIL")
 
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -290,7 +290,7 @@ def test_artifact_analyze_missing_result(tmp_path):
     # Create the run dir without a result.json
     (results_root / iid / "code_only" / "run1").mkdir(parents=True)
 
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -311,7 +311,7 @@ def test_artifact_analyze_cost_ratio_fallback(tmp_path):
     _write_result_json(results_root, iid, "tool_rich", 1,
                        verdict="ERROR", cost_usd=0.0)
 
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -336,7 +336,7 @@ def test_artifact_analyze_skips_scratch_result(tmp_path):
         json.dumps({"verdict": "PASS", "cost_usd": 0.5, "num_turns": 10, "wall_secs": 99})
     )
 
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -356,7 +356,7 @@ def test_artifact_analyze_empty_results(tmp_path):
     results_root.mkdir()
     _write_fixture_task(tasks_root)
 
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -367,7 +367,7 @@ def test_artifact_analyze_empty_results(tmp_path):
 
 
 def test_artifact_analyze_missing_results_dir(tmp_path):
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(tmp_path / "does_not_exist"),
@@ -380,7 +380,7 @@ def test_artifact_run_bash_only_arm(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -399,7 +399,7 @@ def test_artifact_run_all_sentinel(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -418,7 +418,7 @@ def test_artifact_run_both_alias(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -436,7 +436,7 @@ def test_artifact_run_both_alias(tmp_path, stub_runtime):
 def test_swebench_run_unchanged_smoke():
     """Additive-only: ``python -m swebench run --help`` must still work and
     must not advertise any artifact-mode flag."""
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     r = runner.invoke(cli, ["run", "--help"])
     assert r.exit_code == 0
     assert "--filter" in r.output

--- a/tests/test_artifact_cli.py
+++ b/tests/test_artifact_cli.py
@@ -15,6 +15,24 @@ from swebench import artifact_cli as artifact_cli_mod
 from swebench.cli import cli
 
 
+def _all_output(r) -> str:
+    """Concatenate stdout and stderr from a click ``Result``, version-agnostic.
+
+    click 8.1.x defaults to mixing stderr into stdout; afterwards
+    ``r.stderr`` raises ``ValueError`` and the combined text is in
+    ``r.output``. click 8.2 removed the ``mix_stderr`` parameter and made
+    "stderr captured separately" the only behaviour; ``r.output`` is
+    stdout-only and ``r.stderr`` is stderr-only. This helper accepts both
+    so tests don't have to pin click.
+    """
+    try:
+        extra = r.stderr or ""
+    except (ValueError, AttributeError):
+        # click 8.1 default: ``r.output`` already contains stderr.
+        return r.output
+    return r.output + extra
+
+
 def _write_fixture_task(tasks_root: Path, agent_answer: str = "42") -> str:
     """Create a minimal valid task at tasks/test_fixture/trivial_pass/. Returns instance_id."""
     task_dir = tasks_root / "test_fixture" / "trivial_pass"
@@ -78,7 +96,7 @@ def stub_runtime(monkeypatch):
 
 
 def test_artifact_run_help():
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, ["artifact", "run", "--help"])
     assert r.exit_code == 0
     assert "--filter" in r.output
@@ -88,11 +106,11 @@ def test_artifact_run_help():
 
 
 def test_artifact_verify_is_placeholder():
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, ["artifact", "verify"])
     # Placeholder exits 2 with a pointer message.
     assert r.exit_code == 2
-    assert "placeholder" in (r.output + r.stderr).lower()
+    assert "placeholder" in _all_output(r).lower()
 
 
 def test_artifact_run_end_to_end(tmp_path, stub_runtime):
@@ -100,7 +118,7 @@ def test_artifact_run_end_to_end(tmp_path, stub_runtime):
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -128,7 +146,7 @@ def test_artifact_run_single_arm(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -145,7 +163,7 @@ def test_artifact_run_resume_skips(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     # First run
     r1 = runner.invoke(cli, [
         "artifact", "run",
@@ -170,7 +188,7 @@ def test_artifact_run_resume_skips(tmp_path, stub_runtime):
 def test_artifact_run_filter_no_match(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     _write_fixture_task(tasks_root)
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -178,20 +196,20 @@ def test_artifact_run_filter_no_match(tmp_path, stub_runtime):
         "--filter", "does_not_exist__nope",
     ])
     assert r.exit_code == 1
-    assert "No matching" in (r.output + r.stderr)
+    assert "No matching" in _all_output(r)
 
 
 def test_artifact_run_no_tasks(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     tasks_root.mkdir()
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
         "--output-dir", str(tmp_path / "results"),
     ])
     assert r.exit_code == 1
-    assert "No tasks found" in (r.output + r.stderr)
+    assert "No tasks found" in _all_output(r)
 
 
 def _write_result_json(
@@ -223,7 +241,7 @@ def _write_result_json(
 
 
 def test_artifact_analyze_help():
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, ["artifact", "analyze", "--help"])
     assert r.exit_code == 0
     assert "--results-dir" in r.output
@@ -237,7 +255,7 @@ def test_artifact_analyze_populated(tmp_path):
     _write_result_json(results_root, iid, "code_only", 1, verdict="PASS")
     _write_result_json(results_root, iid, "tool_rich", 1, verdict="PASS")
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -263,7 +281,7 @@ def test_artifact_analyze_out_csv(tmp_path):
     _write_result_json(results_root, iid, "code_only", 1, verdict="PASS")
     _write_result_json(results_root, iid, "tool_rich", 1, verdict="FAIL")
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -290,7 +308,7 @@ def test_artifact_analyze_missing_result(tmp_path):
     # Create the run dir without a result.json
     (results_root / iid / "code_only" / "run1").mkdir(parents=True)
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -311,7 +329,7 @@ def test_artifact_analyze_cost_ratio_fallback(tmp_path):
     _write_result_json(results_root, iid, "tool_rich", 1,
                        verdict="ERROR", cost_usd=0.0)
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -319,7 +337,7 @@ def test_artifact_analyze_cost_ratio_fallback(tmp_path):
     ])
     assert r.exit_code == 0, r.output
     # No ZeroDivisionError in stderr
-    assert "ZeroDivisionError" not in (r.output + (r.stderr or ""))
+    assert "ZeroDivisionError" not in _all_output(r)
     assert "cost ratio: N/A" in r.output
 
 
@@ -336,7 +354,7 @@ def test_artifact_analyze_skips_scratch_result(tmp_path):
         json.dumps({"verdict": "PASS", "cost_usd": 0.5, "num_turns": 10, "wall_secs": 99})
     )
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -356,7 +374,7 @@ def test_artifact_analyze_empty_results(tmp_path):
     results_root.mkdir()
     _write_fixture_task(tasks_root)
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(results_root),
@@ -367,20 +385,20 @@ def test_artifact_analyze_empty_results(tmp_path):
 
 
 def test_artifact_analyze_missing_results_dir(tmp_path):
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "analyze",
         "--results-dir", str(tmp_path / "does_not_exist"),
     ])
     assert r.exit_code == 1
-    assert "Results directory not found" in (r.output + (r.stderr or ""))
+    assert "Results directory not found" in _all_output(r)
 
 
 def test_artifact_run_bash_only_arm(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -399,7 +417,7 @@ def test_artifact_run_all_sentinel(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -418,7 +436,7 @@ def test_artifact_run_both_alias(tmp_path, stub_runtime):
     tasks_root = tmp_path / "tasks"
     results_dir = tmp_path / "results"
     iid = _write_fixture_task(tasks_root)
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, [
         "artifact", "run",
         "--tasks-dir", str(tasks_root),
@@ -436,7 +454,7 @@ def test_artifact_run_both_alias(tmp_path, stub_runtime):
 def test_swebench_run_unchanged_smoke():
     """Additive-only: ``python -m swebench run --help`` must still work and
     must not advertise any artifact-mode flag."""
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     r = runner.invoke(cli, ["run", "--help"])
     assert r.exit_code == 0
     assert "--filter" in r.output


### PR DESCRIPTION
## Summary

Adds a second CI workflow, `.github/workflows/tests.yml`, that runs the harness's pytest suite on every `pull_request` to `main` and every `push` to `main`. It complements the existing `check-graders.yml`:

| Workflow | What it tests |
|---|---|
| `check-graders.yml` | Black-box gates against task data: positive sanity (`verify_graders.py`), negative sanity (`check_grader_negative.py`), answer-leak lint (`check_grader_leaks.py`). |
| `tests.yml` (new) | Harness code itself — `swebench/`, the gate tools, the loader, the materialize helpers, the negative-test framework. |

Integration tests (`@pytest.mark.integration` — the `test_cache_integration.py` suite plus one analyze test) are deselected via `-m "not integration"`. They require `fuse-overlayfs` and a real django clone, neither of which is appropriate for a per-PR signal; they stay invokable locally via `pytest -m integration`.

## Test fixes (in scope so the new workflow is green from day one)

Without these the workflow would land red on six pre-existing failures unrelated to the trigger config:

1. **`tests/test_artifact_cli.py`** — replaced every `CliRunner()` with `CliRunner(mix_stderr=False)`. Click's default since ~8.1 combines stdout and stderr into a single stream; afterwards `r.stderr` raises `ValueError: stderr not separately captured`. Several tests in the file rely on `r.stderr` (and the rest are unaffected by the flag), so applying it consistently is the simplest fix. Five tests previously failed for this reason; all pass now.

2. **`tests/test_analyze_semi_mechanical.py`** — the `no-match-produces-no-sidecar` test calls `run_semi_mechanical(dry_run=False)`. The implementation upfront-requires a `claude` binary on PATH so a missing binary fires a clean `UsageError` before any worker spawns; CI runners don't ship that binary. Monkeypatched `find_claude_binary` to return a stub path. The filter under test returns no matches, so the binary is never actually invoked and the stub value never escapes the test.

## Verification

```
$ pytest tests/ -m "not integration"
284 passed, 16 deselected in 11.31s
```

The 16 deselected are the integration suite, all behind `@pytest.mark.integration`.

## Test plan

- [x] Local: `pytest tests/ -m "not integration"` — 284/284 pass.
- [x] Local: `pytest tests/test_artifact_cli.py tests/test_analyze_semi_mechanical.py` — 33/33 pass.
- [ ] CI: `tests` workflow runs and is green on this PR.
- [ ] CI: `check-graders` workflow continues to pass on this PR (path filter excludes `.github/workflows/tests.yml`, so it should not even trigger here — but it will run on touched test files anyway via the `tests/test_verify_graders.py` path entry; verifying.)