### PR TITLE
fix(tasks): declare structural_verifier where verify.py exists (#167)

### DIFF
--- a/.github/workflows/check-graders.yml
+++ b/.github/workflows/check-graders.yml
@@ -15,10 +15,12 @@ on:
       - "tools/verify_graders.py"
       - "tools/check_grader_negative.py"
       - "tools/check_grader_leaks.py"
+      - "tools/check_structural_verifier_consistency.py"
       - "Makefile"
       - ".github/workflows/check-graders.yml"
       - "tests/test_verify_graders.py"
       - "tests/test_check_grader_negative.py"
+      - "tests/test_check_structural_verifier_consistency.py"
 
 jobs:
   graders:
@@ -50,3 +52,6 @@ jobs:
 
       - name: Answer-leak lint
         run: make check-graders-leaks
+
+      - name: Structural-verifier consistency lint
+        run: make check-graders-structural

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,15 @@
 PYTHON ?= python3
 
 .PHONY: help check-graders check-graders-positive check-graders-negative \
-        check-graders-leaks check-graders-fast test
+        check-graders-leaks check-graders-structural check-graders-fast test
 
 help:
 	@echo "Available targets:"
-	@echo "  make check-graders            run positive + negative + leak gates on every task"
+	@echo "  make check-graders            run positive + negative + leak + structural-verifier gates on every task"
 	@echo "  make check-graders-positive   run only the positive sanity check (verify_graders.py)"
 	@echo "  make check-graders-negative   run only the negative sanity check (check_grader_negative.py)"
 	@echo "  make check-graders-leaks      run only the answer-leak lint (check_grader_leaks.py)"
+	@echo "  make check-graders-structural run only the structural_verifier consistency lint"
 	@echo "  make check-graders-fast       run negative gate ONLY for tasks that ship grader/negative_cases.py"
 	@echo "  make test                     run pytest"
 
@@ -27,12 +28,14 @@ help:
 #   2. The negative check (deliberately wrong artifacts → grader returns
 #      passed=False). Catches graders that ACCEPT artifacts they shouldn't.
 #   3. The answer-leak lint (no embedded reference values in detail strings).
+#   4. The structural_verifier consistency lint (every workspace/verify.py is
+#      declared in task.yaml, and every declaration points at a real file).
 #
-# All three are individually invokable; ``check-graders`` is the umbrella
+# All four are individually invokable; ``check-graders`` is the umbrella
 # target the CI workflow uses.
 # ---------------------------------------------------------------------------
 
-check-graders: check-graders-positive check-graders-negative check-graders-leaks
+check-graders: check-graders-positive check-graders-negative check-graders-leaks check-graders-structural
 	@echo ""
 	@echo "All grader gates passed."
 
@@ -44,6 +47,9 @@ check-graders-negative:
 
 check-graders-leaks:
 	$(PYTHON) tools/check_grader_leaks.py
+
+check-graders-structural:
+	$(PYTHON) tools/check_structural_verifier_consistency.py
 
 # A faster lane for PRs that only add or modify a single task: skip the
 # default-mutation pass for unrelated tasks and only exercise tasks that

--- a/problems/artifact/algorithmic/bin_packing_first_fit_optimal/task.yaml
+++ b/problems/artifact/algorithmic/bin_packing_first_fit_optimal/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/bins.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/algorithmic/coin_change_min/task.yaml
+++ b/problems/artifact/algorithmic/coin_change_min/task.yaml
@@ -4,6 +4,7 @@ difficulty: easy
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/answer.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/algorithmic/graph_min_vertex_cover/task.yaml
+++ b/problems/artifact/algorithmic/graph_min_vertex_cover/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/cover.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/algorithmic/interval_scheduling_weighted/task.yaml
+++ b/problems/artifact/algorithmic/interval_scheduling_weighted/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/schedule.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/algorithmic/knapsack_01/task.yaml
+++ b/problems/artifact/algorithmic/knapsack_01/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/pack.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/algorithmic/makespan_scheduling/task.yaml
+++ b/problems/artifact/algorithmic/makespan_scheduling/task.yaml
@@ -4,6 +4,7 @@ difficulty: easy
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/schedule.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/algorithmic/min_cost_assignment/task.yaml
+++ b/problems/artifact/algorithmic/min_cost_assignment/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/assignment.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/algorithmic/traveling_salesman_small/task.yaml
+++ b/problems/artifact/algorithmic/traveling_salesman_small/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/tour.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/data_processing/regression_detection/task.yaml
+++ b/problems/artifact/data_processing/regression_detection/task.yaml
@@ -5,6 +5,7 @@ problem_statement: prompt.md
 workspace_dir: workspace/
 workspace_generator: workspace/generator.py
 output_artifact: output/regressions.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/binary_strings_no_run/task.yaml
+++ b/problems/artifact/enumeration/binary_strings_no_run/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/strings.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/graphs_chromatic_3/task.yaml
+++ b/problems/artifact/enumeration/graphs_chromatic_3/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/graphs.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/integer_partitions_15/task.yaml
+++ b/problems/artifact/enumeration/integer_partitions_15/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/partitions.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/latin_squares_3/task.yaml
+++ b/problems/artifact/enumeration/latin_squares_3/task.yaml
@@ -4,6 +4,7 @@ difficulty: easy
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/latin_squares.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/nqueens_7/task.yaml
+++ b/problems/artifact/enumeration/nqueens_7/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solutions.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/permutations_fixed_points/task.yaml
+++ b/problems/artifact/enumeration/permutations_fixed_points/task.yaml
@@ -4,6 +4,7 @@ difficulty: easy
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/perms.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/subset_sum_count/task.yaml
+++ b/problems/artifact/enumeration/subset_sum_count/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/subsets.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/enumeration/sudoku_row_completions/task.yaml
+++ b/problems/artifact/enumeration/sudoku_row_completions/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/completions.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/iterative_numerical/exp_decay_fit/task.yaml
+++ b/problems/artifact/iterative_numerical/exp_decay_fit/task.yaml
@@ -4,6 +4,7 @@ difficulty: easy
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/params.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/iterative_numerical/hparam_search/task.yaml
+++ b/problems/artifact/iterative_numerical/hparam_search/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/result.json
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.json
 execution_budget:

--- a/problems/artifact/stateful_reasoning/unreachable_functions/task.yaml
+++ b/problems/artifact/stateful_reasoning/unreachable_functions/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/unreachable.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/stateful_reasoning/upgrade_impact/task.yaml
+++ b/problems/artifact/stateful_reasoning/upgrade_impact/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/conflicts.jsonl
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.jsonl
 execution_budget:

--- a/problems/artifact/verification_heavy/cron_next_fire/task.yaml
+++ b/problems/artifact/verification_heavy/cron_next_fire/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solution.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/problems/artifact/verification_heavy/csv_dialect_parser/task.yaml
+++ b/problems/artifact/verification_heavy/csv_dialect_parser/task.yaml
@@ -4,6 +4,7 @@ difficulty: easy
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solution.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/problems/artifact/verification_heavy/expression_evaluator/task.yaml
+++ b/problems/artifact/verification_heavy/expression_evaluator/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solution.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/problems/artifact/verification_heavy/iban_validator/task.yaml
+++ b/problems/artifact/verification_heavy/iban_validator/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solution.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/problems/artifact/verification_heavy/json_pointer_rfc6901/task.yaml
+++ b/problems/artifact/verification_heavy/json_pointer_rfc6901/task.yaml
@@ -4,6 +4,7 @@ difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solution.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/problems/artifact/verification_heavy/lru_cache_impl/task.yaml
+++ b/problems/artifact/verification_heavy/lru_cache_impl/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/lru_cache.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/problems/artifact/verification_heavy/parse_iso_duration/task.yaml
+++ b/problems/artifact/verification_heavy/parse_iso_duration/task.yaml
@@ -4,6 +4,7 @@ difficulty: easy
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solution.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/problems/artifact/verification_heavy/semver_compare/task.yaml
+++ b/problems/artifact/verification_heavy/semver_compare/task.yaml
@@ -4,6 +4,7 @@ difficulty: medium
 problem_statement: prompt.md
 workspace_dir: workspace/
 output_artifact: output/solution.py
+structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py
 reference_output: grader/reference_output.py
 execution_budget:

--- a/tests/test_check_structural_verifier_consistency.py
+++ b/tests/test_check_structural_verifier_consistency.py
@@ -1,0 +1,129 @@
+"""Tests for tools/check_structural_verifier_consistency.py.
+
+Mirrors the style of test_verify_graders.py — runs the tool as a
+subprocess so the CLI exit-code contract is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+_TOOL = (
+    Path(__file__).resolve().parent.parent
+    / "tools"
+    / "check_structural_verifier_consistency.py"
+)
+
+
+def _run_tool(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_TOOL), "--root", str(root)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_task(
+    root: Path,
+    slug: str,
+    *,
+    has_verify: bool,
+    declares: bool,
+    declared_path: str = "workspace/verify.py",
+) -> Path:
+    task_dir = root / "problems" / "artifact" / "test_fixture" / slug
+    (task_dir / "workspace").mkdir(parents=True)
+    if has_verify:
+        (task_dir / "workspace" / "verify.py").write_text("def verify(p): pass\n")
+    yaml_lines = [
+        f"instance_id: test_fixture__{slug}",
+        "category: test_fixture",
+        "difficulty: easy",
+        "problem_statement: prompt.md",
+        "workspace_dir: workspace/",
+        "output_artifact: out.txt",
+    ]
+    if declares:
+        yaml_lines.append(f"structural_verifier: {declared_path}")
+    yaml_lines += [
+        "hidden_grader: grader/hidden.py",
+        "reference_output: grader/reference_output.txt",
+        "execution_budget:",
+        "  max_code_runs: 0",
+        "  max_wall_seconds: 0",
+    ]
+    (task_dir / "task.yaml").write_text("\n".join(yaml_lines) + "\n")
+    return task_dir
+
+
+def test_self_test_passes() -> None:
+    """The bundled --self-test must always pass."""
+    res = subprocess.run(
+        [sys.executable, str(_TOOL), "--self-test"],
+        capture_output=True, text=True,
+    )
+    assert res.returncode == 0, (
+        f"self-test failed (code {res.returncode}):\n"
+        f"stdout: {res.stdout}\nstderr: {res.stderr}"
+    )
+
+
+def test_clean_repo_returns_zero(tmp_path: Path) -> None:
+    """A repo where every (verify.py, declaration) pair agrees is clean."""
+    _make_task(tmp_path, "both_present", has_verify=True, declares=True)
+    _make_task(tmp_path, "neither_present", has_verify=False, declares=False)
+
+    res = _run_tool(tmp_path)
+    assert res.returncode == 0, (
+        f"expected exit 0, got {res.returncode}\n"
+        f"stdout: {res.stdout}\nstderr: {res.stderr}"
+    )
+    assert "no structural_verifier inconsistencies" in res.stdout
+
+
+def test_missing_declaration_is_flagged(tmp_path: Path) -> None:
+    """workspace/verify.py without a task.yaml declaration → exit 1."""
+    _make_task(tmp_path, "needs_decl", has_verify=True, declares=False)
+
+    res = _run_tool(tmp_path)
+    assert res.returncode == 1
+    assert "MISSING_DECLARATION" in res.stderr
+    assert "needs_decl" in res.stderr
+
+
+def test_missing_file_is_flagged(tmp_path: Path) -> None:
+    """task.yaml declaration without a real file → exit 1."""
+    _make_task(tmp_path, "dangling_decl", has_verify=False, declares=True)
+
+    res = _run_tool(tmp_path)
+    assert res.returncode == 1
+    assert "MISSING_FILE" in res.stderr
+    assert "dangling_decl" in res.stderr
+
+
+def test_empty_tasks_dir_returns_two(tmp_path: Path) -> None:
+    """Discovery error: no task.yaml files → exit 2."""
+    (tmp_path / "problems" / "artifact").mkdir(parents=True)
+
+    res = _run_tool(tmp_path)
+    assert res.returncode == 2
+    assert "no task.yaml files found" in res.stderr
+
+
+def test_real_repo_is_consistent() -> None:
+    """The real onlycodes repo must satisfy the lint at HEAD.
+
+    This is the regression guard for issue #167: any future task that
+    ships workspace/verify.py without declaring structural_verifier
+    (or vice versa) will fail this test.
+    """
+    repo = Path(__file__).resolve().parent.parent
+    res = _run_tool(repo)
+    assert res.returncode == 0, (
+        f"real repo failed structural_verifier lint:\n"
+        f"stdout: {res.stdout}\nstderr: {res.stderr}"
+    )

--- a/tools/check_structural_verifier_consistency.py
+++ b/tools/check_structural_verifier_consistency.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Consistency gate for ``structural_verifier`` declarations.
+
+Per ``docs/SCHEMA_ARTIFACT.md`` §2.2 and §4, the ``structural_verifier``
+field in ``task.yaml`` is optional, but when a task ships
+``workspace/verify.py`` the field MUST be declared (and conversely, a
+task that declares the field MUST ship the file).
+
+This lint walks ``problems/artifact/<category>/<slug>/`` and flags two
+classes of inconsistency:
+
+  * ``MISSING_DECLARATION`` — ``workspace/verify.py`` exists on disk but
+    ``task.yaml`` does not declare ``structural_verifier``. The harness
+    will not register the verifier even though the agent can see and
+    import it; future analysis tooling that keys off the declaration
+    will silently skip the task.
+  * ``MISSING_FILE`` — ``task.yaml`` declares ``structural_verifier``
+    but the referenced file does not exist. The harness loader treats
+    this as a hard error at task-load time; we want CI to surface it
+    earlier.
+
+The tool intentionally does NOT enforce that every task ship a
+verifier; verifiers are optional by schema.
+
+Exit code:
+    0 — no inconsistencies
+    1 — at least one inconsistency (each printed to stderr)
+    2 — discovery error (e.g. tasks dir missing or unreadable)
+
+Usage:
+    python tools/check_structural_verifier_consistency.py
+    python tools/check_structural_verifier_consistency.py --root /path/to/onlycodes
+    python tools/check_structural_verifier_consistency.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+
+# Match a top-level ``structural_verifier:`` key. ``task.yaml`` does not
+# nest the field, so a simple line-anchored regex is sufficient and
+# avoids a yaml dependency for this lightweight CI gate.
+_DECL_RE = re.compile(r"^structural_verifier\s*:\s*(\S+)\s*$", re.MULTILINE)
+
+
+class Violation(NamedTuple):
+    task_dir: Path
+    kind: str   # "MISSING_DECLARATION" | "MISSING_FILE"
+    detail: str
+
+    def format(self, root: Path) -> str:
+        rel = self.task_dir.relative_to(root)
+        return f"  {rel}: {self.kind}: {self.detail}"
+
+
+def find_task_yamls(root: Path) -> list[Path]:
+    """Return every ``task.yaml`` under ``problems/artifact/``."""
+    base = root / "problems" / "artifact"
+    if not base.is_dir():
+        return []
+    return sorted(base.glob("*/*/task.yaml"))
+
+
+def _declared_path(task_yaml_text: str) -> str | None:
+    """Return the relative path declared as ``structural_verifier`` if any."""
+    m = _DECL_RE.search(task_yaml_text)
+    if not m:
+        return None
+    return m.group(1)
+
+
+def scan_task(task_yaml: Path) -> list[Violation]:
+    """Return any inconsistencies for one task."""
+    task_dir = task_yaml.parent
+    text = task_yaml.read_text()
+    declared = _declared_path(text)
+    # Convention is workspace/verify.py; the field MAY point elsewhere,
+    # so we honor whatever path the manifest declares.
+    declared_file = (task_dir / declared) if declared else None
+    conventional_file = task_dir / "workspace" / "verify.py"
+
+    out: list[Violation] = []
+
+    if declared is None and conventional_file.is_file():
+        out.append(Violation(
+            task_dir=task_dir,
+            kind="MISSING_DECLARATION",
+            detail=(
+                "workspace/verify.py exists but task.yaml does not declare "
+                "structural_verifier: workspace/verify.py"
+            ),
+        ))
+    elif declared is not None and declared_file is not None and not declared_file.is_file():
+        out.append(Violation(
+            task_dir=task_dir,
+            kind="MISSING_FILE",
+            detail=(
+                f"task.yaml declares structural_verifier: {declared} but the "
+                f"file does not exist on disk"
+            ),
+        ))
+
+    return out
+
+
+def scan_all(root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for ty in find_task_yamls(root):
+        violations.extend(scan_task(ty))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repo root (default: parent of tools/)",
+    )
+    p.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run unit tests against handcrafted fixtures",
+    )
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    root: Path = args.root
+    task_yamls = find_task_yamls(root)
+    if not task_yamls:
+        print(f"no task.yaml files found under {root}/problems/artifact/",
+              file=sys.stderr)
+        return 2
+
+    violations = scan_all(root)
+    if violations:
+        print(
+            f"FAIL: {len(violations)} structural_verifier inconsistency(ies) "
+            f"in {len({v.task_dir for v in violations})} task(s):",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(v.format(root), file=sys.stderr)
+        return 1
+
+    print(f"OK: scanned {len(task_yamls)} task.yaml file(s); no "
+          f"structural_verifier inconsistencies")
+    return 0
+
+
+# ────────────────────────────── self-test ─────────────────────────────────
+
+
+def _make_task(tmp: Path, *, has_verify: bool, declares: bool) -> Path:
+    """Build a minimal task tree under tmp and return the task dir."""
+    task = tmp / "problems" / "artifact" / "test_fixture" / f"v{int(has_verify)}_d{int(declares)}"
+    (task / "workspace").mkdir(parents=True)
+    if has_verify:
+        (task / "workspace" / "verify.py").write_text("def verify(p): pass\n")
+    yaml_lines = [
+        "instance_id: test_fixture__sample",
+        "category: test_fixture",
+        "difficulty: easy",
+        "problem_statement: prompt.md",
+        "workspace_dir: workspace/",
+        "output_artifact: out.txt",
+    ]
+    if declares:
+        yaml_lines.append("structural_verifier: workspace/verify.py")
+    yaml_lines.extend([
+        "hidden_grader: grader/hidden.py",
+        "reference_output: grader/reference_output.txt",
+        "execution_budget:",
+        "  max_code_runs: 0",
+        "  max_wall_seconds: 0",
+    ])
+    (task / "task.yaml").write_text("\n".join(yaml_lines) + "\n")
+    return task
+
+
+def _self_test() -> int:
+    import tempfile
+
+    failed = 0
+
+    with tempfile.TemporaryDirectory(prefix="check_sv_") as raw:
+        tmp = Path(raw)
+
+        # Case 1: has verify.py + declared → clean.
+        _make_task(tmp, has_verify=True, declares=True)
+        # Case 2: no verify.py + not declared → clean.
+        _make_task(tmp, has_verify=False, declares=False)
+        # Case 3: has verify.py + NOT declared → MISSING_DECLARATION.
+        case3 = _make_task(tmp, has_verify=True, declares=False)
+        # Case 4: declared + NO verify.py → MISSING_FILE.
+        case4 = _make_task(tmp, has_verify=False, declares=True)
+
+        violations = scan_all(tmp)
+        kinds = {v.task_dir: v.kind for v in violations}
+
+        if kinds.get(case3) != "MISSING_DECLARATION":
+            print(f"FAIL: case3 expected MISSING_DECLARATION, got {kinds.get(case3)}",
+                  file=sys.stderr)
+            failed += 1
+        if kinds.get(case4) != "MISSING_FILE":
+            print(f"FAIL: case4 expected MISSING_FILE, got {kinds.get(case4)}",
+                  file=sys.stderr)
+            failed += 1
+        # Cases 1 and 2 must produce no violation rows.
+        clean_dirs = {
+            tmp / "problems" / "artifact" / "test_fixture" / "v1_d1",
+            tmp / "problems" / "artifact" / "test_fixture" / "v0_d0",
+        }
+        for v in violations:
+            if v.task_dir in clean_dirs:
+                print(f"FAIL: clean fixture flagged: {v.format(tmp)}",
+                      file=sys.stderr)
+                failed += 1
+
+        # Also exercise the regex on a yaml that has the field elsewhere
+        # (e.g. inside a tag string) — must still match the keyed line.
+        weird = (
+            "tags: [structural_verifier_unrelated]\n"
+            "structural_verifier: workspace/verify.py\n"
+        )
+        if _declared_path(weird) != "workspace/verify.py":
+            print("FAIL: regex did not detect declaration in mixed yaml",
+                  file=sys.stderr)
+            failed += 1
+        # And a yaml where the token only appears in a comment-like line
+        # MUST NOT count as a declaration.
+        commentish = "tags:\n  - structural_verifier\n"
+        if _declared_path(commentish) is not None:
+            print("FAIL: regex matched a tag list as a declaration",
+                  file=sys.stderr)
+            failed += 1
+
+    if failed:
+        print(f"\n{failed} self-test failure(s)", file=sys.stderr)
+        return 1
+    print("OK: self-test passed (4 fixtures + 2 regex cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #167.

- Per `docs/SCHEMA_ARTIFACT.md` §2.2 / §4, `structural_verifier` is optional, but tasks that ship `workspace/verify.py` MUST declare it so the harness (and future analysis tooling) can find the verifier.
- Audit of `problems/artifact/` found **29** task.yaml files shipping `workspace/verify.py` without the matching declaration — a superset of the 11 cases called out in #167. All 29 are updated; the field is inserted between `output_artifact:` and `hidden_grader:` to match the canonical schema example.
- Adds **`tools/check_structural_verifier_consistency.py`** — a one-shot lint that fails when `workspace/verify.py` exists but the field is missing (`MISSING_DECLARATION`), or when the field is declared but no file exists on disk (`MISSING_FILE`). Includes a bundled `--self-test` and the same arg shape (`--root`) as the sibling lints.
- Wires the new gate into the `Makefile` (`check-graders-structural` target, included in the umbrella `check-graders`) and `.github/workflows/check-graders.yml` as a new required CI step. Path filters and watched test paths updated accordingly.
- Adds **`tests/test_check_structural_verifier_consistency.py`** with 6 tests: clean fixtures (both present / neither present), `MISSING_DECLARATION`, `MISSING_FILE`, empty-tasks-dir → exit 2, the bundled `--self-test`, and a regression guard that runs the lint against the real repo at HEAD.

After the change: 48 task.yaml files load via `swebench.artifact_loader.load_tasks`; 43 declare `structural_verifier`, matching the 43 `workspace/verify.py` files on disk. No tasks declare the field without the file existing.

No prompts needed updating — every task that lacks `verify.py` also doesn't mention it in `prompt.md`.

## Acceptance criteria (from #167)

- [x] Every task with a `workspace/verify.py` declares `structural_verifier: workspace/verify.py` in its `task.yaml`.
- [x] Tasks WITHOUT a `verify.py` do not declare the field (and prompts that mention it are updated or the verifier is added — none mention it).
- [x] Adds a one-shot consistency check to `tools/` that fails when `verify.py` exists but the field is missing, OR vice versa.

## Test plan

- [x] `python tools/check_structural_verifier_consistency.py --self-test` → OK
- [x] `python tools/check_structural_verifier_consistency.py` against the real repo → OK (48 task.yaml files, 0 inconsistencies)
- [x] Negative regression: removed declaration from one task, lint exits 1 with `MISSING_DECLARATION`
- [x] `pytest tests/test_check_structural_verifier_consistency.py` → 6 passed
- [x] `swebench.artifact_loader.load_tasks` loads all 48 tasks; 43 declare `structural_verifier` (matches 43 `verify.py` files)
- [ ] CI: `check-graders` workflow (positive + negative + leak + structural) — runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)