### PR TITLE
feat(run): default arms to 'all', add mini-benchmark docs and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ python -m swebench add <instance_id> --set swe/swebench-verified-mini
 python -m swebench add --from-file ids.txt --set swe/swebench-verified-mini --concurrency 8
 
 # Run evaluation arms
-python -m swebench run                           # both arms, all problems
+python -m swebench run                           # all three arms, all problems
 python -m swebench run --arms onlycode           # onlycode arm only
 python -m swebench run --arms baseline           # baseline arm only
+python -m swebench run --arms bash_only          # bash_only arm only
+python -m swebench run --arms both               # baseline+onlycode (excludes bash_only)
 python -m swebench run --filter django__django-16379
 python -m swebench run --runs 3                  # multiple runs per arm
 python -m swebench run --no-cache                # skip OverlayFS cache

--- a/docs/BATCHED_RUN_SWE.md
+++ b/docs/BATCHED_RUN_SWE.md
@@ -1,6 +1,6 @@
 # Batched SWE-bench Mini Run
 
-100 problems split across two sets and 9 batches. All batches write to the same output dir so `analyze` sees a single cohesive run.
+100 problems split across two sets and 9 batches. Each seed is an independent full run in its own output dir. Three seeds are planned for variance estimation.
 
 ## Sets
 
@@ -9,12 +9,21 @@
 | swebench-verified-mini | 50 | Django (25), Sphinx (25) | V1–V4 |
 | swebench-datasci-mini | 50 | scikit-learn (15), matplotlib (12), xarray (8), sympy (7), seaborn (5), astropy (3) | D1–D5 |
 
+## Seeds
+
+| Seed | Output dir | Status |
+|---|---|---|
+| seed_1 | `runs/swebench/full_run_seed_1/` | V1–V4 complete (50/100) |
+| seed_2 | `runs/swebench/full_run_seed_2/` | not started |
+| seed_3 | `runs/swebench/full_run_seed_3/` | not started |
+
 ## How it works
 
-- `--output-dir` is fixed across all batches — results accumulate under `runs/swebench/full_run_v1/`
-- `--resume` (default on) skips any `(instance, arm, run)` triple that already has a result, so re-running a batch is safe
-- Same-repo batches share the OverlayFS cache, so sequential same-repo batches are faster than cross-repo ones
-- Arms: `baseline` (full tool suite) and `onlycode` (execute_code MCP only)
+- Each seed gets its own `--output-dir` — independent runs, no cross-contamination.
+- `--resume` (default on) skips any `(instance, arm, run)` triple that already has a result within a seed dir, so re-running a batch is safe.
+- Same-repo batches share the OverlayFS cache, so sequential same-repo batches are faster than cross-repo ones.
+- Arms: `baseline` (full tool suite), `onlycode` (execute_code MCP only), `bash_only` (Bash-only built-ins)
+- **Always run with `--parallel 2`** — each instance runs 3 arms sequentially, but 2 instances can run concurrently without contention.
 
 ## Commands
 
@@ -25,13 +34,14 @@ source .venv/bin/activate
 
 ---
 
-## verified-mini batches
+## Seed 1 — `runs/swebench/full_run_seed_1/`
 
 ### Batch V1 — Django part 1 (13 problems)
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "django__django-11790,django__django-11815,django__django-11848,django__django-11880,django__django-11885,django__django-11951,django__django-11964,django__django-11999,django__django-12039,django__django-12050,django__django-12143,django__django-12155,django__django-12193"
 ```
 
@@ -39,7 +49,8 @@ python -m swebench run \
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "django__django-12209,django__django-12262,django__django-12273,django__django-12276,django__django-12304,django__django-12308,django__django-12325,django__django-12406,django__django-12708,django__django-12713,django__django-12774,django__django-9296"
 ```
 
@@ -47,7 +58,8 @@ python -m swebench run \
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "sphinx-doc__sphinx-10323,sphinx-doc__sphinx-10435,sphinx-doc__sphinx-10466,sphinx-doc__sphinx-10673,sphinx-doc__sphinx-11510,sphinx-doc__sphinx-7590,sphinx-doc__sphinx-7748,sphinx-doc__sphinx-7757,sphinx-doc__sphinx-7985,sphinx-doc__sphinx-8035,sphinx-doc__sphinx-8056,sphinx-doc__sphinx-8265,sphinx-doc__sphinx-8269"
 ```
 
@@ -55,19 +67,17 @@ python -m swebench run \
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "sphinx-doc__sphinx-8475,sphinx-doc__sphinx-8548,sphinx-doc__sphinx-8551,sphinx-doc__sphinx-8638,sphinx-doc__sphinx-8721,sphinx-doc__sphinx-9229,sphinx-doc__sphinx-9230,sphinx-doc__sphinx-9281,sphinx-doc__sphinx-9320,sphinx-doc__sphinx-9367,sphinx-doc__sphinx-9461,sphinx-doc__sphinx-9698"
 ```
-
----
-
-## datasci-mini batches
 
 ### Batch D1 — scikit-learn part 1 (8 problems)
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "scikit-learn__scikit-learn-10427,scikit-learn__scikit-learn-10803,scikit-learn__scikit-learn-11206,scikit-learn__scikit-learn-11596,scikit-learn__scikit-learn-12704,scikit-learn__scikit-learn-13013,scikit-learn__scikit-learn-13283,scikit-learn__scikit-learn-13496"
 ```
 
@@ -75,7 +85,8 @@ python -m swebench run \
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "scikit-learn__scikit-learn-13864,scikit-learn__scikit-learn-14125,scikit-learn__scikit-learn-14710,scikit-learn__scikit-learn-15094,scikit-learn__scikit-learn-24677,scikit-learn__scikit-learn-25694,scikit-learn__scikit-learn-3840"
 ```
 
@@ -83,7 +94,8 @@ python -m swebench run \
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "matplotlib__matplotlib-13859,matplotlib__matplotlib-19763,matplotlib__matplotlib-21042,matplotlib__matplotlib-22767,matplotlib__matplotlib-23088,matplotlib__matplotlib-23476,matplotlib__matplotlib-24177,matplotlib__matplotlib-24637,matplotlib__matplotlib-25126,matplotlib__matplotlib-25442,matplotlib__matplotlib-25772,matplotlib__matplotlib-26160"
 ```
 
@@ -91,7 +103,8 @@ python -m swebench run \
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "pydata__xarray-2905,pydata__xarray-3520,pydata__xarray-4075,pydata__xarray-4629,pydata__xarray-4911,pydata__xarray-5455,pydata__xarray-6601,pydata__xarray-7003,astropy__astropy-12962,astropy__astropy-13842,astropy__astropy-6938"
 ```
 
@@ -99,26 +112,215 @@ python -m swebench run \
 
 ```bash
 python -m swebench run \
-  --output-dir runs/swebench/full_run_v1 \
+  --output-dir runs/swebench/full_run_seed_1 \
+  --parallel 2 \
   --filter "sympy__sympy-11232,sympy__sympy-13259,sympy__sympy-14180,sympy__sympy-15976,sympy__sympy-17318,sympy__sympy-19016,sympy__sympy-21596,mwaskom__seaborn-2389,mwaskom__seaborn-2813,mwaskom__seaborn-2946,mwaskom__seaborn-3069,mwaskom__seaborn-3202"
+```
+
+### Seed 1 analysis
+
+```bash
+python -m swebench analyze summary \
+  --results-dir runs/swebench/full_run_seed_1 \
+  --out runs/swebench/full_run_seed_1/summary.csv
 ```
 
 ---
 
-## Intermediate analysis
+## Seed 2 — `runs/swebench/full_run_seed_2/`
 
-Run at any point — problems with no results yet won't appear:
-
-```bash
-python -m swebench analyze --results-dir runs/swebench/full_run_v1
-```
-
-## Final analysis
-
-Same command once all 9 batches are done:
+### Batch V1 — Django part 1 (13 problems)
 
 ```bash
-python -m swebench analyze \
-  --results-dir runs/swebench/full_run_v1 \
-  --out runs/swebench/full_run_v1/summary.csv
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "django__django-11790,django__django-11815,django__django-11848,django__django-11880,django__django-11885,django__django-11951,django__django-11964,django__django-11999,django__django-12039,django__django-12050,django__django-12143,django__django-12155,django__django-12193"
 ```
+
+### Batch V2 — Django part 2 (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "django__django-12209,django__django-12262,django__django-12273,django__django-12276,django__django-12304,django__django-12308,django__django-12325,django__django-12406,django__django-12708,django__django-12713,django__django-12774,django__django-9296"
+```
+
+### Batch V3 — Sphinx part 1 (13 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "sphinx-doc__sphinx-10323,sphinx-doc__sphinx-10435,sphinx-doc__sphinx-10466,sphinx-doc__sphinx-10673,sphinx-doc__sphinx-11510,sphinx-doc__sphinx-7590,sphinx-doc__sphinx-7748,sphinx-doc__sphinx-7757,sphinx-doc__sphinx-7985,sphinx-doc__sphinx-8035,sphinx-doc__sphinx-8056,sphinx-doc__sphinx-8265,sphinx-doc__sphinx-8269"
+```
+
+### Batch V4 — Sphinx part 2 (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "sphinx-doc__sphinx-8475,sphinx-doc__sphinx-8548,sphinx-doc__sphinx-8551,sphinx-doc__sphinx-8638,sphinx-doc__sphinx-8721,sphinx-doc__sphinx-9229,sphinx-doc__sphinx-9230,sphinx-doc__sphinx-9281,sphinx-doc__sphinx-9320,sphinx-doc__sphinx-9367,sphinx-doc__sphinx-9461,sphinx-doc__sphinx-9698"
+```
+
+### Batch D1 — scikit-learn part 1 (8 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "scikit-learn__scikit-learn-10427,scikit-learn__scikit-learn-10803,scikit-learn__scikit-learn-11206,scikit-learn__scikit-learn-11596,scikit-learn__scikit-learn-12704,scikit-learn__scikit-learn-13013,scikit-learn__scikit-learn-13283,scikit-learn__scikit-learn-13496"
+```
+
+### Batch D2 — scikit-learn part 2 (7 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "scikit-learn__scikit-learn-13864,scikit-learn__scikit-learn-14125,scikit-learn__scikit-learn-14710,scikit-learn__scikit-learn-15094,scikit-learn__scikit-learn-24677,scikit-learn__scikit-learn-25694,scikit-learn__scikit-learn-3840"
+```
+
+### Batch D3 — matplotlib (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "matplotlib__matplotlib-13859,matplotlib__matplotlib-19763,matplotlib__matplotlib-21042,matplotlib__matplotlib-22767,matplotlib__matplotlib-23088,matplotlib__matplotlib-23476,matplotlib__matplotlib-24177,matplotlib__matplotlib-24637,matplotlib__matplotlib-25126,matplotlib__matplotlib-25442,matplotlib__matplotlib-25772,matplotlib__matplotlib-26160"
+```
+
+### Batch D4 — xarray + astropy (11 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "pydata__xarray-2905,pydata__xarray-3520,pydata__xarray-4075,pydata__xarray-4629,pydata__xarray-4911,pydata__xarray-5455,pydata__xarray-6601,pydata__xarray-7003,astropy__astropy-12962,astropy__astropy-13842,astropy__astropy-6938"
+```
+
+### Batch D5 — sympy + seaborn (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_2 \
+  --parallel 2 \
+  --filter "sympy__sympy-11232,sympy__sympy-13259,sympy__sympy-14180,sympy__sympy-15976,sympy__sympy-17318,sympy__sympy-19016,sympy__sympy-21596,mwaskom__seaborn-2389,mwaskom__seaborn-2813,mwaskom__seaborn-2946,mwaskom__seaborn-3069,mwaskom__seaborn-3202"
+```
+
+### Seed 2 analysis
+
+```bash
+python -m swebench analyze summary \
+  --results-dir runs/swebench/full_run_seed_2 \
+  --out runs/swebench/full_run_seed_2/summary.csv
+```
+
+---
+
+## Seed 3 — `runs/swebench/full_run_seed_3/`
+
+### Batch V1 — Django part 1 (13 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "django__django-11790,django__django-11815,django__django-11848,django__django-11880,django__django-11885,django__django-11951,django__django-11964,django__django-11999,django__django-12039,django__django-12050,django__django-12143,django__django-12155,django__django-12193"
+```
+
+### Batch V2 — Django part 2 (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "django__django-12209,django__django-12262,django__django-12273,django__django-12276,django__django-12304,django__django-12308,django__django-12325,django__django-12406,django__django-12708,django__django-12713,django__django-12774,django__django-9296"
+```
+
+### Batch V3 — Sphinx part 1 (13 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "sphinx-doc__sphinx-10323,sphinx-doc__sphinx-10435,sphinx-doc__sphinx-10466,sphinx-doc__sphinx-10673,sphinx-doc__sphinx-11510,sphinx-doc__sphinx-7590,sphinx-doc__sphinx-7748,sphinx-doc__sphinx-7757,sphinx-doc__sphinx-7985,sphinx-doc__sphinx-8035,sphinx-doc__sphinx-8056,sphinx-doc__sphinx-8265,sphinx-doc__sphinx-8269"
+```
+
+### Batch V4 — Sphinx part 2 (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "sphinx-doc__sphinx-8475,sphinx-doc__sphinx-8548,sphinx-doc__sphinx-8551,sphinx-doc__sphinx-8638,sphinx-doc__sphinx-8721,sphinx-doc__sphinx-9229,sphinx-doc__sphinx-9230,sphinx-doc__sphinx-9281,sphinx-doc__sphinx-9320,sphinx-doc__sphinx-9367,sphinx-doc__sphinx-9461,sphinx-doc__sphinx-9698"
+```
+
+### Batch D1 — scikit-learn part 1 (8 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "scikit-learn__scikit-learn-10427,scikit-learn__scikit-learn-10803,scikit-learn__scikit-learn-11206,scikit-learn__scikit-learn-11596,scikit-learn__scikit-learn-12704,scikit-learn__scikit-learn-13013,scikit-learn__scikit-learn-13283,scikit-learn__scikit-learn-13496"
+```
+
+### Batch D2 — scikit-learn part 2 (7 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "scikit-learn__scikit-learn-13864,scikit-learn__scikit-learn-14125,scikit-learn__scikit-learn-14710,scikit-learn__scikit-learn-15094,scikit-learn__scikit-learn-24677,scikit-learn__scikit-learn-25694,scikit-learn__scikit-learn-3840"
+```
+
+### Batch D3 — matplotlib (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "matplotlib__matplotlib-13859,matplotlib__matplotlib-19763,matplotlib__matplotlib-21042,matplotlib__matplotlib-22767,matplotlib__matplotlib-23088,matplotlib__matplotlib-23476,matplotlib__matplotlib-24177,matplotlib__matplotlib-24637,matplotlib__matplotlib-25126,matplotlib__matplotlib-25442,matplotlib__matplotlib-25772,matplotlib__matplotlib-26160"
+```
+
+### Batch D4 — xarray + astropy (11 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "pydata__xarray-2905,pydata__xarray-3520,pydata__xarray-4075,pydata__xarray-4629,pydata__xarray-4911,pydata__xarray-5455,pydata__xarray-6601,pydata__xarray-7003,astropy__astropy-12962,astropy__astropy-13842,astropy__astropy-6938"
+```
+
+### Batch D5 — sympy + seaborn (12 problems)
+
+```bash
+python -m swebench run \
+  --output-dir runs/swebench/full_run_seed_3 \
+  --parallel 2 \
+  --filter "sympy__sympy-11232,sympy__sympy-13259,sympy__sympy-14180,sympy__sympy-15976,sympy__sympy-17318,sympy__sympy-19016,sympy__sympy-21596,mwaskom__seaborn-2389,mwaskom__seaborn-2813,mwaskom__seaborn-2946,mwaskom__seaborn-3069,mwaskom__seaborn-3202"
+```
+
+### Seed 3 analysis
+
+```bash
+python -m swebench analyze summary \
+  --results-dir runs/swebench/full_run_seed_3 \
+  --out runs/swebench/full_run_seed_3/summary.csv
+```
+
+---
+
+## Cross-seed analysis
+
+Once all three seeds are complete, compare per-instance pass rates across seeds to estimate variance:
+
+```bash
+python -m swebench analyze summary --results-dir runs/swebench/full_run_seed_1 --out runs/swebench/full_run_seed_1/summary.csv
+python -m swebench analyze summary --results-dir runs/swebench/full_run_seed_2 --out runs/swebench/full_run_seed_2/summary.csv
+python -m swebench analyze summary --results-dir runs/swebench/full_run_seed_3 --out runs/swebench/full_run_seed_3/summary.csv
+```
+
+Then aggregate the three CSVs to get mean pass rate ± stderr per arm.

--- a/docs/RESULTS_SWE_MINI.md
+++ b/docs/RESULTS_SWE_MINI.md
@@ -1,0 +1,60 @@
+# SWE-bench Mini — Batched Run Results (verified-mini, partial)
+
+Status as of 2026-05-10. Companion to [BATCHED_RUN_SWE.md](BATCHED_RUN_SWE.md).
+
+## Scope
+
+- **Run dir:** `runs/swebench/full_run_seed_1/`
+- **Completed:** 50/100 instances — the full `swebench-verified-mini` set (Django 25, Sphinx 25, batches V1–V4).
+- **Not yet run:** `swebench-datasci-mini` (50 instances, batches D1–D5: scikit-learn, matplotlib, xarray, sympy, seaborn, astropy).
+- **Arms:** `baseline` (full tool suite), `onlycode` (execute_code MCP only), `bash_only` (Bash-only built-ins). 1 run per (instance, arm).
+
+## Headline numbers
+
+| Arm | PASS | Rate | Total cost | Total turns |
+|---|---|---|---|---|
+| baseline  | 32/50 | 64.0% | $26.46 | 1,098 |
+| onlycode  | 34/50 | **68.0%** | $28.17 | 1,688 |
+| bash_only | 32/50 | 64.0% | $44.51 | 1,731 |
+
+- onlycode is +2 instances over baseline (+4pp) — within noise at n=50, but never worse on aggregate.
+- bash_only matches baseline pass rate but spends ~1.7× the dollars and ~58% more turns.
+- Per-turn cost: baseline ≈ $0.024, onlycode ≈ $0.017, bash_only ≈ $0.026. onlycode's turns are the cheapest, consistent with short REPL ops vs. shell spinups.
+
+## By repo
+
+| Repo | baseline | onlycode | bash_only |
+|---|---|---|---|
+| django (25)     | 22 (88%) | 23 (92%) | 23 (92%) |
+| sphinx-doc (25) | 10 (40%) | 11 (44%) |  9 (36%) |
+
+Django is largely saturated across arms. Sphinx is where the hard tail lives and where arm differences would show up — but the n=25 sub-sample is too small to call.
+
+## Agreement across arms (n=50)
+
+| baseline | onlycode | bash_only | count |
+|---|---|---|---|
+| PASS | PASS | PASS | 30 |
+| FAIL | FAIL | FAIL | 14 |
+| FAIL | **PASS** | FAIL |  3 |
+| FAIL | **PASS** | **PASS** |  1 |
+| **PASS** | FAIL | FAIL |  1 |
+| **PASS** | FAIL | **PASS** |  1 |
+
+- 44/50 instances are unanimous (30 pass, 14 fail) — most of the suite doesn't discriminate between arms.
+- onlycode-unique wins: 3 (instances where only onlycode passed).
+- onlycode-unique losses: 1.
+- The signal lives in 6 instances. With this much noise, the +2 onlycode lead is suggestive, not conclusive.
+
+## Caveats
+
+- **Half the suite is missing.** Datasci-mini (sklearn, matplotlib, xarray, sympy, seaborn, astropy) has not been run. Numerical/scientific code may stress arms differently than web-framework code.
+- **Single run per arm.** No variance estimate. The 6 split instances dominate the headline delta — re-running them would tell us if those splits are stable.
+- **Sphinx sub-sample is small.** That's where arm differences are most likely to materialize, and we have only 25 instances.
+
+## Next steps
+
+1. Run D1–D5 to fill out the datasci half.
+2. Once complete, regenerate the summary CSV: `python -m swebench analyze summary --results-dir runs/swebench/full_run_seed_1 --out runs/swebench/full_run_seed_1/summary.csv`.
+   - **Known gap:** `analyze summary` currently only emits `baseline`/`onlycode` rows; `bash_only` is omitted from the CSV. Aggregate bash_only stats in this doc were computed by parsing `*_bash_only_run1_test.txt` and the matching JSONL `result` events directly. Worth fixing in the analyzer before the final write-up.
+3. Consider re-running the 6 split instances to estimate variance before reporting a verdict.

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -538,8 +538,8 @@ def _cleanup_stale_overlays(
 @click.option(
     "--arms",
     type=click.Choice(["baseline", "onlycode", "bash_only", "both", "all"]),
-    default="both",
-    help="Which arms to run (default: both). 'both'=baseline+onlycode; 'all'=baseline+onlycode+bash_only.",
+    default="all",
+    help="Which arms to run (default: all = baseline+onlycode+bash_only). 'both'=baseline+onlycode (excludes bash_only).",
 )
 @click.option(
     "--persistent-kernel/--no-persistent-kernel",


### PR DESCRIPTION
## Summary
- Change `--arms` default from `both` to `all` (now includes `bash_only` arm by default)
- Update README to reflect new default and add `bash_only` / `both` usage examples
- Expand `docs/BATCHED_RUN_SWE.md` with full batched-run documentation
- Add `docs/RESULTS_SWE_MINI.md` with mini benchmark results

## Test plan
- [ ] `python -m swebench run --help` shows `default: all`
- [ ] `python -m swebench run --arms both` still excludes bash_only
- [ ] Docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)