### PR TITLE
fix(hparam_search): per-instance Gaussian peaks (#168)

### DIFF
--- a/problems/artifact/iterative_numerical/hparam_search/grader/hidden.py
+++ b/problems/artifact/iterative_numerical/hparam_search/grader/hidden.py
@@ -1,23 +1,34 @@
 """Hidden grader for iterative_numerical__hparam_search.
 
-Contract: ``grade(scratch_dir: Path) -> GradeResult``. See docs/SCHEMA_ARTIFACT.md §3.
+Contract: ``grade(scratch_dir: Path) -> GradeResult``. See
+``docs/SCHEMA_ARTIFACT.md`` §3.
 
 Correctness criterion:
 
-    The agent's output/result.json MUST report hyperparameters (learning_rate,
-    hidden_size, dropout) such that when evaluate(lr, hs, do) is called with
-    these values, the returned accuracy >= ACCURACY_TARGET (0.90).
+    The agent's ``output/result.json`` MUST report hyperparameters
+    (``learning_rate``, ``hidden_size``, ``dropout``) such that when
+    ``evaluate(lr, hs, do)`` is called with these values, the returned
+    accuracy is ``>= ACCURACY_TARGET`` (0.90).
 
     The grader re-evaluates the toy model on the reported params — agents
     cannot hallucinate high accuracy without actually finding good params.
 
-Determinism: the toy model is a deterministic pure-Python function.
+Per issue #168 the Gaussian peak locations are derived from
+``sha256(INSTANCE_ID)`` rather than living as literal constants in source.
+The grader mirrors the derivation in ``workspace/generator.py``, so the
+grader stays independent of the materialized ``calibration.bin``.
+
+Determinism: the toy model is a deterministic pure-Python function and the
+peak-derivation RNG is seeded from a constant, so ``grade()`` is
+reproducible.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
+import random
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,13 +42,32 @@ class GradeResult:
 
 OUTPUT_REL = "output/result.json"
 ACCURACY_TARGET = 0.90
+INSTANCE_ID = "iterative_numerical__hparam_search"
+
+
+def _seed_for_instance(instance_id: str) -> int:
+    """Mirror of ``swebench.artifact_materialize._seed_for_instance``."""
+    digest = hashlib.sha256(instance_id.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16)
+
+
+def _derive_peaks(instance_id: str) -> tuple[float, int, float]:
+    """Mirror of ``workspace/generator.derive_peaks`` — keep in lockstep."""
+    rng = random.Random(_seed_for_instance(instance_id))
+    lr_peak = 10 ** rng.uniform(math.log10(3e-4), math.log10(5e-2))
+    hs_peak = 8 * rng.randint(4, 48)
+    do_peak = rng.uniform(0.10, 0.60)
+    return lr_peak, hs_peak, do_peak
+
+
+_LR_PEAK, _HS_PEAK, _DO_PEAK = _derive_peaks(INSTANCE_ID)
 
 
 def _evaluate(learning_rate: float, hidden_size: int, dropout: float) -> float:
-    """Mirror of toy_model.py:evaluate — kept in sync."""
-    lr_score = math.exp(-3.0 * (math.log10(learning_rate / 0.01)) ** 2)
-    hs_score = math.exp(-((hidden_size - 128) / 128.0) ** 2)
-    do_score = math.exp(-((dropout - 0.3) / 0.2) ** 2)
+    """Mirror of ``workspace/toy_model.py:evaluate`` — kept in sync (issue #168)."""
+    lr_score = math.exp(-3.0 * (math.log10(learning_rate / _LR_PEAK)) ** 2)
+    hs_score = math.exp(-((hidden_size - _HS_PEAK) / 128.0) ** 2)
+    do_score = math.exp(-((dropout - _DO_PEAK) / 0.2) ** 2)
     return round(0.95 * lr_score * hs_score * do_score, 6)
 
 

--- a/problems/artifact/iterative_numerical/hparam_search/grader/reference_output.json
+++ b/problems/artifact/iterative_numerical/hparam_search/grader/reference_output.json
@@ -1,6 +1,6 @@
 {
-  "learning_rate": 0.01,
-  "hidden_size": 128,
-  "dropout": 0.3,
+  "learning_rate": 0.0012412191399767878,
+  "hidden_size": 232,
+  "dropout": 0.2396241143461019,
   "accuracy": 0.95
 }

--- a/problems/artifact/iterative_numerical/hparam_search/prompt.md
+++ b/problems/artifact/iterative_numerical/hparam_search/prompt.md
@@ -7,11 +7,16 @@ You are provided a deterministic toy model in `toy_model.py`. Your goal is to fi
 ```python
 from toy_model import evaluate
 
-accuracy = evaluate(learning_rate=0.01, hidden_size=128, dropout=0.3)
+accuracy = evaluate(learning_rate=0.001, hidden_size=64, dropout=0.5)
 # returns a float in [0.0, 0.95]
 ```
 
 The function is **deterministic** — same inputs always return the same accuracy.
+
+The model has per-instance calibration data (loaded from `calibration.bin`
+sitting next to the module). The Gaussian *shape* of the response surface is
+fixed, but the *location* of its peak varies per task instance, so reading
+`toy_model.py` will NOT tell you the optimum. Call `evaluate()` and search.
 
 Parameters to search:
 - `learning_rate`: float, try values in [1e-4, 0.1] (log scale recommended)
@@ -20,10 +25,11 @@ Parameters to search:
 
 ## Your goal
 
-Find parameters with **accuracy ≥ 0.90**. The model has a unique global optimum — search to find it.
+Find parameters with **accuracy ≥ 0.90**. The model has a unique global optimum
+inside the declared search space — search to find it.
 
 Suggested approach:
-1. Start with a coarse grid search
+1. Start with a coarse grid search across the declared ranges
 2. Refine around the best-performing region
 3. Report the best configuration found
 
@@ -33,12 +39,14 @@ Write `output/result.json`:
 
 ```json
 {
-  "learning_rate": 0.01,
-  "hidden_size": 128,
-  "dropout": 0.3,
+  "learning_rate": 0.001,
+  "hidden_size": 64,
+  "dropout": 0.5,
   "accuracy": 0.95
 }
 ```
+
+(Values above are illustrative — they are *not* the answer.)
 
 The grader will **re-evaluate** `evaluate(learning_rate, hidden_size, dropout)` on your reported parameters. Reported `accuracy` is informational — the grader computes the actual value.
 

--- a/problems/artifact/iterative_numerical/hparam_search/task.yaml
+++ b/problems/artifact/iterative_numerical/hparam_search/task.yaml
@@ -3,6 +3,7 @@ category: iterative_numerical
 difficulty: hard
 problem_statement: prompt.md
 workspace_dir: workspace/
+workspace_generator: workspace/generator.py
 output_artifact: output/result.json
 structural_verifier: workspace/verify.py
 hidden_grader: grader/hidden.py

--- a/problems/artifact/iterative_numerical/hparam_search/workspace/generator.py
+++ b/problems/artifact/iterative_numerical/hparam_search/workspace/generator.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Workspace generator for iterative_numerical__hparam_search.
+
+Writes a binary ``calibration.bin`` file holding the per-instance Gaussian
+peak locations the ``toy_model`` uses. Peaks are derived deterministically
+from the RNG seed the harness passes in (which is itself derived from
+``sha256(instance_id)`` — see ``docs/SCHEMA_ARTIFACT.md`` §5.1).
+
+The generator script itself is NEVER materialized into the agent's scratch
+dir; only its output (``calibration.bin``) is visible to the agent. This is
+the mechanism that makes the toy model's optimum unreachable from pure
+source-code inspection — see issue #168.
+
+Stdlib-only, per the materializer's scrubbed-env contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import struct
+from pathlib import Path
+
+# Calibration layout — KEEP IN SYNC with ``workspace/toy_model.py`` and
+# ``grader/hidden.py``. Bumping ``_MAGIC`` is a breaking change: regenerate
+# the reference_output if you ever do.
+#
+#   magic    (8 bytes ASCII)        — format/version tag
+#   lr_peak  (double, little-endian)
+#   hs_peak  (double, little-endian) — stored as float, cast to int by callers
+#   do_peak  (double, little-endian)
+#
+# Total payload: 8 + 3*8 = 32 bytes.
+_MAGIC = b"HPARMC01"
+_STRUCT_FORMAT = "<3d"
+
+
+def derive_peaks(seed: int) -> tuple[float, int, float]:
+    """Return ``(lr_peak, hs_peak, do_peak)`` from a Python-RNG seed.
+
+    Distributions are chosen so the optimum lands inside the search range
+    declared by ``prompt.md`` but is *not* near the historical fixed
+    ``(0.01, 128, 0.3)`` optimum that issue #168 retired.
+
+    - ``lr_peak``: log-uniform in [3e-4, 5e-2]
+    - ``hs_peak``: integer multiple of 8 in [32, 384]
+    - ``do_peak``: uniform in [0.10, 0.60]
+    """
+    rng = random.Random(seed)
+    lr_peak = 10 ** rng.uniform(math.log10(3e-4), math.log10(5e-2))
+    hs_peak = 8 * rng.randint(4, 48)
+    do_peak = rng.uniform(0.10, 0.60)
+    return lr_peak, hs_peak, do_peak
+
+
+def write_calibration(output_dir: Path, seed: int) -> None:
+    lr_peak, hs_peak, do_peak = derive_peaks(seed)
+    payload = struct.pack(_STRUCT_FORMAT, lr_peak, float(hs_peak), do_peak)
+    out = output_dir / "calibration.bin"
+    out.write_bytes(_MAGIC + payload)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seed", type=int, required=True)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--instance-id", type=str, required=False, default="")
+    args = ap.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    write_calibration(args.output_dir, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/problems/artifact/iterative_numerical/hparam_search/workspace/toy_model.py
+++ b/problems/artifact/iterative_numerical/hparam_search/workspace/toy_model.py
@@ -1,12 +1,48 @@
 """Toy model for hparam_search benchmark.
 
-evaluate(learning_rate, hidden_size, dropout) -> accuracy
+``evaluate(learning_rate, hidden_size, dropout) -> accuracy``
 
-Deterministic function simulating a model training result.
-This is the SAME function the grader uses to verify your answer.
+The function's *shape* (three independent Gaussian factors) is fixed, but
+its peak locations are loaded at import time from the per-instance
+``calibration.bin`` data file shipped alongside this module. That file is
+written by the task harness from a seed derived from the task's
+``instance_id`` (see ``docs/SCHEMA_ARTIFACT.md`` §5.1) — so reading this
+source file does NOT reveal the optimum. To find it, call ``evaluate``
+and search.
+
+The grader uses the same Gaussian formula, derives the same peaks
+independently from the task's ``instance_id``, and re-evaluates the
+reported hyperparameters. Hallucinated accuracy values are caught.
 """
 
+from __future__ import annotations
+
 import math
+import struct
+from pathlib import Path
+
+_CALIBRATION_PATH = Path(__file__).parent / "calibration.bin"
+_MAGIC = b"HPARMC01"
+_STRUCT_FORMAT = "<3d"
+_PAYLOAD_LEN = len(_MAGIC) + struct.calcsize(_STRUCT_FORMAT)
+
+
+def _load_peaks() -> tuple[float, int, float]:
+    if not _CALIBRATION_PATH.is_file():
+        raise RuntimeError(
+            f"missing {_CALIBRATION_PATH.name} — the workspace was not "
+            "materialized by the task harness"
+        )
+    data = _CALIBRATION_PATH.read_bytes()
+    if len(data) != _PAYLOAD_LEN or data[: len(_MAGIC)] != _MAGIC:
+        raise RuntimeError(
+            f"corrupt or unknown-format calibration file: {_CALIBRATION_PATH.name}"
+        )
+    lr_peak, hs_peak, do_peak = struct.unpack(_STRUCT_FORMAT, data[len(_MAGIC):])
+    return lr_peak, int(round(hs_peak)), do_peak
+
+
+_LR_PEAK, _HS_PEAK, _DO_PEAK = _load_peaks()
 
 
 def evaluate(learning_rate: float, hidden_size: int, dropout: float) -> float:
@@ -15,7 +51,7 @@ def evaluate(learning_rate: float, hidden_size: int, dropout: float) -> float:
     Parameters
     ----------
     learning_rate : float
-        Learning rate. Try values around 0.001 – 0.1.
+        Learning rate. Try values around 1e-4 – 0.1 (log scale recommended).
     hidden_size : int
         Number of hidden units. Try powers of 2: 16, 32, 64, 128, 256, 512.
     dropout : float
@@ -24,9 +60,10 @@ def evaluate(learning_rate: float, hidden_size: int, dropout: float) -> float:
     Returns
     -------
     float
-        Accuracy in [0.0, 0.95].
+        Accuracy in [0.0, 0.95]. Maximised when ``(learning_rate, hidden_size,
+        dropout)`` matches the per-instance hidden peak — search to find it.
     """
-    lr_score = math.exp(-3.0 * (math.log10(learning_rate / 0.01)) ** 2)
-    hs_score = math.exp(-((hidden_size - 128) / 128.0) ** 2)
-    do_score = math.exp(-((dropout - 0.3) / 0.2) ** 2)
+    lr_score = math.exp(-3.0 * (math.log10(learning_rate / _LR_PEAK)) ** 2)
+    hs_score = math.exp(-((hidden_size - _HS_PEAK) / 128.0) ** 2)
+    do_score = math.exp(-((dropout - _DO_PEAK) / 0.2) ** 2)
     return round(0.95 * lr_score * hs_score * do_score, 6)

--- a/tests/test_hparam_search.py
+++ b/tests/test_hparam_search.py
@@ -1,0 +1,190 @@
+"""Regression tests for ``problems/artifact/iterative_numerical/hparam_search``.
+
+Background — issue #168 retired the original ``toy_model.py`` whose
+peak constants ``(0.01, 128, 0.3)`` were visible in source. The replacement
+derives Gaussian peaks per-instance from ``sha256(instance_id)`` and ships
+them as a binary calibration file produced by ``workspace/generator.py``.
+
+These tests pin three invariants:
+
+1. The historical "read it from source" answer ``(0.01, 128, 0.3)`` no
+   longer scores anywhere near the ``0.90`` accuracy target — agents that
+   inspect the source instead of searching will fail the grader.
+2. The generator and the grader derive the *same* peaks for the task's
+   pinned ``instance_id`` (they must stay in lockstep — schema §3.1).
+3. The harness-derived seed (``sha256(instance_id)[:8]`` as int) plumbed
+   through ``workspace/generator.py`` produces a ``calibration.bin`` that,
+   when loaded by ``workspace/toy_model.py``, agrees with the grader's
+   in-source derivation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import math
+import struct
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+_TASK_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "problems"
+    / "artifact"
+    / "iterative_numerical"
+    / "hparam_search"
+)
+_INSTANCE_ID = "iterative_numerical__hparam_search"
+
+
+def _load_module(name: str, path: Path):
+    """Load a module from an explicit path without polluting sys.modules permanently."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+def _seed_for_instance(instance_id: str) -> int:
+    """Mirror of ``swebench.artifact_materialize._seed_for_instance``."""
+    digest = hashlib.sha256(instance_id.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16)
+
+
+@pytest.fixture(scope="module")
+def grader_module():
+    return _load_module(
+        "hparam_search_hidden",
+        _TASK_DIR / "grader" / "hidden.py",
+    )
+
+
+@pytest.fixture(scope="module")
+def generator_module():
+    return _load_module(
+        "hparam_search_generator",
+        _TASK_DIR / "workspace" / "generator.py",
+    )
+
+
+def test_old_inspect_answer_no_longer_wins(grader_module) -> None:
+    """The historical literal answer ``(0.01, 128, 0.3)`` MUST fail the grader.
+
+    Pre-issue #168, the Gaussian peaks lived as constants in
+    ``toy_model.py``; an agent could read them and report ``(0.01, 128, 0.3)``
+    without searching. After the fix the peaks are per-instance, so the old
+    inspection answer should not even come close to the accuracy target.
+    """
+    acc = grader_module._evaluate(0.01, 128, 0.3)
+    assert acc < grader_module.ACCURACY_TARGET, (
+        f"old (0.01, 128, 0.3) still scores {acc} ≥ target "
+        f"{grader_module.ACCURACY_TARGET} — search is not being exercised"
+    )
+    # Stronger: it should not even be in the same league as the target.
+    assert acc < 0.5 * grader_module.ACCURACY_TARGET, (
+        f"old (0.01, 128, 0.3) scores {acc}, suspiciously close to target — "
+        "did the per-instance peaks land near the historical optimum?"
+    )
+
+
+def test_global_optimum_not_near_historical(grader_module) -> None:
+    """At least one derived peak must be meaningfully off ``(0.01, 128, 0.3)``."""
+    lr_peak = grader_module._LR_PEAK
+    hs_peak = grader_module._HS_PEAK
+    do_peak = grader_module._DO_PEAK
+
+    lr_off = abs(math.log10(lr_peak / 0.01))   # log-space distance
+    hs_off = abs(hs_peak - 128)
+    do_off = abs(do_peak - 0.3)
+
+    # At least one axis must be clearly off the historical peak. Thresholds are
+    # generous (1 decade in LR, 32 units in HS, 0.1 in dropout) so a benign
+    # future change to the derivation cannot silently re-converge.
+    assert (lr_off >= 0.3) or (hs_off >= 32) or (do_off >= 0.1), (
+        f"derived peaks {lr_peak, hs_peak, do_peak} are dangerously close to "
+        "the historical (0.01, 128, 0.3) — agents could still inspect-solve"
+    )
+
+
+def test_grader_optimum_scores_above_target(grader_module) -> None:
+    """The grader's own derived peaks must achieve the accuracy target.
+
+    This is a smoke check: if the peak derivation drifts so far that no point
+    in the declared search space hits 0.90, the task becomes unsolvable.
+    """
+    acc = grader_module._evaluate(
+        grader_module._LR_PEAK,
+        grader_module._HS_PEAK,
+        grader_module._DO_PEAK,
+    )
+    assert acc >= grader_module.ACCURACY_TARGET
+    # The unrounded max is 0.95 by construction; allow small rounding slop.
+    assert acc >= 0.94
+
+
+def test_generator_and_grader_derive_same_peaks(grader_module, generator_module) -> None:
+    """Generator (writes calibration.bin) and grader (re-derives in source) must agree."""
+    seed = _seed_for_instance(_INSTANCE_ID)
+    gen_lr, gen_hs, gen_do = generator_module.derive_peaks(seed)
+    assert gen_lr == pytest.approx(grader_module._LR_PEAK, rel=0, abs=0)
+    assert gen_hs == grader_module._HS_PEAK
+    assert gen_do == pytest.approx(grader_module._DO_PEAK, rel=0, abs=0)
+
+
+def test_calibration_roundtrip_via_generator(generator_module) -> None:
+    """End-to-end: run the generator and reload the same peaks through toy_model.
+
+    Reproduces what the harness does:
+
+    1. ``swebench.artifact_materialize`` derives seed from instance_id.
+    2. Generator is invoked as a subprocess, writes ``calibration.bin``.
+    3. Agent imports ``toy_model``, which reads the binary file.
+
+    We verify that the round-trip preserves the peak values exactly.
+    """
+    seed = _seed_for_instance(_INSTANCE_ID)
+    with tempfile.TemporaryDirectory() as tmp:
+        scratch = Path(tmp)
+        # Copy toy_model.py next to the calibration file the generator will
+        # write — toy_model reads ``Path(__file__).parent / "calibration.bin"``.
+        toy_model_src = (_TASK_DIR / "workspace" / "toy_model.py").read_text()
+        (scratch / "toy_model.py").write_text(toy_model_src)
+        generator_module.write_calibration(scratch, seed)
+
+        # Sanity-check the calibration file shape.
+        data = (scratch / "calibration.bin").read_bytes()
+        assert data[:8] == b"HPARMC01"
+        assert len(data) == 8 + struct.calcsize("<3d")
+
+        # Load toy_model from the tmp dir so it picks up the local
+        # ``calibration.bin`` rather than the committed one (if any).
+        module = _load_module("hparam_search_toy_model_tmp", scratch / "toy_model.py")
+        lr_peak, hs_peak, do_peak = generator_module.derive_peaks(seed)
+        assert module._LR_PEAK == lr_peak
+        assert module._HS_PEAK == hs_peak
+        assert module._DO_PEAK == do_peak
+
+
+def test_calibration_bin_is_not_committed_to_workspace() -> None:
+    """``calibration.bin`` must be generated at materialize time, not committed.
+
+    Committing it would defeat the no-leak invariant: the binary would be
+    visible in the agent's scratch dir *with* a stable shape regardless of
+    instance_id, and (more importantly) it would be readable directly from
+    the source tree without the per-instance derivation ever running.
+    """
+    calibration_path = _TASK_DIR / "workspace" / "calibration.bin"
+    assert not calibration_path.exists(), (
+        f"{calibration_path} should not be committed — "
+        "the workspace generator produces it at materialize time"
+    )


### PR DESCRIPTION
Closes #168.

## Summary

The `iterative_numerical__hparam_search` toy model used to ship its scoring formula in source — three Gaussian factors with literal peaks at `(lr=0.01, hs=128, dropout=0.3)`. An agent that read `toy_model.py` could report the optimum without ever running a search loop, defeating the whole point of the `iterative_numerical` category.

This PR adopts the **per-instance peaks** approach from the issue: peaks are derived deterministically from `sha256(instance_id)` and shipped to scratch via a binary `calibration.bin` produced by a `workspace_generator`. The Gaussian formula shape stays visible in `toy_model.py`, but the peak locations are no longer literals you can read.

## Changes

- **`workspace/generator.py` (NEW)** — stdlib-only `workspace_generator` script. Derives `(lr_peak, hs_peak, do_peak)` from the harness-supplied seed (`sha256(instance_id)[:8]` per `SCHEMA_ARTIFACT.md` §5.1) and writes them to `calibration.bin` using a magic-prefixed `struct.pack` layout. The generator script is never materialized into the agent's scratch dir.
- **`workspace/toy_model.py`** — same three-Gaussian shape, but peaks are loaded at import time from `calibration.bin` (which sits next to the module after materialization). The closed-form constants `(0.01, 128, 0.3)` are gone from source.
- **`grader/hidden.py`** — keeps a mirror of the formula (per existing convention) and mirrors the **derivation** as well: hard-codes `INSTANCE_ID` and re-derives the same peaks from `sha256(INSTANCE_ID)`. The grader stays independent of the agent's scratch state — it never reads `calibration.bin`.
- **`prompt.md`** — illustrative example replaced with non-answer values; new paragraph explicitly tells the agent the peaks are per-instance calibration and `evaluate()` is the only way to discover them.
- **`task.yaml`** — declares `workspace_generator: workspace/generator.py`.
- **`grader/reference_output.json`** — regenerated for this instance's derived peaks: `lr≈0.001241, hs=232, do≈0.239624, accuracy=0.95`.
- **`tests/test_hparam_search.py` (NEW)** — regression suite pinning the new invariants:
  - `test_old_inspect_answer_no_longer_wins` — `(0.01, 128, 0.3)` scores `0.038` (`< 0.5 × target`).
  - `test_global_optimum_not_near_historical` — at least one derived peak is meaningfully off the historical position.
  - `test_grader_optimum_scores_above_target` — grader's own optimum still ≥ 0.90.
  - `test_generator_and_grader_derive_same_peaks` — they must stay in lockstep.
  - `test_calibration_roundtrip_via_generator` — generator → `toy_model._load_peaks` round-trips exactly.
  - `test_calibration_bin_is_not_committed_to_workspace` — the binary must be generated at materialize time, never checked in.

## Acceptance criteria from #168

- [x] **Opaque / per-instance peaks** — `(lr_peak, hs_peak, do_peak)` derived from `sha256(instance_id)`, shipped via binary `calibration.bin` produced by `workspace_generator`.
- [x] **`prompt.md` no longer promises inspect-solvability** — explicit "call `evaluate()` and search" wording; illustrative example uses non-answer values.
- [x] **Grader references the same opaque mechanism** — `_derive_peaks` in `hidden.py` mirrors `derive_peaks` in `generator.py` byte-for-byte (same RNG, same distributions).
- [x] **`reference_output.json` still passes** — `grade(reference) → passed=True, score=1.0` confirmed locally.
- [x] **Test where global optimum is NOT near `(0.01, 128, 0.3)`** — `test_old_inspect_answer_no_longer_wins` + `test_global_optimum_not_near_historical`.

## Test plan

- [x] `pytest tests/test_hparam_search.py` — 6/6 passing locally.
- [x] Manual positive sanity check (mirroring `tools/verify_graders.py`): materialize → place `reference_output` at `output/result.json` → `grade()` returns `passed=True, score=1.0`.
- [x] Manual negative gate (SCHEMA §5.5 defaults): all six default mutations (empty / truncated_half / reversed_lines / renamed_field / off_by_one / wrap_in_list) are rejected by the new grader.
- [x] Answer-leak lint: `python tools/check_grader_leaks.py --root .` reports `OK: scanned 1 grader file(s); no leaks found`.
- [ ] CI: `make check-graders`, `make check-graders-negative`, full pytest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)