### PR TITLE
fix(#203): per-repo Python version + pre-install pins for old scikit-learn

### DIFF
--- a/scripts/bust_datasci_cache.sh
+++ b/scripts/bust_datasci_cache.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# bust_datasci_cache.sh — one-time cache-bust for scikit-learn + matplotlib instances
+#
+# Removes the lockfile.txt for each affected cache entry so the harness
+# triggers a full venv rebuild on the next run (picking up the new Python
+# version + pre-install pins added in issue #203).
+#
+# Usage:
+#   bash scripts/bust_datasci_cache.sh
+#
+# The SWEBENCH_CACHE_ROOT env var controls where cache entries live.
+# Defaults to ~/.cache/swebench if unset.
+
+set -euo pipefail
+
+CACHE_ROOT="${SWEBENCH_CACHE_ROOT:-${HOME}/.cache/swebench}"
+INSTANCES_DIR="${CACHE_ROOT}/instances"
+
+# scikit-learn 0.20–0.22 instances (Python 3.10 + setuptools/numpy/cython pins)
+SKLEARN_IDS=(10427 10803 11206 11596 3840 12704 13283 13496 13013 13864 14125 14710 15094)
+
+# matplotlib 3.1–3.7 era instances (Python 3.11 + numpy<2 + cython<3 + setuptools<65 pins)
+MPL_IDS=(13859 19763 21042 22767 23088 23476 24177 24637 25126 25442 25772 26160)
+
+bust() {
+    local prefix="$1"; shift
+    for id in "$@"; do
+        local entry="${INSTANCES_DIR}/${prefix}-${id}"
+        local lockfile="${entry}/lockfile.txt"
+        if [[ -f "${lockfile}" ]]; then
+            echo "Busting ${prefix}-${id} (removing lockfile)"
+            rm -f "${lockfile}"
+        elif [[ -d "${entry}" ]]; then
+            echo "  ${prefix}-${id}: directory exists but no lockfile — skipping"
+        else
+            echo "  ${prefix}-${id}: not cached — nothing to do"
+        fi
+    done
+}
+
+echo "=== bust_datasci_cache.sh ==="
+echo "Cache root: ${CACHE_ROOT}"
+echo ""
+
+echo "--- scikit-learn (${#SKLEARN_IDS[@]} instances) ---"
+bust scikit-learn__scikit-learn "${SKLEARN_IDS[@]}"
+
+echo ""
+echo "--- matplotlib (${#MPL_IDS[@]} instances) ---"
+bust matplotlib__matplotlib "${MPL_IDS[@]}"
+
+echo ""
+echo "Done. Affected entries will rebuild on next swebench run."
+echo "(New builds will use Python 3.10 for scikit-learn and pre-install pins for matplotlib.)"

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -11,6 +11,41 @@ import tempfile
 import threading
 from pathlib import Path
 
+# ---------------------------------------------------------------------------
+# Per-repo Python interpreter and pre-install pin tables
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PYTHON = "python3.11"
+
+_REPO_PYTHON: dict[str, str] = {
+    # scikit-learn 0.20–0.22: setuptools ≥ 61 + Cython 0.29 ABI mismatch on 3.11
+    "scikit-learn/scikit-learn": "python3.10",
+}
+
+_REPO_PRE_INSTALL: dict[str, list[str]] = {
+    # scikit-learn 0.20–0.22: pins required before `pip install -e .`
+    "scikit-learn/scikit-learn": ["setuptools<60", "numpy<1.24", "cython<3"],
+    # matplotlib 3.1 era: numpy 2.x ABI break + old setuptools/cython
+    "matplotlib/matplotlib": ["setuptools<65", "numpy<2", "cython<3"],
+}
+
+# Sentinel file written inside the venv dir to record which python binary
+# created it.  A mismatch triggers a full venv rebuild.
+_SENTINEL_FILENAME = ".python_bin"
+
+
+def _venv_sentinel(venv_dir: str) -> str:
+    """Return the path to the python_bin sentinel file inside *venv_dir*."""
+    return os.path.join(venv_dir, _SENTINEL_FILENAME)
+
+
+def _read_sentinel(venv_dir: str) -> str | None:
+    """Read and return the sentinel value, or None if absent/unreadable."""
+    try:
+        return Path(_venv_sentinel(venv_dir)).read_text().strip()
+    except OSError:
+        return None
+
 # Per-slug locks so concurrent cache-setup threads don't race on the same bare clone.
 _bare_clone_locks: dict[str, threading.Lock] = {}
 _bare_clone_locks_mu = threading.Lock()
@@ -311,15 +346,41 @@ def _pin_jinja2(pip: str) -> None:
         )
 
 
-def setup_venv(venv_dir: str, repo_dir: str) -> None:
-    """Create a venv and pip install the project in editable mode (if not already done)."""
+def setup_venv(
+    venv_dir: str,
+    repo_dir: str,
+    *,
+    python_bin: str = _DEFAULT_PYTHON,
+    pre_install: list[str] | None = None,
+) -> None:
+    """Create a venv and pip install the project in editable mode (if not already done).
+
+    Parameters
+    ----------
+    venv_dir:
+        Directory where the virtual environment lives (created if absent).
+    repo_dir:
+        Root of the project to install in editable mode.
+    python_bin:
+        Python interpreter to use when creating a *fresh* venv (e.g.
+        ``"python3.10"``).  Defaults to ``_DEFAULT_PYTHON`` (``"python3.11"``).
+        Ignored when reusing an existing venv whose sentinel matches.
+    pre_install:
+        Optional list of pip requirement specs to install *before* the
+        editable install (e.g. ``["setuptools<60", "numpy<1.24", "cython<3"]``).
+        When non-empty, the editable install uses ``--no-build-isolation`` so
+        the pinned packages are visible during the build.  Only applied on the
+        fresh-venv creation path.
+    """
     pip = os.path.join(venv_dir, "bin", "pip")
     if os.path.isdir(venv_dir):
         # F-19: Guard against a partially-built venv skeleton that has the
         # directory but not bin/pip (e.g. venv creation crashed mid-way).
-        # If pip is missing, wipe the directory so the new-venv branch below
-        # recreates it cleanly.
         if not os.path.isfile(pip):
+            shutil.rmtree(venv_dir, ignore_errors=True)
+        elif _read_sentinel(venv_dir) != python_bin:
+            # Sentinel mismatch: the venv was created with a different Python
+            # binary.  Wipe and fall through to the fresh-create path.
             shutil.rmtree(venv_dir, ignore_errors=True)
         else:
             # Venv exists from a prior run. Re-run the editable install so that C
@@ -357,8 +418,9 @@ def setup_venv(venv_dir: str, repo_dir: str) -> None:
             if _needs_jinja2_pin(repo_dir):
                 _pin_jinja2(pip)
             return
+    # Fresh venv creation path.
     subprocess.run(
-        ["python3.11", "-m", "venv", venv_dir],
+        [python_bin, "-m", "venv", venv_dir],
         check=True,
         capture_output=True,
     )
@@ -370,12 +432,30 @@ def setup_venv(venv_dir: str, repo_dir: str) -> None:
         text=True,
         check=True,
     )
-    subprocess.run(
-        [pip, "install", "--quiet", "-e", repo_dir],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    if pre_install:
+        # Install pinned build dependencies before the editable install so the
+        # build backend sees the correct versions.  --no-build-isolation ensures
+        # the already-installed pins are used during the build (not re-resolved
+        # from scratch inside an isolated build env).
+        subprocess.run(
+            [pip, "install", "--quiet", *pre_install],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            [pip, "install", "--quiet", "-e", repo_dir, "--no-build-isolation"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    else:
+        subprocess.run(
+            [pip, "install", "--quiet", "-e", repo_dir],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
     # Try common test/dev extras; ignore failures (not all packages define them).
     for extra in ("test", "tests", "dev", "testing"):
         subprocess.run(
@@ -392,6 +472,8 @@ def setup_venv(venv_dir: str, repo_dir: str) -> None:
     )
     if _needs_jinja2_pin(repo_dir):
         _pin_jinja2(pip)
+    # Write the sentinel last — only after a fully successful install.
+    Path(_venv_sentinel(venv_dir)).write_text(python_bin + "\n")
 
 
 def apply_test_patch(repo_dir: str, patch_path: str) -> bool:

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -32,6 +32,9 @@ from swebench.cache import (
     OverlayError,
 )
 from swebench.harness import (
+    _DEFAULT_PYTHON,
+    _REPO_PRE_INSTALL,
+    _REPO_PYTHON,
     apply_test_patch,
     clone_repo,
     find_claude_binary,
@@ -42,6 +45,19 @@ from swebench.harness import (
     setup_venv,
     strip_git_history,
 )
+
+
+def _venv_kwargs(repo_slug: str) -> dict:
+    """Return keyword args for ``setup_venv()`` based on the repo slug.
+
+    Looks up per-repo Python interpreter and pre-install pin overrides from
+    the harness lookup tables.  Returns a dict suitable for ``**``-unpacking
+    into ``setup_venv(..., **_venv_kwargs(slug))``.
+    """
+    return {
+        "python_bin": _REPO_PYTHON.get(repo_slug, _DEFAULT_PYTHON),
+        "pre_install": _REPO_PRE_INSTALL.get(repo_slug),
+    }
 from swebench.models import Problem
 
 
@@ -356,7 +372,7 @@ def _setup_problem(problem: Problem, clone_base: str) -> tuple[str, str]:
     # Strip history so the agent cannot recover the upstream fix via git log.
     # Safe to do here: this clone is thrown away after the run.
     strip_git_history(repo_dir)
-    setup_venv(venv_dir, repo_dir)
+    setup_venv(venv_dir, repo_dir, **_venv_kwargs(problem.repo_slug))
     return repo_dir, venv_dir
 
 
@@ -410,7 +426,7 @@ def _setup_problem_cached(
         # setup_venv call that scrub_cache_dir later removed).
         git_reset(lower, problem.base_commit)
         shutil.rmtree(venv_dir, ignore_errors=True)
-        setup_venv(venv_dir, lower)
+        setup_venv(venv_dir, lower, **_venv_kwargs(problem.repo_slug))
         scrub_cache_dir(lower)
         write_lockfile(venv_dir, lockfile)
 

--- a/tests/test_harness_venv.py
+++ b/tests/test_harness_venv.py
@@ -1,0 +1,268 @@
+"""Tests for the per-repo Python-version sentinel in setup_venv().
+
+Covers the three paths introduced by issue #203:
+  (a) sentinel is written on fresh venv creation,
+  (b) a mismatched sentinel forces a full venv rebuild,
+  (c) a matching sentinel takes the existing-venv reuse path.
+
+All subprocess.run calls are monkeypatched so no real venvs are created.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from swebench.harness import (
+    _DEFAULT_PYTHON,
+    _REPO_PRE_INSTALL,
+    _REPO_PYTHON,
+    _read_sentinel,
+    _venv_sentinel,
+    setup_venv,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_success(args: list[str] | None = None) -> MagicMock:
+    """Return a MagicMock that looks like a successful subprocess.CompletedProcess."""
+    m = MagicMock()
+    m.returncode = 0
+    m.args = args or []
+    m.stdout = ""
+    m.stderr = ""
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Sentinel unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_written_after_fresh_venv_creation(tmp_path: Path) -> None:
+    """Sentinel file is written with the python_bin after a successful fresh install."""
+    venv_dir = str(tmp_path / "venv")
+    repo_dir = str(tmp_path / "repo")
+    os.makedirs(repo_dir)
+
+    calls_made: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        calls_made.append(cmd)
+        # After the venv creation call, create bin/pip so the sentinel write can
+        # happen (the real code checks os.path.isdir(venv_dir) first).
+        if len(cmd) >= 3 and "-m" in cmd and "venv" in cmd:
+            pip_dir = os.path.join(venv_dir, "bin")
+            os.makedirs(pip_dir, exist_ok=True)
+            Path(os.path.join(pip_dir, "pip")).touch()
+        return _make_success(cmd)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        setup_venv(venv_dir, repo_dir, python_bin="python3.10")
+
+    sentinel_value = _read_sentinel(venv_dir)
+    assert sentinel_value == "python3.10", (
+        f"Expected sentinel 'python3.10', got {sentinel_value!r}"
+    )
+
+
+def test_sentinel_mismatch_forces_rebuild(tmp_path: Path) -> None:
+    """When the sentinel doesn't match python_bin, the old venv is wiped and rebuilt."""
+    venv_dir = str(tmp_path / "venv")
+    repo_dir = str(tmp_path / "repo")
+    os.makedirs(repo_dir)
+
+    # Create a pre-existing venv skeleton with pip and a WRONG sentinel.
+    pip_dir = os.path.join(venv_dir, "bin")
+    os.makedirs(pip_dir)
+    Path(os.path.join(pip_dir, "pip")).touch()
+    # Sentinel says python3.11 was used:
+    Path(_venv_sentinel(venv_dir)).write_text("python3.11\n")
+
+    venv_creation_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if len(cmd) >= 3 and "-m" in cmd and "venv" in cmd:
+            venv_creation_calls.append(cmd)
+            # Recreate the bin/pip after wipe so later calls succeed.
+            new_pip_dir = os.path.join(venv_dir, "bin")
+            os.makedirs(new_pip_dir, exist_ok=True)
+            Path(os.path.join(new_pip_dir, "pip")).touch()
+        return _make_success(cmd)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        setup_venv(venv_dir, repo_dir, python_bin="python3.10")
+
+    # Venv creation must have been called exactly once (the rebuild).
+    assert len(venv_creation_calls) == 1, (
+        f"Expected 1 venv creation call, got {len(venv_creation_calls)}: "
+        f"{venv_creation_calls}"
+    )
+    # The creation call must use the requested python_bin.
+    assert "python3.10" in venv_creation_calls[0], (
+        f"venv creation did not use python3.10: {venv_creation_calls[0]}"
+    )
+    # Sentinel must now reflect the new interpreter.
+    assert _read_sentinel(venv_dir) == "python3.10"
+
+
+def test_matching_sentinel_takes_reuse_path(tmp_path: Path) -> None:
+    """When the sentinel matches python_bin, setup_venv() reuses the existing venv."""
+    venv_dir = str(tmp_path / "venv")
+    repo_dir = str(tmp_path / "repo")
+    os.makedirs(repo_dir)
+
+    # Create a pre-existing venv with pip and a MATCHING sentinel.
+    pip_dir = os.path.join(venv_dir, "bin")
+    os.makedirs(pip_dir)
+    pip_path = os.path.join(pip_dir, "pip")
+    Path(pip_path).touch()
+    Path(_venv_sentinel(venv_dir)).write_text("python3.11\n")
+
+    venv_creation_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if len(cmd) >= 3 and "-m" in cmd and "venv" in cmd:
+            venv_creation_calls.append(cmd)
+        return _make_success(cmd)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        setup_venv(venv_dir, repo_dir, python_bin="python3.11")
+
+    # Venv must NOT have been recreated.
+    assert venv_creation_calls == [], (
+        f"Unexpected venv creation on reuse path: {venv_creation_calls}"
+    )
+
+
+def test_missing_pip_triggers_rebuild_regardless_of_sentinel(tmp_path: Path) -> None:
+    """A venv directory with a sentinel but no pip is treated as broken and rebuilt."""
+    venv_dir = str(tmp_path / "venv")
+    repo_dir = str(tmp_path / "repo")
+    os.makedirs(repo_dir)
+
+    # Create the venv dir and sentinel but no bin/pip.
+    os.makedirs(venv_dir)
+    Path(_venv_sentinel(venv_dir)).write_text("python3.11\n")
+    # Do NOT create bin/pip.
+
+    venv_creation_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if len(cmd) >= 3 and "-m" in cmd and "venv" in cmd:
+            venv_creation_calls.append(cmd)
+            new_pip_dir = os.path.join(venv_dir, "bin")
+            os.makedirs(new_pip_dir, exist_ok=True)
+            Path(os.path.join(new_pip_dir, "pip")).touch()
+        return _make_success(cmd)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        setup_venv(venv_dir, repo_dir, python_bin="python3.11")
+
+    assert len(venv_creation_calls) == 1, (
+        f"Expected rebuild when pip is missing, got {len(venv_creation_calls)} creation calls"
+    )
+
+
+def test_pre_install_uses_no_build_isolation(tmp_path: Path) -> None:
+    """When pre_install is non-empty, the editable install uses --no-build-isolation."""
+    venv_dir = str(tmp_path / "venv")
+    repo_dir = str(tmp_path / "repo")
+    os.makedirs(repo_dir)
+
+    install_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if "-m" in cmd and "venv" in cmd:
+            pip_dir = os.path.join(venv_dir, "bin")
+            os.makedirs(pip_dir, exist_ok=True)
+            Path(os.path.join(pip_dir, "pip")).touch()
+        if "install" in cmd:
+            install_calls.append(cmd)
+        return _make_success(cmd)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        setup_venv(
+            venv_dir,
+            repo_dir,
+            python_bin="python3.11",
+            pre_install=["setuptools<60", "numpy<1.24"],
+        )
+
+    # Find the editable install call.
+    editable_calls = [c for c in install_calls if "-e" in c and repo_dir in c]
+    assert editable_calls, "No editable install call found"
+    assert any("--no-build-isolation" in c for c in editable_calls), (
+        f"--no-build-isolation not found in any editable install call: {editable_calls}"
+    )
+
+
+def test_no_build_isolation_absent_without_pre_install(tmp_path: Path) -> None:
+    """Without pre_install, the editable install does NOT use --no-build-isolation."""
+    venv_dir = str(tmp_path / "venv")
+    repo_dir = str(tmp_path / "repo")
+    os.makedirs(repo_dir)
+
+    install_calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        if "-m" in cmd and "venv" in cmd:
+            pip_dir = os.path.join(venv_dir, "bin")
+            os.makedirs(pip_dir, exist_ok=True)
+            Path(os.path.join(pip_dir, "pip")).touch()
+        if "install" in cmd:
+            install_calls.append(cmd)
+        return _make_success(cmd)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        setup_venv(venv_dir, repo_dir, python_bin="python3.11")
+
+    editable_calls = [c for c in install_calls if "-e" in c and repo_dir in c]
+    assert editable_calls, "No editable install call found"
+    for c in editable_calls:
+        assert "--no-build-isolation" not in c, (
+            f"--no-build-isolation found unexpectedly without pre_install: {c}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lookup table sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_sklearn_uses_python310() -> None:
+    assert _REPO_PYTHON.get("scikit-learn/scikit-learn") == "python3.10"
+
+
+def test_sklearn_pre_install_pins() -> None:
+    pins = _REPO_PRE_INSTALL.get("scikit-learn/scikit-learn")
+    assert pins is not None
+    assert any("setuptools<60" in p for p in pins)
+    assert any("numpy<1.24" in p for p in pins)
+    assert any("cython<3" in p for p in pins)
+
+
+def test_matplotlib_pre_install_pins() -> None:
+    pins = _REPO_PRE_INSTALL.get("matplotlib/matplotlib")
+    assert pins is not None
+    assert any("numpy<2" in p for p in pins)
+    assert any("cython<3" in p for p in pins)
+    assert any("setuptools<65" in p for p in pins)
+
+
+def test_default_python_is_311() -> None:
+    assert _DEFAULT_PYTHON == "python3.11"
+
+
+def test_unlisted_repo_uses_default() -> None:
+    """A repo not in _REPO_PYTHON should fall back to _DEFAULT_PYTHON."""
+    assert _REPO_PYTHON.get("some/other-repo", _DEFAULT_PYTHON) == _DEFAULT_PYTHON


### PR DESCRIPTION
Closes #203

## What changed

Old scikit-learn (0.20–0.22) instances were silently failing to install because Python 3.11 is incompatible with Cython 0.29 + setuptools ≥ 61. Old matplotlib (3.1 era) was failing due to missing `libfreetype6-dev` system headers and a numpy 2.x ABI break. This PR fixes the harness to select the correct Python interpreter and pre-install pins per repo, adds a venv sentinel to detect and rebuild stale environments, and provides a cache-bust script to force rebuilds of the 25 affected cached instances.

## Tier / approach

Tier 2 — Planner → parallel Coder A + Tester → binary checks

## What was changed and why

### `swebench/harness.py`

**Lookup tables** (`_REPO_PYTHON`, `_REPO_PRE_INSTALL`): static dicts mapping `repo_slug` to Python binary name and pip pins list respectively. `scikit-learn/scikit-learn` maps to `python3.10`; both `scikit-learn/scikit-learn` and `matplotlib/matplotlib` have pre-install pins. All other repos fall back to `_DEFAULT_PYTHON = "python3.11"` with no pins — existing behaviour preserved exactly.

**Venv sentinel** (`_SENTINEL_FILENAME = ".python_bin"`): a small text file written inside `venv_dir` containing the python binary path used to create it. On the next `setup_venv()` call, if the sentinel is absent or mismatched against the requested `python_bin`, the stale venv is wiped and rebuilt. This prevents silent failures where a 3.11 venv persists after the interpreter requirement changes.

**`setup_venv()` signature change**: now accepts `python_bin` (default `"python3.11"`) and `pre_install` (default `None`) keyword arguments. When `pre_install` is non-empty, the listed packages are installed before `pip install -e .` and `--no-build-isolation` is added to the editable install so the pinned build deps are visible to the build backend. `--no-build-isolation` is **not** applied to the existing-venv reuse path or to `reinstall_editable()` in `cache.py` — those paths use `--no-deps` and rely on the already-installed environment.

### `swebench/run.py`

Imports `_DEFAULT_PYTHON`, `_REPO_PYTHON`, `_REPO_PRE_INSTALL` from harness and adds a `_venv_kwargs(repo_slug)` helper that returns the appropriate `python_bin` and `pre_install` for a given slug. Both `setup_venv()` call sites (in `_setup_problem()` and in the lockfile-rebuild branch of `_setup_problem_cached()`) are updated to pass `**_venv_kwargs(problem.repo_slug)`.

### `scripts/bust_datasci_cache.sh`

One-time script to remove `lockfile.txt` for the 13 scikit-learn + 12 matplotlib cached instance entries. Deleting the lockfile causes the harness to rebuild the cache entry on the next run, picking up the new Python interpreter and pins. Must be run once after deploying this PR to the cache host.

### `.devcontainer/Dockerfile` (hub-level, NOT in this repo)

The hub-level Dockerfile (`/workspaces/hub_1/.devcontainer/Dockerfile`) needs `libfreetype6-dev libpng-dev` added to the system package install block so matplotlib's C extensions can find `ft2build.h`. This change is **outside this repo** and must be applied manually:

```
# In .devcontainer/Dockerfile, add to the apt-get install block:
libfreetype6-dev libpng-dev
```

Then rebuild the container image.

## Default execution path

**Before**: `setup_venv(venv_dir, repo_dir)` always called `python3.11 -m venv` regardless of which repo was being installed. scikit-learn 0.20–0.22 would fail at `pip install -e .` with a Cython/setuptools ABI error. Stale venvs would silently persist indefinitely.

**After**: `setup_venv(venv_dir, repo_dir, **_venv_kwargs("scikit-learn/scikit-learn"))` calls `python3.10 -m venv`, pre-installs `setuptools<60 numpy<1.24 cython<3`, then runs `pip install -e . --no-build-isolation`. Sentinel `.python_bin` is written after successful creation. On subsequent calls, the sentinel is read first; a match takes the fast reuse path; a mismatch wipes and rebuilds.

## Acceptance criteria

- [x] `setup_venv()` accepts `python_bin` and `pre_install` keyword arguments; defaults preserve existing behaviour
- [x] Sentinel file `venv/.python_bin` is written on fresh venv creation containing the python binary path
- [x] Stale venv (sentinel mismatch) is wiped and recreated with the new python_bin
- [x] Existing venv with matching sentinel takes the reuse path unchanged
- [x] `_REPO_PYTHON` and `_REPO_PRE_INSTALL` lookup tables present in `harness.py`
- [x] Both `setup_venv()` call sites in `run.py` pass `**_venv_kwargs(problem.repo_slug)`
- [x] `--no-build-isolation` only in the fresh-venv + pre_install path
- [x] `scripts/bust_datasci_cache.sh` exists, is executable, covers all 25 affected instance IDs
- [x] `tests/test_harness_venv.py` passes (11 tests)
- [x] Full test suite passes with no regressions (424 passed)
- [ ] Dockerfile adds `libfreetype6-dev libpng-dev pkg-config` — **manual step, outside this repo**

🤖 Generated with [Claude Code](https://claude.com/claude-code)