### PR TITLE
fix(harness): pin jinja2<3.0 for old Sphinx instances

### DIFF
--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -276,6 +276,33 @@ def clone_from_bare(bare_src: str, dest: str) -> None:
     )
 
 
+def _needs_jinja2_pin(repo_dir: str) -> bool:
+    """Return True if the repo uses jinja2.environmentfilter, removed in Jinja2 3.0.
+
+    Old Sphinx versions (< 4.0) import `environmentfilter` from jinja2, which was
+    removed in Jinja2 3.0. Detected by grepping the installed source so the check
+    is version-agnostic and doesn't require hard-coding instance IDs.
+    """
+    candidate = os.path.join(repo_dir, "sphinx", "util", "rst.py")
+    if not os.path.isfile(candidate):
+        return False
+    try:
+        with open(candidate) as f:
+            return "environmentfilter" in f.read()
+    except OSError:
+        return False
+
+
+def _pin_jinja2(pip: str) -> None:
+    """Downgrade Jinja2 to a 2.x release compatible with Python 3.11."""
+    subprocess.run(
+        [pip, "install", "--quiet", "jinja2<3.0,>=2.11"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
 def setup_venv(venv_dir: str, repo_dir: str) -> None:
     """Create a venv and pip install the project in editable mode (if not already done)."""
     pip = os.path.join(venv_dir, "bin", "pip")
@@ -319,6 +346,8 @@ def setup_venv(venv_dir: str, repo_dir: str) -> None:
                 raise subprocess.CalledProcessError(
                     result.returncode, result.args, result.stdout, result.stderr
                 )
+            if _needs_jinja2_pin(repo_dir):
+                _pin_jinja2(pip)
             return
     subprocess.run(
         ["python3.11", "-m", "venv", venv_dir],
@@ -353,6 +382,8 @@ def setup_venv(venv_dir: str, repo_dir: str) -> None:
         text=True,
         check=True,
     )
+    if _needs_jinja2_pin(repo_dir):
+        _pin_jinja2(pip)
 
 
 def apply_test_patch(repo_dir: str, patch_path: str) -> bool:

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -294,13 +294,21 @@ def _needs_jinja2_pin(repo_dir: str) -> bool:
 
 
 def _pin_jinja2(pip: str) -> None:
-    """Downgrade Jinja2 to a 2.x release compatible with Python 3.11."""
-    subprocess.run(
+    """Pin Jinja2 to >=2.11,<3.0 — the last series compatible with Python 3.11
+    that still exports environmentfilter."""
+    result = subprocess.run(
         [pip, "install", "--quiet", "jinja2<3.0,>=2.11"],
         capture_output=True,
         text=True,
-        check=True,
     )
+    if result.returncode != 0:
+        print(
+            f"[harness] jinja2 pin failed (rc={result.returncode}):\n{result.stderr}",
+            flush=True,
+        )
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, result.stdout, result.stderr
+        )
 
 
 def setup_venv(venv_dir: str, repo_dir: str) -> None:

--- a/tests/test_harness_jinja2_pin.py
+++ b/tests/test_harness_jinja2_pin.py
@@ -1,0 +1,71 @@
+"""Tests for _needs_jinja2_pin and _pin_jinja2."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from swebench.harness import _needs_jinja2_pin, _pin_jinja2
+
+
+# ---------------------------------------------------------------------------
+# _needs_jinja2_pin
+# ---------------------------------------------------------------------------
+
+
+def test_needs_pin_when_environmentfilter_present(tmp_path: Path) -> None:
+    rst = tmp_path / "sphinx" / "util" / "rst.py"
+    rst.parent.mkdir(parents=True)
+    rst.write_text("from jinja2 import environmentfilter\n")
+    assert _needs_jinja2_pin(str(tmp_path)) is True
+
+
+def test_no_pin_when_environmentfilter_absent(tmp_path: Path) -> None:
+    rst = tmp_path / "sphinx" / "util" / "rst.py"
+    rst.parent.mkdir(parents=True)
+    rst.write_text("from jinja2 import pass_environment\n")
+    assert _needs_jinja2_pin(str(tmp_path)) is False
+
+
+def test_no_pin_when_file_missing(tmp_path: Path) -> None:
+    assert _needs_jinja2_pin(str(tmp_path)) is False
+
+
+def test_no_pin_on_oserror(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    rst = tmp_path / "sphinx" / "util" / "rst.py"
+    rst.parent.mkdir(parents=True)
+    rst.write_text("environmentfilter")
+
+    def raise_oserror(*_a, **_kw):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("builtins.open", raise_oserror)
+    assert _needs_jinja2_pin(str(tmp_path)) is False
+
+
+# ---------------------------------------------------------------------------
+# _pin_jinja2
+# ---------------------------------------------------------------------------
+
+
+def test_pin_jinja2_calls_correct_constraint() -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        _pin_jinja2("/venv/bin/pip")
+    args = mock_run.call_args[0][0]
+    assert args == ["/venv/bin/pip", "install", "--quiet", "jinja2<3.0,>=2.11"]
+
+
+def test_pin_jinja2_raises_on_failure() -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            args=["/venv/bin/pip", "install", "--quiet", "jinja2<3.0,>=2.11"],
+            stdout="",
+            stderr="Could not find a version",
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            _pin_jinja2("/venv/bin/pip")


### PR DESCRIPTION
## Summary

- Old Sphinx versions (< 4.0) import `jinja2.environmentfilter`, which was removed in Jinja2 3.0
- Our Python 3.11 venvs pull in Jinja2 3.x, causing the test suite to crash on import before Claude runs — silent all-arm failures, \$0 cost, 1 turn
- Affected 7–8 of 13 Sphinx V3 instances across seed_1 and seed_3, making the Sphinx pass rates completely invalid
- Adds `_needs_jinja2_pin(repo_dir)` — detects the broken import by checking `sphinx/util/rst.py` for `environmentfilter` (version-agnostic, no hardcoded instance IDs)
- Calls `_pin_jinja2(pip)` to install `jinja2<3.0,>=2.11` in both the new-venv and existing-venv paths of `setup_venv`

## Test plan

- [x] All 407 unit tests pass (`pytest -m "not integration"`)
- [ ] Re-run seed_3 V3 (Sphinx) to confirm the previously broken instances now run correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)