### PR TITLE
fix(#226): commit test patch after apply to prevent git diff leak

### DIFF
--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -696,14 +696,40 @@ def setup_venv(
 
 
 def apply_test_patch(repo_dir: str, patch_path: str) -> bool:
-    """Apply a test patch to the repo. Returns True if successful."""
+    """Apply a test patch to the repo and commit it. Returns True if successful.
+
+    Committing the patch (rather than leaving it as an unstaged diff) prevents
+    agents from reading the test assertions via ``git diff`` — Issue #226.
+    """
     if not os.path.isfile(patch_path):
         return False
     result = subprocess.run(
         ["git", "-C", repo_dir, "apply", patch_path],
         capture_output=True,
     )
-    return result.returncode == 0
+    if result.returncode != 0:
+        return False
+    env = os.environ.copy()
+    env.update({
+        "GIT_AUTHOR_NAME": "swebench",
+        "GIT_AUTHOR_EMAIL": "swebench@localhost",
+        "GIT_AUTHOR_DATE": "1970-01-01T00:00:00+0000",
+        "GIT_COMMITTER_NAME": "swebench",
+        "GIT_COMMITTER_EMAIL": "swebench@localhost",
+        "GIT_COMMITTER_DATE": "1970-01-01T00:00:00+0000",
+    })
+    subprocess.run(
+        ["git", "-C", repo_dir, "add", "-A"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", repo_dir, "commit", "-m", "test patch"],
+        capture_output=True,
+        env=env,
+        check=True,
+    )
+    return True
 
 
 def make_isolated_claude_config() -> str:

--- a/tests/test_harness_strip.py
+++ b/tests/test_harness_strip.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from swebench.harness import strip_git_history
+from swebench.harness import apply_test_patch, strip_git_history
 
 
 def _git(repo: str, *args: str, check: bool = True) -> subprocess.CompletedProcess:
@@ -243,3 +243,45 @@ def test_strip_works_when_head_is_detached(tmp_path: Path) -> None:
     assert count == "1"
     # HEAD should be a valid commit.
     _git(repo, "rev-parse", "HEAD")
+
+
+def test_apply_test_patch_leaves_empty_git_diff(tmp_path: Path) -> None:
+    """Regression test for Issue #226: test patch must not be visible via git diff.
+
+    After apply_test_patch(), `git diff` and `git diff HEAD` must both return
+    empty output so an agent cannot read the test assertions from the diff.
+    """
+    repo = _make_repo(tmp_path)
+    strip_git_history(repo)
+
+    # Create a minimal patch that adds a new test file.
+    patch_path = tmp_path / "test.patch"
+    patch_path.write_text(
+        "diff --git a/test_secret.py b/test_secret.py\n"
+        "new file mode 100644\n"
+        "index 0000000..e69de29\n"
+        "--- /dev/null\n"
+        "+++ b/test_secret.py\n"
+        "@@ -0,0 +1,3 @@\n"
+        "+def test_answer():\n"
+        "+    assert answer == 42  # hidden assertion\n"
+        "+\n"
+    )
+
+    result = apply_test_patch(repo, str(patch_path))
+    assert result is True
+
+    # git diff (unstaged changes) must be empty — Issue #226.
+    diff = _git(repo, "diff").stdout
+    assert diff == "", f"git diff is not empty after apply_test_patch: {diff!r}"
+
+    # git diff HEAD (staged + unstaged vs last commit) must also be empty.
+    diff_head = _git(repo, "diff", "HEAD").stdout
+    assert diff_head == "", f"git diff HEAD is not empty after apply_test_patch: {diff_head!r}"
+
+    # The patch file itself should exist in the working tree (was applied).
+    assert (Path(repo) / "test_secret.py").exists()
+
+    # History should now have exactly 2 commits (orphan base + test patch commit).
+    count = _git(repo, "rev-list", "--all", "--count").stdout.strip()
+    assert count == "2"


### PR DESCRIPTION
## Summary

- `apply_test_patch()` now runs `git add -A && git commit -m "test patch"` after a successful `git apply`, so the patch lands as a committed HEAD rather than an unstaged diff
- Agents can no longer read hidden test assertions via `git diff` or `git diff HEAD`
- Adds regression test `test_apply_test_patch_leaves_empty_git_diff` in `tests/test_harness_strip.py`

## Root cause

`apply_test_patch()` called `git apply` but never staged or committed the result. The test patch sat as an unstaged working-tree diff, fully visible to any agent that ran `git diff` — including the `onlycode` arm via `execute_code` subprocess. Two of six audited instances in batch D likely passed **because** of this leak (false positives).

## Test plan

- [x] All 8 `test_harness_strip.py` tests pass
- [x] New test creates a repo, strips history, applies a patch, then asserts `git diff` and `git diff HEAD` are both empty and history has exactly 2 commits (orphan base + test patch)
- [ ] Re-run the 6 affected baseline-arm batch-D instances on seed_1 to replace tainted results

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)