### PR TITLE
fix(#211): add certifi to matplotlib pre-install + scipy to sklearn 1.2–1.3 pre-install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ node_modules/
 exec_server/dist/
 results*/
 
+# Root-level copies of exec_server helper modules (staged at runtime by exec-server.js from exec_server/)
+/codebox.py
+/mcp_bridge.py
+

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -25,8 +25,11 @@ _REPO_PYTHON: dict[str, str] = {
 _REPO_PRE_INSTALL: dict[str, list[str]] = {
     # scikit-learn 0.20–0.22: pins required before `pip install -e .`
     "scikit-learn/scikit-learn": ["setuptools<60", "numpy<1.24", "cython<3"],
-    # matplotlib 3.1 era: numpy 2.x ABI break + old setuptools/cython
-    "matplotlib/matplotlib": ["setuptools<65", "numpy<2", "cython<3", "pybind11>=2.6"],
+    # matplotlib 3.1 era: numpy 2.x ABI break + old setuptools/cython.
+    # certifi is required: matplotlib's build downloads freetype/qhull tarballs
+    # over HTTPS and imports certifi for the CA bundle.  Without it, build
+    # fails with "ImportError: `certifi` is unavailable" before any C compile.
+    "matplotlib/matplotlib": ["setuptools<65", "numpy<2", "cython<3", "pybind11>=2.6", "certifi"],
 }
 
 # ---------------------------------------------------------------------------
@@ -60,6 +63,12 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # matplotlib 3.7 era (2023): uses pybind11 + downloads qhull (needs certifi);
     # repo-level setuptools<65 is too old for this version's pyproject.toml build.
     "matplotlib__matplotlib-26160": ["numpy<2", "cython<3", "pybind11>=2.6", "certifi", "wheel"],
+    # scikit-learn 1.2–1.3 era: setup.py's check_package_status() imports scipy
+    # at metadata-generation time, before any editable install. Without scipy
+    # pre-installed, build fails with "scikit-learn requires scipy >= 1.3.2".
+    # scipy<1.12 keeps compatibility with the repo-level numpy<1.24 pin.
+    "scikit-learn__scikit-learn-24677": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.12"],
+    "scikit-learn__scikit-learn-25694": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.12"],
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #211.

## Summary

Two pre-install pin fixes in `swebench/harness.py`:

**Group A — 5 matplotlib instances** (`19763`, `24637`, `25126`, `25442`, `25772`): Added `certifi` to the repo-level `_REPO_PRE_INSTALL["matplotlib/matplotlib"]`. matplotlib's build downloads freetype/qhull tarballs over HTTPS and imports `certifi` for CA verification — without it, the C-extension build fails before any compilation with `ImportError: certifi is unavailable`.

**Group B — 2 sklearn instances** (`24677`, `25694`): Added per-instance overrides in `_INSTANCE_PRE_INSTALL` with `scipy<1.12`. These are sklearn 1.2–1.3 era versions whose `setup.py` calls `check_package_status("scipy", ...)` at pip metadata-generation time (before editable install). Without scipy pre-installed, build fails immediately with `ImportError: scipy is not installed`.

## Validation

Ran `scripts/validate_datasci_mini_setup.py --filter <7 instances>`:

| Instance | Result |
|---|---|
| `matplotlib__matplotlib-19763` | ✅ ok |
| `matplotlib__matplotlib-24637` | ✅ ok |
| `matplotlib__matplotlib-25126` | ✅ ok |
| `matplotlib__matplotlib-25442` | ✅ ok (transient clone failure on first run; passed on retry) |
| `matplotlib__matplotlib-25772` | ✅ ok |
| `scikit-learn__scikit-learn-24677` | ✅ ok |
| `scikit-learn__scikit-learn-25694` | ✅ ok |

Overall datasci-mini score: **40/50 → 46/50**. The remaining 3 failures are the vendored-cloudpickle instances tracked in #208 (need Python 3.7, not installed in this devcontainer).

## Test plan
- [ ] CI pytest passes
- [ ] Re-run full validator: `python scripts/validate_datasci_mini_setup.py` — expect 46/50

🤖 Generated with [Claude Code](https://claude.com/claude-code)