### PR TITLE
test(#188): boundary + wiring tests for grader/doc cleanups

### DIFF
--- a/tests/test_component_artifact_loader_structural_verifier.py
+++ b/tests/test_component_artifact_loader_structural_verifier.py
@@ -1,0 +1,184 @@
+"""Component test: artifact_loader._parse_task_yaml → artifact_models.Task structural_verifier field.
+
+Boundary: swebench.artifact_loader.load_tasks() parses the optional
+``structural_verifier`` field from task.yaml and wires it into
+``swebench.artifact_models.Task.structural_verifier``.
+
+This PR (#188) removed ``structural_verifier:`` from three task.yaml files
+and deleted the corresponding ``workspace/verify.py`` files, making the
+absent-field path the common case. These tests pin the loader→Task contract
+for the ``structural_verifier`` optional field so any future loader change
+that breaks this wiring is caught immediately.
+
+Both real modules cooperate across the parser boundary:
+  - ``swebench.artifact_loader`` (parser/validator)
+  - ``swebench.artifact_models.Task`` (dataclass receiver)
+
+No doubles: ``tmp_path`` (filesystem) is the only seam — it is the canonical
+medium through which the two modules exchange data at load time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from swebench.artifact_loader import load_tasks
+from swebench.artifact_models import Task
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_task(
+    tasks_dir: Path,
+    slug: str,
+    overrides: dict | None = None,
+) -> Path:
+    """Build a minimal valid task under tasks_dir/stateful_reasoning/<slug>/.
+
+    Returns the task directory.
+    """
+    category = "stateful_reasoning"
+    task_dir = tasks_dir / category / slug
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "workspace").mkdir(exist_ok=True)
+    (task_dir / "grader").mkdir(exist_ok=True)
+    (task_dir / "prompt.md").write_text("do the thing\n")
+    (task_dir / "grader" / "hidden.py").write_text(
+        "def grade(d):\n"
+        "    class R:\n"
+        "        passed=True\n"
+        "        score=1.0\n"
+        "        detail='ok'\n"
+        "    return R()\n"
+    )
+    (task_dir / "grader" / "reference_output.txt").write_text("ref\n")
+
+    data: dict = {
+        "instance_id": f"{category}__{slug}",
+        "category": category,
+        "difficulty": "medium",
+        "problem_statement": "prompt.md",
+        "workspace_dir": "workspace/",
+        "output_artifact": "output/result.json",
+        "hidden_grader": "grader/hidden.py",
+        "reference_output": "grader/reference_output.txt",
+        "execution_budget": {"max_code_runs": 0, "max_wall_seconds": 0},
+    }
+    if overrides:
+        data.update(overrides)
+    with open(task_dir / "task.yaml", "w") as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+    return task_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.component
+class TestArtifactLoaderStructuralVerifierContract:
+    """Pin the loader → Task.structural_verifier optional-field contract."""
+
+    def test_absent_field_yields_none(self, tmp_path: Path) -> None:
+        """When task.yaml omits structural_verifier the loaded Task must have None.
+
+        This is the post-#188 common case: tasks that had the field removed
+        should parse cleanly and expose ``structural_verifier=None``.
+        """
+        _write_task(tmp_path, "no_verifier")
+
+        tasks = load_tasks(tmp_path)
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert isinstance(task, Task)
+        assert task.structural_verifier is None, (
+            f"Expected structural_verifier=None for task without field; "
+            f"got {task.structural_verifier!r}"
+        )
+
+    def test_present_string_field_is_accepted_and_forwarded(self, tmp_path: Path) -> None:
+        """When structural_verifier is a string path it must be forwarded verbatim into Task.
+
+        The loader must not strip, normalise, or reject a valid string value.
+        """
+        _write_task(
+            tmp_path,
+            "with_verifier",
+            overrides={"structural_verifier": "workspace/verify.py"},
+        )
+
+        tasks = load_tasks(tmp_path)
+
+        assert len(tasks) == 1
+        assert tasks[0].structural_verifier == "workspace/verify.py", (
+            f"Expected structural_verifier='workspace/verify.py'; "
+            f"got {tasks[0].structural_verifier!r}"
+        )
+
+    def test_wrong_type_integer_rejected(self, tmp_path: Path) -> None:
+        """An integer structural_verifier must be rejected by the loader with ValueError.
+
+        Guards the type-validation branch: loader raises ValueError before
+        constructing a Task, so callers can catch schema errors early.
+        """
+        _write_task(
+            tmp_path,
+            "bad_verifier_int",
+            overrides={"structural_verifier": 42},
+        )
+
+        with pytest.raises(ValueError, match="structural_verifier must be a string"):
+            load_tasks(tmp_path)
+
+    def test_structural_verifier_is_independent_of_workspace_generator(
+        self, tmp_path: Path
+    ) -> None:
+        """Both optional fields may coexist; each is forwarded independently.
+
+        Regression guard: the loader processes optional fields in sequence.
+        A bug that confused structural_verifier with workspace_generator would
+        be caught here.
+        """
+        _write_task(
+            tmp_path,
+            "both_optional",
+            overrides={
+                "structural_verifier": "workspace/verify.py",
+                "workspace_generator": "workspace/generator.py",
+            },
+        )
+
+        tasks = load_tasks(tmp_path)
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert task.structural_verifier == "workspace/verify.py", (
+            f"structural_verifier mismatch: {task.structural_verifier!r}"
+        )
+        assert task.workspace_generator == "workspace/generator.py", (
+            f"workspace_generator mismatch: {task.workspace_generator!r}"
+        )
+
+    def test_multiple_tasks_some_with_some_without_verifier(self, tmp_path: Path) -> None:
+        """The loader handles a mixed batch: some tasks with and some without structural_verifier.
+
+        After #188, the real repo has exactly this mixture. Pin the contract
+        that load_tasks returns both correctly without cross-contamination.
+        """
+        _write_task(tmp_path, "task_with_sv", overrides={"structural_verifier": "workspace/verify.py"})
+        _write_task(tmp_path, "task_without_sv")
+
+        tasks = load_tasks(tmp_path)
+        tasks_by_id = {t.instance_id: t for t in tasks}
+
+        assert "stateful_reasoning__task_with_sv" in tasks_by_id
+        assert "stateful_reasoning__task_without_sv" in tasks_by_id
+
+        assert tasks_by_id["stateful_reasoning__task_with_sv"].structural_verifier == "workspace/verify.py"
+        assert tasks_by_id["stateful_reasoning__task_without_sv"].structural_verifier is None

--- a/tests/test_component_invoke_grader_json_pointer.py
+++ b/tests/test_component_invoke_grader_json_pointer.py
@@ -1,0 +1,294 @@
+"""Component test: invoke_grader → json_pointer_rfc6901 grader hidden.py boundary.
+
+Boundary: swebench.artifact_grade.invoke_grader() runs
+problems/artifact/verification_heavy/json_pointer_rfc6901/grader/hidden.py:grade()
+in a subprocess. This PR (#188) cleaned up a duplicate ``""`` key in
+``_base_doc()`` (the second ``"": "empty-key"  # duplicate intentional``
+entry was removed, leaving only the first occurrence).
+
+These tests verify the contract between the harness (invoke_grader) and the
+concrete json_pointer_rfc6901 grader:
+  - A correct RFC-6901 implementation must pass.
+  - The empty-key pointer ``"/"`` (which resolves the ``""`` key) is tested
+    by the grader and must still work after the deduplication.
+  - A broken implementation (wrong escape handling) must fail.
+  - A missing artifact must yield passed=False without raising.
+
+Both real modules cooperate across the subprocess boundary: no grader doubles,
+no harness doubles. The scratch dir (filesystem) is the only seam.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from swebench.artifact_grade import GraderInvocationError, invoke_grader
+from swebench.artifact_models import ExecutionBudget, GradeResult, Task
+
+# Absolute path to the real json_pointer_rfc6901 task directory.
+_JP_TASK_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "problems/artifact/verification_heavy/json_pointer_rfc6901"
+)
+
+# A correct RFC-6901 implementation mirroring the reference_output.py.
+_CORRECT_SOLUTION = textwrap.dedent("""\
+    def _unescape(token: str) -> str:
+        return token.replace("~1", "/").replace("~0", "~")
+
+    def _split(pointer: str) -> list:
+        if pointer == "":
+            return []
+        if not pointer.startswith("/"):
+            raise ValueError(f"invalid JSON pointer: {pointer!r}")
+        return [_unescape(tok) for tok in pointer[1:].split("/")]
+
+    def _as_array_index(token: str, length: int, *, allow_dash: bool) -> int:
+        if token == "-":
+            if not allow_dash:
+                raise KeyError(f"'-' index not valid here")
+            return length
+        if token == "":
+            raise KeyError("empty array index")
+        if token != "0" and (not token.isdigit() or token[0] == "0"):
+            raise KeyError(f"invalid array index {token!r}")
+        if not token.isdigit():
+            raise KeyError(f"invalid array index {token!r}")
+        idx = int(token)
+        return idx
+
+    def resolve(doc, pointer: str):
+        tokens = _split(pointer)
+        if not tokens:
+            return doc
+        node = doc
+        for i, token in enumerate(tokens):
+            if isinstance(node, dict):
+                if token not in node:
+                    raise KeyError(f"key {token!r} not found")
+                node = node[token]
+            elif isinstance(node, list):
+                idx = _as_array_index(token, len(node), allow_dash=False)
+                if idx >= len(node):
+                    raise KeyError(f"array index {idx} out of range")
+                node = node[idx]
+            else:
+                raise KeyError(f"cannot traverse into {type(node).__name__}")
+        return node
+
+    def set_at(doc, pointer: str, value) -> None:
+        if pointer == "":
+            raise ValueError("cannot replace root document via set_at")
+        tokens = _split(pointer)
+        node = doc
+        for token in tokens[:-1]:
+            if isinstance(node, dict):
+                if token not in node:
+                    raise KeyError(f"key {token!r} not found (no auto-create)")
+                node = node[token]
+            elif isinstance(node, list):
+                idx = _as_array_index(token, len(node), allow_dash=False)
+                if idx >= len(node):
+                    raise KeyError(f"array index {idx} out of range")
+                node = node[idx]
+            else:
+                raise KeyError(f"cannot traverse into {type(node).__name__}")
+        last = tokens[-1]
+        if isinstance(node, dict):
+            node[last] = value
+        elif isinstance(node, list):
+            idx = _as_array_index(last, len(node), allow_dash=True)
+            if idx == len(node):
+                node.append(value)
+            elif idx < len(node):
+                node[idx] = value
+            else:
+                raise KeyError(f"array index {idx} out of range (len={len(node)})")
+        else:
+            raise KeyError(f"cannot set on {type(node).__name__}")
+""")
+
+# A broken solution: incorrect escape order (decodes ~0 before ~1, violating RFC §4).
+_BROKEN_ESCAPE_ORDER = textwrap.dedent("""\
+    def _unescape(token: str) -> str:
+        # BUG: wrong order — RFC 6901 requires ~1 first, then ~0.
+        return token.replace("~0", "~").replace("~1", "/")
+
+    def _split(pointer: str) -> list:
+        if pointer == "":
+            return []
+        if not pointer.startswith("/"):
+            raise ValueError(f"invalid JSON pointer: {pointer!r}")
+        return [_unescape(tok) for tok in pointer[1:].split("/")]
+
+    def resolve(doc, pointer: str):
+        tokens = _split(pointer)
+        if not tokens:
+            return doc
+        node = doc
+        for token in tokens:
+            if isinstance(node, dict):
+                if token not in node:
+                    raise KeyError(token)
+                node = node[token]
+            elif isinstance(node, list):
+                node = node[int(token)]
+            else:
+                raise KeyError(token)
+        return node
+
+    def set_at(doc, pointer: str, value) -> None:
+        if pointer == "":
+            raise ValueError("cannot replace root")
+        tokens = _split(pointer)
+        node = doc
+        for t in tokens[:-1]:
+            if isinstance(node, dict):
+                node = node[t]
+            elif isinstance(node, list):
+                node = node[int(t)]
+        last = tokens[-1]
+        if isinstance(node, dict):
+            node[last] = value
+        elif isinstance(node, list):
+            if last == "-":
+                node.append(value)
+            else:
+                node[int(last)] = value
+""")
+
+
+def _make_jp_task() -> Task:
+    """Build a Task pointing at the real json_pointer_rfc6901 grader directory."""
+    return Task(
+        instance_id="verification_heavy__json_pointer_rfc6901",
+        category="verification_heavy",
+        difficulty="hard",
+        problem_statement="prompt.md",
+        workspace_dir="workspace/",
+        output_artifact="output/solution.py",
+        hidden_grader="grader/hidden.py",
+        reference_output="grader/reference_output.py",
+        execution_budget=ExecutionBudget(0, 0),
+        task_dir=_JP_TASK_DIR.resolve(),
+    )
+
+
+def _write_solution(scratch_dir: Path, code: str) -> None:
+    """Write the agent solution into the expected artifact path."""
+    output_dir = scratch_dir / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "solution.py").write_text(code)
+
+
+@pytest.mark.component
+class TestInvokeGraderJsonPointerContract:
+    """Verify the invoke_grader → json_pointer_rfc6901 grader subprocess contract.
+
+    Specifically guards the post-#188 state where _base_doc() no longer has
+    a duplicate '' key — the grader must still handle the empty-key pointer
+    ('/' → key '' → 'empty-key') correctly.
+    """
+
+    def test_correct_solution_passes(self, tmp_path: Path) -> None:
+        """A correct RFC-6901 resolve+set_at implementation must yield passed=True, score=1.0."""
+        task = _make_jp_task()
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        _write_solution(scratch, _CORRECT_SOLUTION)
+
+        result = invoke_grader(task, scratch)
+
+        assert isinstance(result, GradeResult)
+        assert result.passed is True, (
+            f"Expected correct impl to pass; detail: {result.detail}"
+        )
+        assert result.score == 1.0, f"Expected score=1.0; got {result.score}"
+
+    def test_correct_solution_detail_mentions_all_cases(self, tmp_path: Path) -> None:
+        """The grader detail must report 'all <N> cases passed' with N > 0.
+
+        Pins the detail format contract so a future refactor that silently drops
+        test cases is caught here.
+        """
+        task = _make_jp_task()
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        _write_solution(scratch, _CORRECT_SOLUTION)
+
+        result = invoke_grader(task, scratch)
+
+        assert result.passed is True
+        assert "all" in result.detail and "cases passed" in result.detail, (
+            f"Unexpected detail format; got: {result.detail!r}"
+        )
+        # Extract and verify the count is positive.
+        import re
+        m = re.search(r"all (\d+) cases passed", result.detail)
+        assert m is not None, f"Could not parse case count from: {result.detail!r}"
+        assert int(m.group(1)) > 0
+
+    def test_broken_escape_order_fails(self, tmp_path: Path) -> None:
+        """A solution with wrong ~0/~1 escape order must fail.
+
+        The grader tests '/a~1b' (pointer for key 'a/b') and '/m~0n' (for
+        'm~n') — both require correct RFC §4 escape ordering. This test pins
+        that the grader's escape-ordering test cases catch the common bug.
+        """
+        task = _make_jp_task()
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        _write_solution(scratch, _BROKEN_ESCAPE_ORDER)
+
+        result = invoke_grader(task, scratch)
+
+        assert isinstance(result, GradeResult)
+        assert result.passed is False, (
+            f"Expected wrong-escape-order impl to fail; got passed=True, detail={result.detail!r}"
+        )
+        assert result.score < 1.0, f"Expected score < 1.0; got {result.score}"
+
+    def test_missing_artifact_yields_failed_grade_not_exception(self, tmp_path: Path) -> None:
+        """When no solution.py exists the grader must return passed=False, not raise.
+
+        The harness contract: grader returns a GradeResult even on missing
+        artifact. Only infrastructure failures raise GraderInvocationError.
+        """
+        task = _make_jp_task()
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        # Deliberately write nothing.
+
+        result = invoke_grader(task, scratch)
+
+        assert isinstance(result, GradeResult)
+        assert result.passed is False
+        assert result.score == 0.0
+
+    def test_empty_key_pointer_resolved_after_dedup_cleanup(self, tmp_path: Path) -> None:
+        """The '/' pointer (resolving the '' key) must still pass after the #188 dedup cleanup.
+
+        Before #188, _base_doc() defined '' twice ('': 'empty-key' appeared as the
+        first and fourth key). #188 removed the duplicate second occurrence.
+        The grader's _RESOLVE_TESTS includes ('/','empty-key') — this test
+        confirms the grader still exercises that case correctly and the correct
+        solution passes it.
+        """
+        task = _make_jp_task()
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        _write_solution(scratch, _CORRECT_SOLUTION)
+
+        result = invoke_grader(task, scratch)
+
+        # The correct solution handles '/' → '' key → 'empty-key'.
+        # If the grader's _base_doc() lost the '' key entirely (regression),
+        # it would fail with KeyError on '/'' in _RESOLVE_TESTS, producing
+        # a passed=False result from the grader.
+        assert result.passed is True, (
+            f"Empty-key pointer test case failed after #188 dedup cleanup; "
+            f"detail: {result.detail}"
+        )

--- a/tests/test_json_pointer_grader_base_doc_unique_wiring.py
+++ b/tests/test_json_pointer_grader_base_doc_unique_wiring.py
@@ -1,0 +1,221 @@
+"""Integration tests for json_pointer_rfc6901 grader after duplicate-key removal.
+
+Scenario: slice-json-pointer-grader-base-doc-unique
+Tier: wiring
+
+Verifies the full vertical slice: verify_graders.py tool -> grader/hidden.py._base_doc()
+for the real verification_heavy/json_pointer_rfc6901 task, after removing the
+duplicate empty-string key from _base_doc() (issue #188).
+
+What these tests detect:
+  - If _base_doc() reintroduces a duplicate key, the dict will silently collapse
+    to 6 unique keys; the key-count assertion fails.
+  - If the reference_output.py is moved or deleted, loading the grader fails.
+  - If verify_graders.py subprocess interface changes (exit codes), the
+    subprocess-level assertions catch it.
+  - If the empty-string pointer "/", now resolved against the single unique ""
+    key, breaks any resolve test case, the reference output check surfaces it.
+
+These tests load the real grader module and invoke it directly (wiring tier).
+No @pytest.mark.integration needed — fully offline, sub-second.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_GRADER_PATH = (
+    _REPO_ROOT
+    / "problems"
+    / "artifact"
+    / "verification_heavy"
+    / "json_pointer_rfc6901"
+    / "grader"
+    / "hidden.py"
+)
+_VERIFY_TOOL = _REPO_ROOT / "tools" / "verify_graders.py"
+_TASK_ROOT = _REPO_ROOT / "problems" / "artifact"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_grader():
+    """Load the json_pointer_rfc6901 hidden grader module directly."""
+    name = "_json_pointer_grader_itest"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _GRADER_PATH)
+    assert spec is not None and spec.loader is not None, (
+        f"Cannot load grader from {_GRADER_PATH}"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        del sys.modules[name]
+        raise
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests — structural (wiring tier)
+# ---------------------------------------------------------------------------
+
+
+def test_grader_file_exists() -> None:
+    """Structural: json_pointer_rfc6901/grader/hidden.py must exist on disk."""
+    assert _GRADER_PATH.is_file(), (
+        f"Expected grader at {_GRADER_PATH}"
+    )
+
+
+def test_grader_loads_without_error() -> None:
+    """grader/hidden.py must be importable (syntax valid, no top-level errors)."""
+    mod = _load_grader()
+    assert mod is not None
+
+
+def test_base_doc_has_exactly_seven_unique_keys() -> None:
+    """_base_doc() must return a dict with exactly 7 unique keys.
+
+    Before this fix, _base_doc() had the '' key defined twice as literals (a code
+    quality issue: duplicate dict literal Python silently collapses to 7 keys
+    via last-write-wins). After the fix, the dict has 7 literal definitions and
+    7 runtime keys — the source is now non-misleading.
+
+    This test verifies the runtime dict has exactly 7 keys (no regression into
+    either fewer or more).
+    """
+    mod = _load_grader()
+    assert hasattr(mod, "_base_doc"), "grader must expose _base_doc()"
+    doc = mod._base_doc()
+    assert isinstance(doc, dict)
+    assert len(doc) == 7, (
+        f"Expected 7 unique keys in _base_doc(), got {len(doc)}: {list(doc.keys())}"
+    )
+
+
+def test_base_doc_empty_string_key_present() -> None:
+    """_base_doc() must contain the '' (empty-string) key after deduplication.
+
+    The empty-string key maps to the RFC 6901 root-document pointer '/'.
+    Removing the duplicate must preserve the key, just with a single definition.
+    """
+    mod = _load_grader()
+    doc = mod._base_doc()
+    assert "" in doc, (
+        "Expected empty-string key '' in _base_doc() after duplicate removal"
+    )
+    assert doc[""] == "empty-key", (
+        f"Expected doc[''] == 'empty-key', got {doc['']!r}"
+    )
+
+
+def test_base_doc_required_keys_present() -> None:
+    """_base_doc() must contain all expected RFC 6901 test keys."""
+    mod = _load_grader()
+    doc = mod._base_doc()
+    expected_keys = {"", "a/b", "m~n", "foo", "nested", "arr", "primitives"}
+    missing = expected_keys - set(doc.keys())
+    assert not missing, (
+        f"_base_doc() missing expected keys: {sorted(missing)}"
+    )
+
+
+def test_grade_function_callable() -> None:
+    """grade() must be a callable accepting one argument (scratch_dir path)."""
+    mod = _load_grader()
+    assert hasattr(mod, "grade"), "grader must expose grade()"
+    import inspect
+    sig = inspect.signature(mod.grade)
+    params = list(sig.parameters)
+    assert len(params) == 1, (
+        f"grade() must accept exactly 1 parameter, got {params}"
+    )
+
+
+def test_grade_returns_graderesult_type_on_missing_artifact(tmp_path: Path) -> None:
+    """grade() must return a GradeResult-like object when artifact is missing.
+
+    This tests the interface contract (wiring), not the scoring value.
+    """
+    mod = _load_grader()
+    result = mod.grade(tmp_path)
+    assert hasattr(result, "passed"), "grade() result must have .passed attribute"
+    assert hasattr(result, "score"), "grade() result must have .score attribute"
+    assert hasattr(result, "detail"), "grade() result must have .detail attribute"
+    # Missing artifact: passed must be False, score must be float
+    assert result.passed is False, (
+        f"grade() on missing artifact must return passed=False, got {result.passed!r}"
+    )
+    assert isinstance(result.score, float), (
+        f"grade() score must be float, got {type(result.score)}"
+    )
+
+
+def test_verify_graders_tool_exists() -> None:
+    """Structural: tools/verify_graders.py must exist on disk."""
+    assert _VERIFY_TOOL.is_file(), (
+        f"Expected verify_graders.py at {_VERIFY_TOOL}"
+    )
+
+
+def test_verify_graders_subprocess_with_json_pointer_task(tmp_path: Path) -> None:
+    """verify_graders.py invoked against just the json_pointer_rfc6901 task must exit 0.
+
+    We stage a single-task directory pointing at the real json_pointer_rfc6901 task
+    via symlinks so verify_graders.py exercises the full path
+    (load_tasks -> materialize -> invoke_grader) without running all 40+ tasks.
+
+    Exit code 0 means the reference output passes the grader.
+    Exit code 1 would mean the grader (with _base_doc fixed) disagrees with
+    the reference output — a real failure in the fix.
+    Exit code 2 means task discovery/parse failed (structural wiring error).
+    """
+    # Stage: tmp_path/tasks/verification_heavy/json_pointer_rfc6901 -> real task dir
+    staged = tmp_path / "tasks" / "verification_heavy"
+    staged.mkdir(parents=True)
+    real_task = _TASK_ROOT / "verification_heavy" / "json_pointer_rfc6901"
+    assert real_task.is_dir(), f"json_pointer_rfc6901 task dir not found: {real_task}"
+
+    import os
+    os.symlink(real_task, staged / "json_pointer_rfc6901")
+
+    result = subprocess.run(
+        [sys.executable, str(_VERIFY_TOOL), "--tasks-dir", str(tmp_path / "tasks")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    # Must produce output naming the task
+    combined = result.stdout + result.stderr
+    assert "json_pointer_rfc6901" in combined, (
+        f"verify_graders.py output did not mention json_pointer_rfc6901.\n"
+        f"stdout: {result.stdout[:500]}\nstderr: {result.stderr[:200]}"
+    )
+    # Exit 2 = discovery/parse error (structural failure)
+    assert result.returncode != 2, (
+        f"verify_graders.py exited 2 (discovery/parse error).\n"
+        f"stdout: {result.stdout[:500]}\nstderr: {result.stderr[:200]}"
+    )
+    # Exit 0 = PASS (reference output passed the fixed grader)
+    # Exit 1 = FAIL (grader disagreed with reference — a real regression)
+    assert result.returncode == 0, (
+        f"verify_graders.py exited {result.returncode} — json_pointer_rfc6901 grader "
+        f"did not pass its reference output after _base_doc() deduplication.\n"
+        f"stdout: {result.stdout[:500]}"
+    )

--- a/tests/test_stateful_tasks_load_no_structural_verifier_wiring.py
+++ b/tests/test_stateful_tasks_load_no_structural_verifier_wiring.py
@@ -1,0 +1,153 @@
+"""Integration tests for stateful_reasoning task loading after structural_verifier removal.
+
+Scenario: slice-stateful-tasks-load-no-structural-verifier
+Tier: wiring
+
+Verifies the full vertical slice: artifact_cli.py -> artifact_loader.load_tasks()
+for the real problems/artifact/stateful_reasoning/ directory, after the
+structural_verifier field was removed from event_ledger, unreachable_functions,
+and upgrade_impact task.yaml files (issue #188).
+
+What these tests detect:
+  - If load_tasks() starts requiring structural_verifier (regression), these fail.
+  - If any of the 3 modified task.yaml files become malformed (missing required
+    field, bad instance_id, unknown category), these fail.
+  - If structural_verifier is not parsed as None for tasks that omit it, type
+    contract test fails.
+
+These tests are fully offline and use the real on-disk task files.
+No @pytest.mark.integration needed — sub-second, no network, no containers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from swebench.artifact_loader import load_tasks
+from swebench.artifact_models import Task
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+# load_tasks expects the root of <category>/<slug>/task.yaml — i.e. problems/artifact/
+_ARTIFACT_ROOT = _REPO_ROOT / "problems" / "artifact"
+_STATEFUL_DIR = _ARTIFACT_ROOT / "stateful_reasoning"
+
+_MODIFIED_IDS = {
+    "stateful_reasoning__event_ledger",
+    "stateful_reasoning__unreachable_functions",
+    "stateful_reasoning__upgrade_impact",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_stateful_reasoning_dir_exists() -> None:
+    """Structural: problems/artifact/stateful_reasoning/ directory must exist."""
+    assert _STATEFUL_DIR.is_dir(), (
+        f"Expected stateful_reasoning task directory at {_STATEFUL_DIR}"
+    )
+
+
+def test_load_tasks_returns_list_for_stateful_reasoning() -> None:
+    """load_tasks() on the artifact root must include stateful_reasoning tasks.
+
+    load_tasks() expects the root that contains <category>/<slug>/task.yaml.
+    Filtering to the 3 modified IDs verifies that event_ledger, unreachable_functions,
+    and upgrade_impact all parse successfully from their task.yaml files.
+    """
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids=_MODIFIED_IDS)
+    assert isinstance(tasks, list)
+    assert len(tasks) == len(_MODIFIED_IDS), (
+        f"Expected {len(_MODIFIED_IDS)} stateful_reasoning tasks to load, "
+        f"got {len(tasks)}: {[t.instance_id for t in tasks]}"
+    )
+
+
+def test_modified_tasks_all_present() -> None:
+    """The 3 modified tasks must all appear in the loaded task list."""
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids=_MODIFIED_IDS)
+    loaded_ids = {t.instance_id for t in tasks}
+    missing = _MODIFIED_IDS - loaded_ids
+    assert not missing, (
+        f"Modified tasks not found in stateful_reasoning task load: {sorted(missing)}"
+    )
+
+
+def test_modified_tasks_structural_verifier_is_none() -> None:
+    """All 3 modified tasks must have structural_verifier=None after removal."""
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids=_MODIFIED_IDS)
+    task_map = {t.instance_id: t for t in tasks}
+    for iid in _MODIFIED_IDS:
+        assert iid in task_map, f"Task {iid!r} not found"
+        task = task_map[iid]
+        assert task.structural_verifier is None, (
+            f"Expected structural_verifier=None for {iid!r}, "
+            f"got {task.structural_verifier!r}"
+        )
+
+
+def test_modified_tasks_have_correct_category() -> None:
+    """All 3 modified tasks must have category='stateful_reasoning'."""
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids=_MODIFIED_IDS)
+    task_map = {t.instance_id: t for t in tasks}
+    for iid in _MODIFIED_IDS:
+        assert iid in task_map
+        task = task_map[iid]
+        assert task.category == "stateful_reasoning", (
+            f"Task {iid!r}: expected category='stateful_reasoning', "
+            f"got {task.category!r}"
+        )
+
+
+def test_event_ledger_has_workspace_generator() -> None:
+    """event_ledger must retain workspace_generator after structural_verifier removal."""
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids={"stateful_reasoning__event_ledger"})
+    assert len(tasks) == 1, "event_ledger task not found"
+    el = tasks[0]
+    assert el.workspace_generator is not None, (
+        "event_ledger must still declare workspace_generator after structural_verifier removal"
+    )
+    assert isinstance(el.workspace_generator, str)
+
+
+def test_tasks_sorted_by_instance_id() -> None:
+    """load_tasks() with filter must return tasks in instance_id-sorted order."""
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids=_MODIFIED_IDS)
+    ids = [t.instance_id for t in tasks]
+    assert ids == sorted(ids), (
+        f"Tasks not sorted by instance_id: {ids}"
+    )
+
+
+def test_load_tasks_with_filter_for_modified_ids() -> None:
+    """load_tasks() with filter_ids must return exactly the 3 modified tasks."""
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids=_MODIFIED_IDS)
+    loaded_ids = {t.instance_id for t in tasks}
+    assert loaded_ids == _MODIFIED_IDS, (
+        f"Filtered load returned {loaded_ids!r}, expected {_MODIFIED_IDS!r}"
+    )
+
+
+def test_task_model_type_for_each_modified_task() -> None:
+    """Each loaded task must be a Task instance with the correct field types."""
+    tasks = load_tasks(_ARTIFACT_ROOT, filter_ids=_MODIFIED_IDS)
+    for task in tasks:
+        assert isinstance(task, Task)
+        assert isinstance(task.instance_id, str)
+        assert isinstance(task.category, str)
+        assert isinstance(task.difficulty, str)
+        assert task.difficulty in {"easy", "medium", "hard"}
+        # structural_verifier must be None or str — after removal, must be None
+        assert task.structural_verifier is None
+        # execution_budget must be present
+        assert task.execution_budget is not None
+        assert isinstance(task.execution_budget.max_code_runs, int)
+        assert isinstance(task.execution_budget.max_wall_seconds, int)


### PR DESCRIPTION
## Summary
Follow-up tests for #188 (merged in #197). These were authored after the squash-merge and need their own PR.

- **Component (boundary) tests** — `tests/test_component_artifact_loader_structural_verifier.py`, `tests/test_component_invoke_grader_json_pointer.py`
- **Integration (wiring) tests** — `tests/test_json_pointer_grader_base_doc_unique_wiring.py`, `tests/test_stateful_tasks_load_no_structural_verifier_wiring.py`

These lock in the behavior changed by #197: stateful_reasoning tasks load with no structural_verifier, and the json_pointer grader's base-doc key is unique.

## Test plan
- [ ] `pytest tests/test_component_artifact_loader_structural_verifier.py tests/test_component_invoke_grader_json_pointer.py tests/test_json_pointer_grader_base_doc_unique_wiring.py tests/test_stateful_tasks_load_no_structural_verifier_wiring.py`
- [ ] Full suite green: `pytest -m "not integration"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)