### PR TITLE
fix(#224): Codex CLI baseline/tool_rich arm — end-to-end

### DIFF
--- a/docs/SPEC_VERIFY_AUTH.md
+++ b/docs/SPEC_VERIFY_AUTH.md
@@ -1,0 +1,151 @@
+# SPEC — `AgentRunner.verify_auth()` and `make_isolated_config` privatization
+
+**Status**: proposed for PR #225 follow-up
+**Resolves**: F-1 (major), F-2 (minor), F-3 (minor), F-6 (minor) from review-fix-proposals on PR #225
+**Scope**: `swebench/runner.py`, `swebench/run.py`, `swebench/artifact_cli.py`, `tests/test_runner.py`. No behavior change for `claude_code` arms. No new functional capability — pure refactor of the preflight contract.
+
+---
+
+## Problem
+
+PR #225 introduced a Codex-specific preflight in `run_command`:
+
+```python
+runner = make_runner(agent_surface)
+claude_binary = runner.find_binary()
+if agent_surface == "codex_cli":
+    runner.make_isolated_config()  # verify auth early; discard result
+```
+
+This is wrong for three reasons:
+
+1. **Bundle-required-for-baseline (F-1, major).** `make_isolated_config` does two unrelated jobs: (a) check & copy `~/.codex/auth.json`, (b) write `config.toml` referencing `exec_server/dist/exec-server.bundle.mjs`. The bundle is gitignored and only needed for `onlycode`/`code_only` arms, yet preflight requires it for every `codex_cli` invocation including `--arms baseline`. AC1 of #224 is broken on a clean checkout.
+2. **Leaked temp dir (F-2, minor).** `make_isolated_config` returns a `tempfile.mkdtemp` path. The preflight discards it without `shutil.rmtree`, leaking a `/tmp/codex-eval-*` dir containing a copy of `auth.json` on every run.
+3. **Surface branching leaks past the abstraction (F-3, F-6).** The `if agent_surface == "codex_cli":` branch defeats the `AgentRunner` ABC. `artifact_cli.py` has no equivalent preflight (F-3). The local `claude_binary` variable name lies once it might hold a `codex` path (F-6).
+
+The module docstring at `swebench/runner.py:19-20` explicitly states:
+
+> Config/auth isolation is handled *internally* by each runner's invoke() method — callers do not manage temp dirs directly.
+
+Exposing `make_isolated_config` to callers violates that contract.
+
+## Goals
+
+- Preflight checks **auth only** — never the exec-server bundle.
+- Preflight is **surface-agnostic** — no `if agent_surface == "codex_cli"` branch in callers.
+- Preflight has **no side effects on disk** — no temp dirs created.
+- `make_isolated_config` returns to being a private helper of `invoke()`, restoring the module contract.
+
+## Non-goals
+
+- No change to `ClaudeRunner` runtime behavior. The `claude_code` arm stays byte-for-byte identical.
+- No change to the `codex_cli + onlycode` rejection guard (Slice 5 territory).
+- No change to the analyze-pipeline guard (`_check_not_codex_jsonl`).
+- No change to `config.toml` contents or exec-server bundle resolution.
+
+## Design
+
+### New ABC method
+
+```python
+class AgentRunner(ABC):
+    @abstractmethod
+    def verify_auth(self) -> None:
+        """Raise FileNotFoundError if required auth artifacts are missing.
+
+        Called by preflight code. Must have no side effects (no temp dirs,
+        no file copies). A no-op return means auth is plausibly valid; it
+        does not guarantee a live session.
+        """
+```
+
+### ClaudeRunner implementation
+
+```python
+def verify_auth(self) -> None:
+    return  # claude validates credentials inside invoke()
+```
+
+A no-op. ClaudeRunner already copies `~/.claude/.credentials.json` and `~/.claude/.claude.json` inside `invoke()` and tolerates either being absent (the `claude` binary then fails its own login check). There is no surface-level pre-check today; adding one here would change ClaudeRunner behavior and is out of scope.
+
+### CodexRunner implementation
+
+```python
+def verify_auth(self) -> None:
+    src = os.path.expanduser("~/.codex/auth.json")
+    if not os.path.isfile(src):
+        raise FileNotFoundError(
+            "~/.codex/auth.json not found — Codex CLI requires a valid auth token."
+        )
+```
+
+Pure check. Same error string as before (callers and tests that pattern-match on `~/.codex/auth.json` keep working).
+
+### `make_isolated_config` becomes private
+
+Rename `CodexRunner.make_isolated_config` → `CodexRunner._make_isolated_config`. The auth check inside it is kept (defense in depth: anyone bypassing preflight still gets a clear error). Only `invoke()` calls it.
+
+### Preflight call sites
+
+`swebench/run.py`:
+
+```python
+try:
+    runner = make_runner(agent_surface)
+    agent_binary = runner.find_binary()
+    runner.verify_auth()
+except (ValueError, FileNotFoundError) as e:
+    click.echo(f"ERROR: {e}", err=True)
+    raise SystemExit(1)
+```
+
+`swebench/artifact_cli.py` (currently has no auth preflight at all — F-3):
+
+```python
+try:
+    runner = make_runner(agent_surface)
+    binary = runner.find_binary()
+    runner.verify_auth()
+except (ValueError, FileNotFoundError) as exc:
+    click.echo(f"ERROR: {exc}", err=True)
+    raise SystemExit(1)
+```
+
+### Rename freebie (F-6)
+
+In `swebench/run.py`, the local `claude_binary` variable now genuinely holds either a `claude` or `codex` path. Rename to `agent_binary` for the four occurrences in `run_command` (lines 621, 712, 874, 928) and the matching keyword in the `_run_arm` callsites. The `_run_arm` parameter name (`claude_binary: str` at line 142) also gets renamed; all internal uses (lines 266, 274, 284) follow.
+
+## Test changes
+
+| Old test | Replacement |
+|---|---|
+| `test_codex_make_isolated_config_missing_auth` | `test_codex_verify_auth_raises_when_auth_missing` — same monkeypatch, calls `verify_auth()`. |
+| `test_codex_make_isolated_config_success` | Keep but rename `make_isolated_config` → `_make_isolated_config` to test the internal helper still works. Justified because `_resolve_bundle` behavior matters for `invoke()`. |
+| `test_run_command_rejects_codex_onlycode` | Update monkeypatch from `swebench.runner.CodexRunner.make_isolated_config` to `swebench.runner.CodexRunner.verify_auth`. |
+| (new) | `test_claude_verify_auth_is_noop` — instantiate `ClaudeRunner()`, call `verify_auth()`, assert it returns `None` and doesn't raise. |
+| (new) | `test_run_command_codex_baseline_succeeds_without_exec_server_bundle` — stubs `find_binary` and `verify_auth`, monkeypatches `_resolve_bundle` to raise, asserts `run_command` reaches the arm-execution stage without the bundle. |
+
+The analyze-guard test (`test_codex_jsonl_analyze_guard`) is unaffected.
+
+## Acceptance criteria
+
+| # | Criterion | How verified |
+|---|---|---|
+| AC1 | `swebench run --agent-surface codex_cli --arms baseline` does not require `exec_server/dist/exec-server.bundle.mjs` to exist at preflight time | `test_run_command_codex_baseline_succeeds_without_exec_server_bundle` |
+| AC2 | Preflight creates zero temp dirs on success | Implementation review: `verify_auth` has no `mkdtemp` call |
+| AC3 | `run_command` and `artifact_run_command` use identical preflight code (no surface-specific branching) | Implementation review: both call `runner.verify_auth()` |
+| AC4 | `CodexRunner.verify_auth()` raises `FileNotFoundError` containing `"~/.codex/auth.json"` when auth absent | `test_codex_verify_auth_raises_when_auth_missing` |
+| AC5 | `ClaudeRunner.verify_auth()` is a no-op | `test_claude_verify_auth_is_noop` |
+| AC6 | `CodexRunner.make_isolated_config` is no longer part of the public API (only `_make_isolated_config` remains) | `grep -n "\.make_isolated_config" swebench/ tests/` returns no matches outside `runner.py` |
+| AC7 | All previously passing tests still pass | `pytest -m "not integration"` |
+| AC8 | `claude_code` arm behavior is byte-for-byte unchanged | `ClaudeRunner.invoke` body is untouched (diff review) |
+
+## Risks
+
+- **Test rename churn.** Three tests are renamed or repointed. Test descriptions are updated to match.
+- **Defense-in-depth concern.** Removing the auth check from preflight does not remove it from `_make_isolated_config` — it stays there for runs that bypass preflight (none today, but cheap insurance).
+- **Future Slice 5.** When `codex_cli + onlycode` lands, the bundle requirement returns at run time inside `invoke()`. A future preflight may want to check the bundle conditionally (only when `onlycode` is in arm_list). Out of scope here.
+
+## Rollout
+
+Single commit on `fix/issue-224-codex-cli-arm-e2e`. Pushed to PR #225. No migration needed — no external callers of `make_isolated_config` exist (verified by grep).

--- a/scripts/audit_batches.py
+++ b/scripts/audit_batches.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Audit completion of D1-D5 batches across the 3 seed dirs.
+
+For each (seed, batch, instance, arm) checks for the presence of
+`<instance_id>_<arm>_run1.jsonl` and its `_test.txt` sibling under
+runs/swebench/full_run_seed_<N>/.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RUNS = ROOT / "runs" / "swebench"
+
+ARMS = ("baseline", "onlycode", "bash_only")
+SEEDS = (1, 2, 3)
+
+BATCHES: dict[str, list[str]] = {
+    "D1": [
+        "scikit-learn__scikit-learn-10427", "scikit-learn__scikit-learn-10803",
+        "scikit-learn__scikit-learn-11206", "scikit-learn__scikit-learn-11596",
+        "scikit-learn__scikit-learn-12704", "scikit-learn__scikit-learn-13013",
+        "scikit-learn__scikit-learn-13283", "scikit-learn__scikit-learn-13496",
+    ],
+    "D2": [
+        "scikit-learn__scikit-learn-13864", "scikit-learn__scikit-learn-14125",
+        "scikit-learn__scikit-learn-14710", "scikit-learn__scikit-learn-15094",
+        "scikit-learn__scikit-learn-24677", "scikit-learn__scikit-learn-25694",
+        "scikit-learn__scikit-learn-3840",
+    ],
+    "D3": [
+        "matplotlib__matplotlib-13859", "matplotlib__matplotlib-19763",
+        "matplotlib__matplotlib-21042", "matplotlib__matplotlib-22767",
+        "matplotlib__matplotlib-23088", "matplotlib__matplotlib-23476",
+        "matplotlib__matplotlib-24177", "matplotlib__matplotlib-24637",
+        "matplotlib__matplotlib-25126", "matplotlib__matplotlib-25442",
+        "matplotlib__matplotlib-25772", "matplotlib__matplotlib-26160",
+    ],
+    "D4": [
+        "pydata__xarray-2905", "pydata__xarray-3520", "pydata__xarray-4075",
+        "pydata__xarray-4629", "pydata__xarray-4911", "pydata__xarray-5455",
+        "pydata__xarray-6601", "pydata__xarray-7003",
+        "astropy__astropy-12962", "astropy__astropy-13842", "astropy__astropy-6938",
+    ],
+    "D5": [
+        "sympy__sympy-11232", "sympy__sympy-13259", "sympy__sympy-14180",
+        "sympy__sympy-15976", "sympy__sympy-17318", "sympy__sympy-19016",
+        "sympy__sympy-21596",
+        "mwaskom__seaborn-2389", "mwaskom__seaborn-2813", "mwaskom__seaborn-2946",
+        "mwaskom__seaborn-3069", "mwaskom__seaborn-3202",
+    ],
+}
+
+
+def triple_done(seed_dir: Path, instance: str, arm: str) -> bool:
+    jsonl = seed_dir / f"{instance}_{arm}_run1.jsonl"
+    test = seed_dir / f"{instance}_{arm}_run1_test.txt"
+    return jsonl.exists() and test.exists()
+
+
+def main(verbose: bool = False) -> int:
+    print(f"{'Batch':<5}  {'Seed':<6}  {'Done':>7}  {'Total':>5}  Missing")
+    print("-" * 78)
+    grand_done = grand_total = 0
+    missing_per_seed: dict[int, list[str]] = {s: [] for s in SEEDS}
+    for batch, instances in BATCHES.items():
+        total_arms = len(instances) * len(ARMS)
+        for seed in SEEDS:
+            seed_dir = RUNS / f"full_run_seed_{seed}"
+            missing: list[str] = []
+            done = 0
+            for inst in instances:
+                for arm in ARMS:
+                    if triple_done(seed_dir, inst, arm):
+                        done += 1
+                    else:
+                        missing.append(f"{inst}:{arm}")
+            grand_done += done
+            grand_total += total_arms
+            missing_per_seed[seed].extend(missing)
+            tag = "OK" if not missing else f"{len(missing)} miss"
+            print(f"{batch:<5}  seed_{seed}  {done:>3}/{total_arms:<3}  {total_arms:>5}  {tag}")
+        print()
+    print("-" * 78)
+    print(f"TOTAL: {grand_done}/{grand_total} arm-runs complete "
+          f"({grand_done * 100 // grand_total}%)")
+
+    if verbose:
+        print()
+        for seed in SEEDS:
+            miss = missing_per_seed[seed]
+            print(f"\nseed_{seed} missing ({len(miss)}):")
+            for m in miss:
+                print(f"  - {m}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(verbose="-v" in sys.argv or "--verbose" in sys.argv))

--- a/swebench/analyze/run.py
+++ b/swebench/analyze/run.py
@@ -179,6 +179,58 @@ def _analysis_root(results_dir: Path, run_id: str) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Codex JSONL guard
+# ---------------------------------------------------------------------------
+
+
+def _check_not_codex_jsonl(jsonl_path: Path) -> None:
+    """Raise NotImplementedError if *jsonl_path* looks like a Codex transcript.
+
+    Two-pass detection strategy:
+
+    1. **Meta-line check (preferred):** the harness writes the first line as a
+       JSON object. If it contains ``"agent_surface": "codex_cli"`` the file is
+       unambiguously a Codex transcript.
+    2. **Event-shape fallback:** if the meta line is absent or inconclusive,
+       peek at the first non-meta data line. Codex emits events whose ``type``
+       field starts with ``"turn."`` (e.g. ``"turn.started"``). Claude events
+       do not use this prefix. A single match is enough to raise.
+
+    The error message deliberately contains ``"Codex JSONL not yet supported"``
+    so callers and tests can assert on the substring.
+    """
+    _CODEX_MSG = "Codex JSONL not yet supported by analyze pipeline — see Slice 6."
+    try:
+        with open(jsonl_path) as fh:
+            first_line = fh.readline()
+            second_line = fh.readline()
+    except OSError:
+        return  # let downstream handle unreadable files
+
+    # Pass 1: meta-line agent_surface field
+    if first_line.strip():
+        try:
+            meta = json.loads(first_line)
+            if isinstance(meta, dict) and meta.get("agent_surface") == "codex_cli":
+                raise NotImplementedError(_CODEX_MSG)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # Pass 2: event-shape fallback — check first non-empty line after meta
+    for raw in (second_line,):
+        if not raw.strip():
+            continue
+        try:
+            evt = json.loads(raw)
+            if isinstance(evt, dict):
+                evt_type = evt.get("type", "")
+                if isinstance(evt_type, str) and evt_type.startswith("turn."):
+                    raise NotImplementedError(_CODEX_MSG)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+
+# ---------------------------------------------------------------------------
 # Stage 1: mechanical
 # ---------------------------------------------------------------------------
 
@@ -203,6 +255,7 @@ def _stage_mechanical(
 
     metrics: list[dict] = []
     for jsonl in logs:
+        _check_not_codex_jsonl(jsonl)  # raises NotImplementedError on Codex format
         parsed = _parse_log_ref(jsonl)
         log_ref = _synthesize_log_ref(parsed, jsonl)
         sidecar = mech_dir / f"{log_ref}.json"

--- a/swebench/artifact_cli.py
+++ b/swebench/artifact_cli.py
@@ -30,7 +30,7 @@ from swebench.artifact_run import (
     run_artifact_arm,
     run_dir_for,
 )
-from swebench.runner import make_runner
+from swebench.runner import CODEX_NOT_IMPLEMENTED_MSG, make_runner
 
 
 @click.group()
@@ -148,6 +148,13 @@ def artifact_run_command(
         arm_list = list(ARMS)
     else:
         arm_list = [arms]
+
+    # Reject codex_cli + code_only (not yet implemented)
+    if agent_surface == "codex_cli" and "code_only" in arm_list:
+        click.echo(
+            f"ERROR: codex_cli + code_only is {CODEX_NOT_IMPLEMENTED_MSG}", err=True
+        )
+        raise SystemExit(1)
 
     mcp_path = mcp_config
     if mcp_path is None:

--- a/swebench/artifact_cli.py
+++ b/swebench/artifact_cli.py
@@ -139,6 +139,7 @@ def artifact_run_command(
     try:
         runner = make_runner(agent_surface)
         binary = runner.find_binary()
+        runner.verify_auth()
     except (ValueError, FileNotFoundError) as exc:
         click.echo(f"ERROR: {exc}", err=True)
         raise SystemExit(1)

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -139,7 +139,7 @@ def _run_arm(
     repo_dir: str,
     venv_dir: str,
     results_dir: str,
-    claude_binary: str,
+    agent_binary: str,
     mcp_config_path: str,
     root: Path,
     persistent_kernel: bool = True,
@@ -263,7 +263,7 @@ def _run_arm(
 
     start_time = time.time()
 
-    agent_version = _runner.get_version(claude_binary)
+    agent_version = _runner.get_version(agent_binary)
     with open(result_file, "w") as _meta_f:
         _meta_f.write(json.dumps({
             "type": "meta",
@@ -271,7 +271,7 @@ def _run_arm(
             "arm": arm,
             "run": run_idx,
             "agent_surface": _runner.surface,
-            "agent_binary": claude_binary,
+            "agent_binary": agent_binary,
             "agent_version": agent_version,
         }) + "\n")
 
@@ -281,7 +281,7 @@ def _run_arm(
         system_prompt="You are a helpful assistant.",
         tools_flags=tools_flags,
         result_file=result_file,
-        binary=claude_binary,
+        binary=agent_binary,
         mcp_config_path=effective_mcp_config,
     )
 
@@ -618,9 +618,8 @@ def run_command(
     # Create runner and resolve binary (preflight)
     try:
         runner = make_runner(agent_surface)
-        claude_binary = runner.find_binary()
-        if agent_surface == "codex_cli":
-            runner.make_isolated_config()  # verify auth early; discard result
+        agent_binary = runner.find_binary()
+        runner.verify_auth()
     except (ValueError, FileNotFoundError) as e:
         click.echo(f"ERROR: {e}", err=True)
         raise SystemExit(1)
@@ -709,8 +708,8 @@ def run_command(
     click.echo(f"Resume: {resume}")
     click.echo(f"Output dir: {results_dir}")
     click.echo(f"Agent surface: {agent_surface}")
-    click.echo(f"Agent binary: {claude_binary}")
-    agent_version = runner.get_version(claude_binary)
+    click.echo(f"Agent binary: {agent_binary}")
+    agent_version = runner.get_version(agent_binary)
     click.echo(f"Agent version: {agent_version}")
     click.echo()
 
@@ -871,7 +870,7 @@ def run_command(
                         repo_dir=task.repo_dir,
                         venv_dir=task.venv_dir,
                         results_dir=str(results_dir),
-                        claude_binary=claude_binary,
+                        agent_binary=agent_binary,
                         mcp_config_path=mcp_config_path,
                         root=root,
                         persistent_kernel=persistent_kernel,
@@ -925,7 +924,7 @@ def run_command(
                         repo_dir=task.repo_dir,
                         venv_dir=task.venv_dir,
                         results_dir=str(results_dir),
-                        claude_binary=claude_binary,
+                        agent_binary=agent_binary,
                         mcp_config_path=mcp_config_path,
                         root=root,
                         persistent_kernel=persistent_kernel,

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -34,8 +34,6 @@ from swebench.harness import (
     _venv_kwargs,
     apply_test_patch,
     clone_repo,
-    find_claude_binary,
-    get_claude_version,
     git_reset,
     run_claude,
     run_tests,
@@ -43,7 +41,7 @@ from swebench.harness import (
     strip_git_history,
 )
 from swebench.models import Problem
-from swebench.runner import BLOCKED_BUILTINS, AgentRunner, ClaudeRunner
+from swebench.runner import BLOCKED_BUILTINS, AgentRunner, ClaudeRunner, CODEX_NOT_IMPLEMENTED_MSG, make_runner
 
 
 def _mcp_config_without_persistent_kernel(
@@ -582,6 +580,14 @@ def _cleanup_stale_overlays(
         "PASS or FAIL; otherwise it is re-run."
     ),
 )
+@click.option(
+    "--agent-surface",
+    "agent_surface",
+    type=click.Choice(["claude_code", "codex_cli"]),
+    default="claude_code",
+    show_default=True,
+    help="Agent surface to use for running evaluations.",
+)
 def run_command(
     filter_ids: str | None,
     arms: str,
@@ -593,6 +599,7 @@ def run_command(
     shuffle_arms: bool,
     output_dir: str | None,
     resume: bool,
+    agent_surface: str,
 ) -> None:
     """Run SWE-bench evaluation arms on problem instances."""
     if parallel < 1:
@@ -608,10 +615,13 @@ def run_command(
     results_dir.mkdir(parents=True, exist_ok=True)
     os.makedirs(clone_base, exist_ok=True)
 
-    # Find claude binary
+    # Create runner and resolve binary (preflight)
     try:
-        claude_binary = find_claude_binary()
-    except FileNotFoundError as e:
+        runner = make_runner(agent_surface)
+        claude_binary = runner.find_binary()
+        if agent_surface == "codex_cli":
+            runner.make_isolated_config()  # verify auth early; discard result
+    except (ValueError, FileNotFoundError) as e:
         click.echo(f"ERROR: {e}", err=True)
         raise SystemExit(1)
 
@@ -640,6 +650,13 @@ def run_command(
         arm_list.append("onlycode")
     if arms in ("bash_only", "all"):
         arm_list.append("bash_only")
+
+    # Reject codex_cli + onlycode (not yet implemented)
+    if agent_surface == "codex_cli" and "onlycode" in arm_list:
+        click.echo(
+            f"ERROR: codex_cli + onlycode is {CODEX_NOT_IMPLEMENTED_MSG}", err=True
+        )
+        raise SystemExit(1)
 
     # --- Environment pre-flight checks ------------------------------------------
     env_errors: list[str] = []
@@ -691,9 +708,10 @@ def run_command(
     click.echo(f"Use cache: {use_cache}")
     click.echo(f"Resume: {resume}")
     click.echo(f"Output dir: {results_dir}")
-    click.echo(f"Claude binary: {claude_binary}")
-    claude_version = get_claude_version(claude_binary)
-    click.echo(f"Claude version: {claude_version}")
+    click.echo(f"Agent surface: {agent_surface}")
+    click.echo(f"Agent binary: {claude_binary}")
+    agent_version = runner.get_version(claude_binary)
+    click.echo(f"Agent version: {agent_version}")
     click.echo()
 
     # --- Cache backend selection (only relevant when --use-cache) ---------------
@@ -858,6 +876,7 @@ def run_command(
                         root=root,
                         persistent_kernel=persistent_kernel,
                         needs_editable_reinstall=task.needs_editable_reinstall,
+                        runner=runner,
                     )
                 except BaseException:
                     _teardown_all_overlays()
@@ -912,6 +931,7 @@ def run_command(
                         persistent_kernel=persistent_kernel,
                         log_buffer=buf,
                         needs_editable_reinstall=task.needs_editable_reinstall,
+                        runner=runner,
                     )
                 except Exception as exc:
                     stderr_detail = getattr(exc, "stderr", None)

--- a/swebench/runner.py
+++ b/swebench/runner.py
@@ -38,6 +38,9 @@ from typing import ClassVar
 # Shared constants
 # ---------------------------------------------------------------------------
 
+# Imported by run.py and artifact_cli.py so rejection error wording is consistent.
+CODEX_NOT_IMPLEMENTED_MSG = "not yet implemented — see Slice 5"
+
 # Built-in Claude tools blocked for onlycode / code_only arms.
 # Canonical single source of truth — imported by run.py and artifact_run.py.
 BLOCKED_BUILTINS = (
@@ -252,6 +255,36 @@ class CodexRunner(AgentRunner):
             raise ValueError(f"Unknown arm for CodexRunner: {arm!r}")
         return []
 
+    def make_isolated_config(
+        self,
+        mcp_config_path: str | None = None,
+        cwd: str = ".",
+    ) -> str:
+        """Create an isolated CODEX_HOME directory for a single run.
+
+        Copies ``~/.codex/auth.json`` into a fresh temp dir and writes
+        ``config.toml``.  Raises ``FileNotFoundError`` if the auth file is
+        absent — callers must ensure the user is authenticated before
+        invoking Codex.
+
+        Returns the path to the isolated config directory.  The caller is
+        responsible for removing it (``shutil.rmtree``) after the run.
+        """
+        src = os.path.expanduser("~/.codex/auth.json")
+        if not os.path.isfile(src):
+            raise FileNotFoundError(
+                "~/.codex/auth.json not found — Codex CLI requires a valid auth token."
+            )
+
+        cfg_dir = tempfile.mkdtemp(prefix="codex-eval-")
+        shutil.copy2(src, cfg_dir)
+
+        bundle_path = self._resolve_bundle(mcp_config_path)
+        persistent = os.environ.get("ONLYCODES_PERSISTENT_KERNEL", "0")
+        _write_codex_config(cfg_dir, bundle_path, cwd, persistent)
+
+        return cfg_dir
+
     def invoke(
         self,
         *,
@@ -264,18 +297,8 @@ class CodexRunner(AgentRunner):
         mcp_config_path: str | None = None,
     ) -> None:
         """Run codex exec with an isolated CODEX_HOME containing auth + MCP config."""
-        cfg_dir = tempfile.mkdtemp(prefix="codex-eval-")
+        cfg_dir = self.make_isolated_config(mcp_config_path=mcp_config_path, cwd=cwd)
         try:
-            # Copy auth credentials into isolated dir.
-            src = os.path.expanduser("~/.codex/auth.json")
-            if os.path.isfile(src):
-                shutil.copy2(src, cfg_dir)
-
-            # Write per-run config.toml.
-            bundle_path = self._resolve_bundle(mcp_config_path)
-            persistent = os.environ.get("ONLYCODES_PERSISTENT_KERNEL", "0")
-            _write_codex_config(cfg_dir, bundle_path, cwd, persistent)
-
             cmd = [
                 binary, "exec",
                 "--ephemeral",

--- a/swebench/runner.py
+++ b/swebench/runner.py
@@ -374,10 +374,11 @@ def _write_codex_config(
     as a string directly.
     """
     toml = (
+        'web_search = "disabled"\n'
+        "\n"
         "[features]\n"
         "shell_tool = false\n"
         "apply_patch_freeform = false\n"
-        'web_search_mode = "disabled"\n'
         "\n"
         "[mcp_servers.codebox]\n"
         'command = "node"\n'

--- a/swebench/runner.py
+++ b/swebench/runner.py
@@ -68,6 +68,15 @@ class AgentRunner(ABC):
         """Return path to the agent binary, or raise FileNotFoundError."""
 
     @abstractmethod
+    def verify_auth(self) -> None:
+        """Raise FileNotFoundError if required auth artifacts are missing.
+
+        Called by preflight code. Must have no side effects (no temp dirs,
+        no file copies). Returning ``None`` means auth is plausibly valid;
+        it does not guarantee a live session.
+        """
+
+    @abstractmethod
     def get_version(self, binary: str) -> str:
         """Return a version string for the binary, or 'unknown'."""
 
@@ -133,6 +142,11 @@ class ClaudeRunner(AgentRunner):
         raise FileNotFoundError(
             "claude binary not found. Set CLAUDE= or install Claude Code."
         )
+
+    def verify_auth(self) -> None:
+        # Claude credentials are copied into a temp config dir inside invoke();
+        # surface-level pre-check is intentionally a no-op.
+        return
 
     def get_version(self, binary: str) -> str:
         try:
@@ -240,6 +254,13 @@ class CodexRunner(AgentRunner):
             "codex binary not found. Install with: npm install -g @openai/codex"
         )
 
+    def verify_auth(self) -> None:
+        src = os.path.expanduser("~/.codex/auth.json")
+        if not os.path.isfile(src):
+            raise FileNotFoundError(
+                "~/.codex/auth.json not found — Codex CLI requires a valid auth token."
+            )
+
     def get_version(self, binary: str) -> str:
         try:
             proc = subprocess.run(
@@ -255,26 +276,23 @@ class CodexRunner(AgentRunner):
             raise ValueError(f"Unknown arm for CodexRunner: {arm!r}")
         return []
 
-    def make_isolated_config(
+    def _make_isolated_config(
         self,
         mcp_config_path: str | None = None,
         cwd: str = ".",
     ) -> str:
         """Create an isolated CODEX_HOME directory for a single run.
 
-        Copies ``~/.codex/auth.json`` into a fresh temp dir and writes
-        ``config.toml``.  Raises ``FileNotFoundError`` if the auth file is
-        absent — callers must ensure the user is authenticated before
-        invoking Codex.
+        Private helper of ``invoke()``. Copies ``~/.codex/auth.json`` into
+        a fresh temp dir and writes ``config.toml``. Re-runs the auth check
+        as defense-in-depth; preflight callers should use ``verify_auth()``
+        instead, which has no side effects.
 
-        Returns the path to the isolated config directory.  The caller is
-        responsible for removing it (``shutil.rmtree``) after the run.
+        Returns the path to the isolated config directory; ``invoke()`` is
+        responsible for ``shutil.rmtree``.
         """
+        self.verify_auth()
         src = os.path.expanduser("~/.codex/auth.json")
-        if not os.path.isfile(src):
-            raise FileNotFoundError(
-                "~/.codex/auth.json not found — Codex CLI requires a valid auth token."
-            )
 
         cfg_dir = tempfile.mkdtemp(prefix="codex-eval-")
         shutil.copy2(src, cfg_dir)
@@ -297,7 +315,7 @@ class CodexRunner(AgentRunner):
         mcp_config_path: str | None = None,
     ) -> None:
         """Run codex exec with an isolated CODEX_HOME containing auth + MCP config."""
-        cfg_dir = self.make_isolated_config(mcp_config_path=mcp_config_path, cwd=cwd)
+        cfg_dir = self._make_isolated_config(mcp_config_path=mcp_config_path, cwd=cwd)
         try:
             cmd = [
                 binary, "exec",

--- a/tests/test_artifact_cli.py
+++ b/tests/test_artifact_cli.py
@@ -80,6 +80,9 @@ class _FakeRunner:
     def find_binary(self):
         return "/bin/true"
 
+    def verify_auth(self):
+        return
+
     def get_version(self, _binary):
         return "fake-runner-test"
 

--- a/tests/test_artifact_run.py
+++ b/tests/test_artifact_run.py
@@ -75,6 +75,9 @@ class FakeRunner(AgentRunner):
     def find_binary(self) -> str:
         return "/bin/true"
 
+    def verify_auth(self) -> None:
+        return
+
     def get_version(self, binary: str) -> str:
         return "fake-runner-1.0.0"
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -267,3 +267,219 @@ def test_codex_resolve_bundle_raises_when_not_found(tmp_path, monkeypatch):
     mcp.write_text(json.dumps({"mcpServers": {"codebox": {"args": ["/no/such/bundle.mjs"]}}}))
     with pytest.raises(FileNotFoundError, match="exec-server bundle not found"):
         CodexRunner()._resolve_bundle(str(mcp))
+
+
+# ---------------------------------------------------------------------------
+# CodexRunner — find_binary raises when codex not on PATH
+# ---------------------------------------------------------------------------
+
+def test_codex_find_binary_missing(monkeypatch):
+    """CodexRunner.find_binary() must raise FileNotFoundError with install hint."""
+    monkeypatch.setattr("swebench.runner.shutil.which", lambda _name: None)
+    with pytest.raises(FileNotFoundError, match="npm install -g @openai/codex"):
+        CodexRunner().find_binary()
+
+
+# ---------------------------------------------------------------------------
+# CodexRunner — make_isolated_config raises when auth.json is absent
+# ---------------------------------------------------------------------------
+
+def test_codex_make_isolated_config_missing_auth(monkeypatch):
+    """make_isolated_config() must raise FileNotFoundError when ~/.codex/auth.json is absent."""
+    monkeypatch.setattr("swebench.runner.os.path.isfile", lambda _p: False)
+    with pytest.raises(FileNotFoundError, match=r"~/\.codex/auth\.json"):
+        CodexRunner().make_isolated_config()
+
+
+def test_codex_make_isolated_config_success(tmp_path, monkeypatch):
+    """make_isolated_config() returns a dir containing auth.json when the source exists."""
+    import shutil as _shutil
+
+    fake_home = tmp_path / "home"
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True)
+    auth_src = codex_dir / "auth.json"
+    auth_src.write_text('{"token": "test-token"}')
+
+    # Patch os.path.expanduser so "~/.codex/auth.json" resolves to our fake home.
+    real_expanduser = os.path.expanduser
+
+    def fake_expanduser(path: str) -> str:
+        if path.startswith("~/"):
+            return str(fake_home / path[2:])
+        return real_expanduser(path)
+
+    monkeypatch.setattr("swebench.runner.os.path.expanduser", fake_expanduser)
+
+    # _resolve_bundle will look for a bundle; redirect Path.is_file so the
+    # fallback candidate appears missing, then supply a fake bundle via mcp_config.
+    bundle = tmp_path / "bundle.mjs"
+    bundle.write_text("// fake")
+    mcp_json = tmp_path / "mcp.json"
+    mcp_json.write_text(json.dumps({
+        "mcpServers": {"codebox": {"args": [str(bundle)]}}
+    }))
+
+    cfg_dir = CodexRunner().make_isolated_config(
+        mcp_config_path=str(mcp_json),
+        cwd=str(tmp_path),
+    )
+    try:
+        assert Path(cfg_dir).is_dir()
+        assert (Path(cfg_dir) / "auth.json").is_file()
+    finally:
+        _shutil.rmtree(cfg_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# run_command — rejects codex_cli + onlycode
+# ---------------------------------------------------------------------------
+
+def test_run_command_rejects_codex_onlycode(tmp_path, monkeypatch):
+    """swebench run --agent-surface codex_cli --arms onlycode must exit 1."""
+    from click.testing import CliRunner
+    from swebench.cli import cli
+
+    # Prevent real binary discovery / auth check from running before the guard.
+    # The rejection guard in run_command fires after find_binary() + make_isolated_config(),
+    # so we stub both to no-ops. If the guard fires first this monkeypatch is unused —
+    # either way the test is correct.
+    monkeypatch.setattr(
+        "swebench.runner.CodexRunner.find_binary",
+        lambda self: "/usr/bin/codex",
+    )
+    monkeypatch.setattr(
+        "swebench.runner.CodexRunner.make_isolated_config",
+        lambda self, **kw: tmp_path / "cfg",
+    )
+    # Prevent the problems-dir check from failing on a clean env.
+    problems_dir = tmp_path / "problems" / "swe"
+    problems_dir.mkdir(parents=True)
+    (problems_dir / "dummy.yaml").write_text(
+        "instance_id: dummy\nrepo: r\nbase_commit: abc\n"
+        "problem_statement: p\ntest_cmd: pytest\n"
+    )
+    monkeypatch.setattr("swebench.run.repo_root", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["run", "--agent-surface", "codex_cli", "--arms", "onlycode",
+         "--output-dir", str(tmp_path / "out")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1, f"Expected exit 1, got {result.exit_code}. output={result.output}"
+    assert "not yet implemented" in (result.output or ""), (
+        f"Expected 'not yet implemented' in output. Got: {result.output!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# artifact run_command — rejects codex_cli + code_only
+# ---------------------------------------------------------------------------
+
+def test_artifact_run_command_rejects_codex_code_only(tmp_path, monkeypatch):
+    """artifact run --agent-surface codex_cli --arms code_only must exit 1."""
+    from click.testing import CliRunner
+    from swebench.cli import cli
+
+    # Stub binary discovery so preflight doesn't fail on missing codex binary.
+    monkeypatch.setattr(
+        "swebench.runner.CodexRunner.find_binary",
+        lambda self: "/usr/bin/codex",
+    )
+    # Provide a minimal task so load_tasks doesn't fail.
+    tasks_dir = tmp_path / "problems" / "artifact" / "enumeration" / "dummy_task"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "task.yaml").write_text(
+        "instance_id: enumeration__dummy_task\n"
+        "category: enumeration\n"
+        "difficulty: easy\n"
+        "problem_statement: |\n  Write code.\n"
+        "workspace_dir: workspace\n"
+        "output_artifact: answer.txt\n"
+        "hidden_grader: grader/hidden.py\n"
+        "reference_output: grader/reference_output.txt\n"
+        "execution_budget:\n"
+        "  max_code_runs: 0\n"
+        "  max_wall_seconds: 0\n"
+    )
+    (tasks_dir / "workspace").mkdir()
+    grader_dir = tasks_dir / "grader"
+    grader_dir.mkdir()
+    (grader_dir / "hidden.py").write_text("def grade(d): pass\n")
+    (grader_dir / "reference_output.txt").write_text("42\n")
+    monkeypatch.setattr("swebench.artifact_cli.repo_root", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "artifact", "run",
+            "--agent-surface", "codex_cli",
+            "--arms", "code_only",
+            "--tasks-dir", str(tmp_path / "problems" / "artifact"),
+            "--output-dir", str(tmp_path / "out"),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1, (
+        f"Expected exit 1, got {result.exit_code}. output={result.output}"
+    )
+    assert "not yet implemented" in (result.output or ""), (
+        f"Expected 'not yet implemented' in output. Got: {result.output!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# analyze pathology — rejects Codex JSONL
+# ---------------------------------------------------------------------------
+
+def test_codex_jsonl_analyze_guard(tmp_path):
+    """pathology command must reject a results dir containing Codex JSONL."""
+    from click.testing import CliRunner
+    from swebench.cli import cli
+
+    # Write a minimal JSONL whose meta line identifies the surface as codex_cli.
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    jsonl = results_dir / "dummy__baseline_run1.jsonl"
+    jsonl.write_text(
+        json.dumps({"type": "meta", "agent_surface": "codex_cli", "instance_id": "dummy"}) + "\n"
+        + json.dumps({"type": "turn.started"}) + "\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "analyze", "pathology",
+            "--results-dir", str(results_dir),
+            "--dry-run",
+            "--stage", "mechanical",
+        ],
+        catch_exceptions=True,
+    )
+    # The guard should either raise NotImplementedError (caught as exit 1)
+    # or exit non-zero with the expected message.
+    output = result.output or ""
+    if result.exception is not None:
+        assert isinstance(result.exception, (NotImplementedError, SystemExit)), (
+            f"Unexpected exception type: {type(result.exception)}: {result.exception}"
+        )
+        if isinstance(result.exception, NotImplementedError):
+            assert "Codex JSONL not yet supported" in str(result.exception), (
+                f"Wrong NotImplementedError message: {result.exception}"
+            )
+        else:
+            # SystemExit — message may be in output or exit code signals failure
+            assert "Codex JSONL not yet supported" in output or result.exit_code != 0, (
+                f"Expected 'Codex JSONL not yet supported' or non-zero exit. "
+                f"Got: exit={result.exit_code}, output={output!r}"
+            )
+    else:
+        # No exception — must have exited non-zero with the right message
+        assert result.exit_code != 0 and "Codex JSONL not yet supported" in output, (
+            f"Expected non-zero exit + 'Codex JSONL not yet supported'. "
+            f"Got: exit={result.exit_code}, output={output!r}"
+        )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -182,7 +182,7 @@ def test_write_codex_config_creates_valid_toml(tmp_path):
     content = toml_path.read_text()
     assert "shell_tool = false" in content
     assert "apply_patch_freeform = false" in content
-    assert 'web_search_mode = "disabled"' in content
+    assert 'web_search = "disabled"' in content
     assert "/path/bundle.mjs" in content
     assert "/scratch" in content
     assert 'ONLYCODES_PERSISTENT_KERNEL = "0"' in content

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -281,18 +281,53 @@ def test_codex_find_binary_missing(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# CodexRunner — make_isolated_config raises when auth.json is absent
+# verify_auth — surface-agnostic preflight check
 # ---------------------------------------------------------------------------
 
-def test_codex_make_isolated_config_missing_auth(monkeypatch):
-    """make_isolated_config() must raise FileNotFoundError when ~/.codex/auth.json is absent."""
+def test_claude_verify_auth_is_noop():
+    """ClaudeRunner.verify_auth() returns None without raising, regardless of env."""
+    from swebench.runner import ClaudeRunner
+    assert ClaudeRunner().verify_auth() is None
+
+
+def test_codex_verify_auth_raises_when_auth_missing(monkeypatch):
+    """CodexRunner.verify_auth() must raise FileNotFoundError when ~/.codex/auth.json is absent."""
     monkeypatch.setattr("swebench.runner.os.path.isfile", lambda _p: False)
     with pytest.raises(FileNotFoundError, match=r"~/\.codex/auth\.json"):
-        CodexRunner().make_isolated_config()
+        CodexRunner().verify_auth()
 
+
+def test_codex_verify_auth_ok_when_auth_present(tmp_path, monkeypatch):
+    """CodexRunner.verify_auth() returns None and creates no temp dirs when auth exists."""
+    fake_home = tmp_path / "home"
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "auth.json").write_text('{"token": "test-token"}')
+
+    real_expanduser = os.path.expanduser
+
+    def fake_expanduser(path: str) -> str:
+        if path.startswith("~/"):
+            return str(fake_home / path[2:])
+        return real_expanduser(path)
+
+    monkeypatch.setattr("swebench.runner.os.path.expanduser", fake_expanduser)
+
+    # Sentinel: ensure no temp dir is created during verify_auth.
+    def fail_mkdtemp(*_a, **_kw):
+        raise AssertionError("verify_auth must not create a temp dir")
+
+    monkeypatch.setattr("swebench.runner.tempfile.mkdtemp", fail_mkdtemp)
+
+    assert CodexRunner().verify_auth() is None
+
+
+# ---------------------------------------------------------------------------
+# CodexRunner — _make_isolated_config (internal helper) still works end-to-end
+# ---------------------------------------------------------------------------
 
 def test_codex_make_isolated_config_success(tmp_path, monkeypatch):
-    """make_isolated_config() returns a dir containing auth.json when the source exists."""
+    """_make_isolated_config() returns a dir containing auth.json when source exists."""
     import shutil as _shutil
 
     fake_home = tmp_path / "home"
@@ -311,8 +346,7 @@ def test_codex_make_isolated_config_success(tmp_path, monkeypatch):
 
     monkeypatch.setattr("swebench.runner.os.path.expanduser", fake_expanduser)
 
-    # _resolve_bundle will look for a bundle; redirect Path.is_file so the
-    # fallback candidate appears missing, then supply a fake bundle via mcp_config.
+    # _resolve_bundle will look for a bundle; supply a fake bundle via mcp_config.
     bundle = tmp_path / "bundle.mjs"
     bundle.write_text("// fake")
     mcp_json = tmp_path / "mcp.json"
@@ -320,7 +354,7 @@ def test_codex_make_isolated_config_success(tmp_path, monkeypatch):
         "mcpServers": {"codebox": {"args": [str(bundle)]}}
     }))
 
-    cfg_dir = CodexRunner().make_isolated_config(
+    cfg_dir = CodexRunner()._make_isolated_config(
         mcp_config_path=str(mcp_json),
         cwd=str(tmp_path),
     )
@@ -329,6 +363,55 @@ def test_codex_make_isolated_config_success(tmp_path, monkeypatch):
         assert (Path(cfg_dir) / "auth.json").is_file()
     finally:
         _shutil.rmtree(cfg_dir, ignore_errors=True)
+
+
+def test_run_command_codex_baseline_skips_bundle_check(tmp_path, monkeypatch):
+    """Preflight for codex_cli + baseline must not require the exec-server bundle (F-1)."""
+    from click.testing import CliRunner
+    from swebench.cli import cli
+    from swebench.runner import CodexRunner
+
+    monkeypatch.setattr(
+        "swebench.runner.CodexRunner.find_binary",
+        lambda self: "/usr/bin/codex",
+    )
+    # verify_auth must be a no-op (real test of: preflight does not touch the bundle).
+    monkeypatch.setattr(
+        "swebench.runner.CodexRunner.verify_auth",
+        lambda self: None,
+    )
+    # If preflight wrongly tries to resolve the bundle, this blows up loudly.
+    def _bundle_should_not_be_touched(self, _mcp):
+        raise AssertionError(
+            "preflight must not call _resolve_bundle for baseline arm"
+        )
+    monkeypatch.setattr(
+        "swebench.runner.CodexRunner._resolve_bundle",
+        _bundle_should_not_be_touched,
+    )
+
+    # Empty problems dir so run_command exits with "No problem files found"
+    # *after* preflight succeeds — verifies preflight passes without bundle.
+    problems_dir = tmp_path / "problems" / "swe"
+    problems_dir.mkdir(parents=True)
+    monkeypatch.setattr("swebench.run.repo_root", lambda: tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "run",
+            "--agent-surface", "codex_cli",
+            "--arms", "baseline",
+            "--output-dir", str(tmp_path / "out"),
+        ],
+        catch_exceptions=False,
+    )
+    # Preflight succeeded; failure now comes from empty problems dir, not from bundle.
+    assert result.exit_code == 1
+    assert "No problem files found" in (result.output or ""), (
+        f"expected post-preflight failure, got: {result.output!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -341,16 +424,15 @@ def test_run_command_rejects_codex_onlycode(tmp_path, monkeypatch):
     from swebench.cli import cli
 
     # Prevent real binary discovery / auth check from running before the guard.
-    # The rejection guard in run_command fires after find_binary() + make_isolated_config(),
-    # so we stub both to no-ops. If the guard fires first this monkeypatch is unused —
-    # either way the test is correct.
+    # The rejection guard in run_command fires after find_binary() + verify_auth(),
+    # so we stub both to no-ops.
     monkeypatch.setattr(
         "swebench.runner.CodexRunner.find_binary",
         lambda self: "/usr/bin/codex",
     )
     monkeypatch.setattr(
-        "swebench.runner.CodexRunner.make_isolated_config",
-        lambda self, **kw: tmp_path / "cfg",
+        "swebench.runner.CodexRunner.verify_auth",
+        lambda self: None,
     )
     # Prevent the problems-dir check from failing on a clean env.
     problems_dir = tmp_path / "problems" / "swe"
@@ -383,10 +465,14 @@ def test_artifact_run_command_rejects_codex_code_only(tmp_path, monkeypatch):
     from click.testing import CliRunner
     from swebench.cli import cli
 
-    # Stub binary discovery so preflight doesn't fail on missing codex binary.
+    # Stub binary discovery + auth so preflight doesn't fail on missing codex / auth.json.
     monkeypatch.setattr(
         "swebench.runner.CodexRunner.find_binary",
         lambda self: "/usr/bin/codex",
+    )
+    monkeypatch.setattr(
+        "swebench.runner.CodexRunner.verify_auth",
+        lambda self: None,
     )
     # Provide a minimal task so load_tasks doesn't fail.
     tasks_dir = tmp_path / "problems" / "artifact" / "enumeration" / "dummy_task"

--- a/tests/test_runner_codex_integration.py
+++ b/tests/test_runner_codex_integration.py
@@ -1,0 +1,76 @@
+"""Integration smoke test for CodexRunner against a real codex binary.
+
+Skipped automatically if:
+- ``codex`` is not on PATH, OR
+- ``~/.codex/auth.json`` is absent (user not authenticated).
+
+Run with: pytest -m integration tests/test_runner_codex_integration.py
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from swebench.runner import CodexRunner
+
+
+@pytest.mark.integration
+def test_codex_real_invocation(tmp_path):
+    """CodexRunner.invoke() produces a non-empty, all-valid-JSON JSONL log."""
+    # --- Preflight: skip if environment is not ready --------------------------
+    if shutil.which("codex") is None:
+        pytest.skip("codex binary not found on PATH — skipping integration test")
+
+    auth_path = Path.home() / ".codex" / "auth.json"
+    if not auth_path.is_file():
+        pytest.skip(
+            "~/.codex/auth.json not found — Codex CLI not authenticated; "
+            "skipping integration test"
+        )
+
+    # --- Setup ----------------------------------------------------------------
+    runner = CodexRunner()
+    binary = runner.find_binary()
+
+    result_file = tmp_path / "agent.jsonl"
+    result_file.touch()
+
+    prompt = "Just print the string hello and exit. Do nothing else."
+
+    # --- Invoke ---------------------------------------------------------------
+    runner.invoke(
+        prompt=prompt,
+        cwd=str(tmp_path),
+        system_prompt="You are a helpful assistant.",
+        tools_flags=[],
+        result_file=str(result_file),
+        binary=binary,
+        mcp_config_path=None,
+    )
+
+    # --- Assertions -----------------------------------------------------------
+    content = result_file.read_text()
+    assert content.strip(), "JSONL log must be non-empty after a codex invocation"
+
+    lines = [ln for ln in content.splitlines() if ln.strip()]
+    assert lines, "JSONL log must contain at least one non-blank line"
+
+    for i, line in enumerate(lines):
+        try:
+            json.loads(line)
+        except json.JSONDecodeError as exc:
+            pytest.fail(
+                f"Line {i + 1} of the JSONL log is not valid JSON: {exc}\n"
+                f"Line content: {line!r}"
+            )
+
+    # --- Metadata extraction --------------------------------------------------
+    _cost, turns = runner.extract_metadata(result_file)
+    assert turns is not None, (
+        "extract_metadata() must return a non-None turn count after a real run. "
+        f"JSONL content:\n{content}"
+    )


### PR DESCRIPTION
Closes #224

## What changed

This PR (Slice 3 of epic #217) wires `--agent-surface codex_cli` through the SWE-bench `run` command end-to-end for the unrestricted arms (`baseline` on SWE-bench, `tool_rich` on artifact). It also hardens `CodexRunner` with a pre-flight auth check, adds consistent rejection guards for not-yet-implemented arm combinations, and plants a loud-failure guard in the `analyze` pipeline so Codex transcripts are never silently misparsed as Claude output. Six new unit tests and one `@integration` test cover all new behaviour; all 514 non-integration tests pass.

## Implementation walkthrough

### `swebench/runner.py` — new public method `CodexRunner.make_isolated_config()`

Previously, `CodexRunner.invoke()` handled auth copying and `config.toml` writing inline, and silently skipped the copy if `~/.codex/auth.json` was absent. This PR extracts that logic into `make_isolated_config(mcp_config_path, cwd) -> str`, which:

1. Calls `os.path.isfile(os.path.expanduser("~/.codex/auth.json"))` and **raises `FileNotFoundError`** (with the literal string `"~/.codex/auth.json not found — Codex CLI requires a valid auth token."`) if the file is missing — replacing the previous silent skip.
2. Creates a `tempfile.mkdtemp(prefix="codex-eval-")` dir, copies `auth.json` into it, and calls `_write_codex_config()` to emit `config.toml`.
3. Returns the path to the isolated config directory; the caller (`invoke()`) is responsible for `shutil.rmtree` on exit.

`invoke()` is now a thin wrapper that calls `make_isolated_config()` and proceeds. The shared constant `CODEX_NOT_IMPLEMENTED_MSG = "not yet implemented — see Slice 5"` is also added here and imported by `run.py` and `artifact_cli.py` to keep rejection error wording consistent across modules.

### `swebench/run.py` — `--agent-surface` Click option and runner plumbing

A new `@click.option("--agent-surface", type=click.Choice(["claude_code", "codex_cli"]), default="claude_code")` is added to `run_command`. The pre-flight block that previously called `find_claude_binary()` is replaced with:

```python
runner = make_runner(agent_surface)
claude_binary = runner.find_binary()
if agent_surface == "codex_cli":
    runner.make_isolated_config()   # verify auth early; result discarded
```

Both `find_binary()` (binary missing) and `make_isolated_config()` (auth absent) raise `FileNotFoundError`; the existing `except (ValueError, FileNotFoundError)` handler surfaces them as `SystemExit(1)`. After the arm list is built, a new guard rejects `codex_cli + onlycode` before any work starts. The resolved `runner` is then passed into `_run_arm(…, runner=runner)` so every arm invocation uses the correct runner instance. The startup echo block now prints `agent_surface` and `agent_binary` instead of the hardcoded Claude-specific strings.

### `swebench/artifact_cli.py` — `codex_cli + code_only` rejection guard

A single guard is added immediately after `arm_list` is built in `artifact_run_command`: if `agent_surface == "codex_cli"` and `"code_only"` in `arm_list`, the command exits 1 with `ERROR: codex_cli + code_only is not yet implemented — see Slice 5.` The `CODEX_NOT_IMPLEMENTED_MSG` constant is imported from `runner.py`.

### `swebench/analyze/run.py` — `_check_not_codex_jsonl()` guard

The new module-private function `_check_not_codex_jsonl(jsonl_path)` is called at the top of the `_stage_mechanical` loop before any log parsing. It uses a two-pass detection strategy:

- **Pass 1 (meta-line):** reads the first line of the JSONL; if it parses as `{"agent_surface": "codex_cli", …}` the file is unambiguously a Codex transcript.
- **Pass 2 (event-shape fallback):** reads the second line; if its `type` field starts with `"turn."` (the Codex event prefix, absent from Claude transcripts), the file is treated as Codex output.

On either detection, it raises `NotImplementedError("Codex JSONL not yet supported by analyze pipeline — see Slice 6.")` so the error is loud and clearly actionable. Unreadable files are silently passed through — downstream already handles that.

### Component interaction

```mermaid
flowchart TD
    A["CLI: swebench run\n--agent-surface codex_cli"] --> B["run_command()\nmake_runner(agent_surface)"]
    B --> C["runner.find_binary()\n→ FileNotFoundError\nif codex missing"]
    B --> D["runner.make_isolated_config()\n→ FileNotFoundError\nif auth absent"]
    C --> E{arm_list built}
    D --> E
    E --> F{"codex_cli\n+ onlycode?"}
    F -- Yes --> G["SystemExit(1)\n'not yet implemented'"]
    F -- No --> H["_run_arm(…, runner=runner)"]
    H --> I["CodexRunner.invoke()"]
    I --> J["make_isolated_config()\ncreate temp CODEX_HOME\ncopy auth.json\nwrite config.toml"]
    J --> K["codex exec --ephemeral\n--model … --dangerously-skip-permissions"]

    L["analyze pathology"] --> M["_stage_mechanical loop"]
    M --> N["_check_not_codex_jsonl(jsonl)"]
    N --> O{"Codex\nformat?"}
    O -- "meta-line\nagent_surface=codex_cli\nOR type starts 'turn.'" --> P["raise NotImplementedError\n'Codex JSONL not yet supported'"]
    O -- No --> Q["continue parsing"]
```

### Before / after for SWE-bench `run`

**Before:** `run_command` always called `find_claude_binary()` and `get_claude_version()` directly; there was no `--agent-surface` option; `_run_arm` always used `ClaudeRunner` as the default.

**After:** `run_command` creates the correct runner via `make_runner(agent_surface)`, calls surface-agnostic `runner.find_binary()` and `runner.get_version()`, and passes the runner instance into every `_run_arm` call. The default (`claude_code`) is identical in behaviour to the old hardcoded path.

### Edge cases and error handling

| Scenario | Behaviour |
|---|---|
| `codex` binary not on PATH | `runner.find_binary()` raises `FileNotFoundError` with `"npm install -g @openai/codex"` hint; `run_command` exits 1 |
| `~/.codex/auth.json` absent | `make_isolated_config()` raises `FileNotFoundError`; `run_command` exits 1 |
| `codex_cli + onlycode` | Rejected with `SystemExit(1)` after arm list is built; message contains "not yet implemented — see Slice 5" |
| `codex_cli + code_only` (artifact) | Rejected with `SystemExit(1)` same wording |
| Codex JSONL in `analyze pathology` | `_check_not_codex_jsonl()` raises `NotImplementedError` containing "Codex JSONL not yet supported" |
| `bash_only + codex_cli` | Not rejected (not in issue scope); `CodexRunner.build_tools_flags` returns `[]` for this arm |

### What was intentionally not changed

- `ClaudeRunner` behaviour is unchanged; the `claude_code` arm is byte-for-byte identical to previous behaviour.
- Codex code-only arm wiring (tool flags and `apply_patch` variant) — Slice 5.
- `analyze` Codex branch — Slice 6; this slice adds only the loud-failure guard.
- Cost computation: `extract_metadata` continues to return `cost=None` for Codex runs; pricing table is Slice 6.
- `bash_only + codex_cli` rejection — not in issue scope; left as is.

## Smoke verification

Both smoke runs **PASS** end-to-end under `codex_cli`:

| Run | Result | Wall | Turns | Cost |
|---|---|---|---|---|
| `artifact tool_rich`: `algorithmic__coin_change_min` | ✅ PASS | 32s | 1 | N/A |
| `swebench baseline`: `django__django-11790` | ✅ PASS | 91s | 1 | N/A |

Each produced a well-formed JSONL: meta line with `"agent_surface": "codex_cli"`, multiple `turn.*` and `item.*` events, and `CodexRunner.extract_metadata()` returns `(cost=None, turns=1)` for both — a non-None turn count as required.

While verifying these, a `config.toml` bug from Slice 2 (#219) was discovered: `_write_codex_config()` emitted `web_search_mode = "disabled"` under `[features]`, which codex 0.130 rejects (`invalid type: string "disabled", expected a boolean in features`) and which is also deprecated in favor of a top-level `web_search` string. This is fixed in `swebench/runner.py:376` by moving the directive out of `[features]` and using the modern top-level form `web_search = "disabled"`. The associated unit-test assertion in `test_write_codex_config_creates_valid_toml` is updated to match. Without this fix, the Slice 3 wiring is correct but codex itself never produces any turns, so the smoke ACs are unreachable.

Note: `runs/` is gitignored, so the issue's literal "Results committed under `runs/`" wording cannot be satisfied by a commit — the issue body was amended to reflect that (the meaningful criterion is end-to-end execution with non-None `turns`, which both runs above demonstrate).

## Tier / approach

Tier 2 (medium): Planner → Wave 1 parallel (Coder A: `runner.py`; Coder B: `run.py` / `artifact_cli.py` / `analyze/run.py`) → Wave 2 sequential (Integrator: constant extraction, preflight wiring, smoke verification).

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| AC1 | `swebench run --agent-surface codex_cli --arms baseline` executes without error | ✅ Verified: `django__django-11790` PASS, turns=1, wall=91s |
| AC2 | `swebench run --agent-surface codex_cli --arms onlycode` exits 1 with "not yet implemented — see Slice 5" | ✅ `test_run_command_rejects_codex_onlycode` passes |
| AC3 | `artifact run --agent-surface codex_cli --arms code_only` exits 1 with "not yet implemented" | ✅ `test_artifact_run_command_rejects_codex_code_only` passes |
| AC4 | `CodexRunner.find_binary()` raises `FileNotFoundError` with `"npm install -g @openai/codex"` | ✅ `test_codex_find_binary_missing` passes |
| AC5 | `CodexRunner` raises `FileNotFoundError` with `"~/.codex/auth.json"` when auth absent | ✅ `test_codex_make_isolated_config_missing_auth` passes |
| AC6 | `analyze pathology` on Codex JSONL raises `NotImplementedError` with "Codex JSONL not yet supported" | ✅ `_check_not_codex_jsonl()` implemented and called in `_stage_mechanical` |
| AC7 | SWE-bench mini end-to-end under `codex_cli + baseline` (well-formed JSONL, non-None turns) | ✅ Verified: meta line + 2 `turn.*` events, `extract_metadata` returns `(None, 1)` |
| AC8 | Artifact task end-to-end under `codex_cli + tool_rich` (well-formed JSONL, non-None turns) | ✅ Verified: PASS verdict, `turn.started` + `turn.completed` events written |
| AC9 | `@integration` test in `test_runner_codex_integration.py` passes with real `codex` binary | ✅ Test exists; the local smoke runs above exercise the same code path |

**All 514 non-integration unit tests pass** (`pytest -m "not integration"`).