### PR TITLE
fix(#238): sympy test-node resolution + pre-flight collection check

### DIFF
--- a/swebench/analyze/__init__.py
+++ b/swebench/analyze/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import click
 
+from swebench.analyze.backfill import _register as _register_backfill
 from swebench.analyze.run import register_pathology_command
 from swebench.analyze.summary import _register
 
@@ -15,5 +16,6 @@ def analyze_command() -> None:
 
 _register(analyze_command)
 register_pathology_command(analyze_command)
+_register_backfill(analyze_command)
 
 __all__ = ["analyze_command"]

--- a/swebench/analyze/backfill.py
+++ b/swebench/analyze/backfill.py
@@ -1,0 +1,144 @@
+"""`analyze backfill` — reclassify historical ``FAIL`` results as ``env_fail``.
+
+Issue #238 / #234: before the pre-flight ``pytest --collect-only`` check was
+added, a run that collected 0 items was scored ``FAIL`` because pytest exited
+non-zero.  Those runs were never failures in the sense the benchmark cares
+about — there were simply no tests to run.  This subcommand walks
+``*_test.txt`` files in a results dir, identifies the ones where the body
+contains ``0 items collected`` (or pytest's "no tests ran" / "no tests
+collected" phrases) **and** the last non-empty line is ``FAIL``, and rewrites
+the last line to ``env_fail``.
+
+The rewrite is idempotent — files whose last line is already ``env_fail`` are
+skipped — and supports ``--dry-run`` so an operator can preview the change set
+before committing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import click
+
+from swebench import repo_root
+
+
+# Phrases pytest emits when zero items are collected.  We match any of them
+# in the body of the test file to gate the FAIL→env_fail rewrite.  All
+# matches are case-insensitive against the verbatim text — these are pytest's
+# own strings and have not changed across recent releases.
+_ZERO_COLLECTION_MARKERS: tuple[str, ...] = (
+    "0 items collected",
+    "no tests ran",
+    "no tests collected",
+    "collected 0 items",
+)
+
+
+def _body_signals_zero_collection(text: str) -> bool:
+    """Return True if *text* contains any zero-collection marker phrase."""
+    lowered = text.lower()
+    return any(marker.lower() in lowered for marker in _ZERO_COLLECTION_MARKERS)
+
+
+def _last_non_empty_line(lines: list[str]) -> tuple[int, str] | None:
+    """Return ``(index, stripped)`` of the last non-empty line, or None."""
+    for i in range(len(lines) - 1, -1, -1):
+        s = lines[i].strip()
+        if s:
+            return i, s
+    return None
+
+
+def _should_rewrite(text: str) -> bool:
+    """Return True if *text* should be rewritten FAIL → env_fail."""
+    lines = text.splitlines()
+    last = _last_non_empty_line(lines)
+    if last is None:
+        return False
+    _, stripped = last
+    if stripped != "FAIL":
+        return False
+    return _body_signals_zero_collection(text)
+
+
+def _rewrite_text(text: str) -> str:
+    """Return *text* with the last ``FAIL`` line replaced by ``env_fail``.
+
+    Assumes :func:`_should_rewrite` returned True for *text*.  The trailing
+    newline (if any) is preserved.
+    """
+    # Replace the last FAIL token in the text.  We rsplit on newlines so the
+    # final terminator (``\n`` or absent) is preserved.
+    # Find the last index of a line equal to ``FAIL`` (stripped).
+    lines = text.splitlines(keepends=True)
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip() == "FAIL":
+            # Preserve original line ending if present.
+            terminator = "\n" if lines[i].endswith("\n") else ""
+            lines[i] = "env_fail" + terminator
+            break
+    return "".join(lines)
+
+
+def scan_results_dir(rdir: Path) -> list[Path]:
+    """Return ``*_test.txt`` files in *rdir* that need FAIL→env_fail rewrite."""
+    candidates: list[Path] = []
+    for test_file in sorted(rdir.glob("*_test.txt")):
+        try:
+            text = test_file.read_text()
+        except OSError:
+            continue
+        if _should_rewrite(text):
+            candidates.append(test_file)
+    return candidates
+
+
+def _register(analyze_command: click.Group) -> None:
+    """Register the `backfill` subcommand on the given analyze group."""
+
+    @analyze_command.command("backfill")
+    @click.option(
+        "--results-dir",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        default=None,
+        help="Path to results directory (default: auto-detect runs/swebench/).",
+    )
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        default=False,
+        help="Print which files would be rewritten without modifying them.",
+    )
+    def backfill_command(results_dir: Path | None, dry_run: bool) -> None:
+        """Reclassify historical 0-items-collected FAILs as env_fail.
+
+        Walks ``*_test.txt`` files under ``--results-dir`` (default:
+        ``runs/swebench/``).  A file is rewritten iff its body contains a
+        zero-collection marker (``0 items collected`` / ``no tests ran`` /
+        ``no tests collected``) AND its last non-empty line is ``FAIL``.
+        The rewrite replaces that last ``FAIL`` with ``env_fail``.
+        """
+        rdir = Path(results_dir) if results_dir else (repo_root() / "runs" / "swebench")
+        if not rdir.is_dir():
+            click.echo(f"ERROR: Results directory not found: {rdir}", err=True)
+            raise SystemExit(1)
+
+        candidates = scan_results_dir(rdir)
+        if not candidates:
+            click.echo(f"No FAIL→env_fail rewrites needed in {rdir}/")
+            return
+
+        action = "Would rewrite" if dry_run else "Rewrote"
+        for test_file in candidates:
+            if dry_run:
+                click.echo(f"  [dry-run] {test_file.name}")
+            else:
+                original = test_file.read_text()
+                test_file.write_text(_rewrite_text(original))
+                click.echo(f"  rewrote {test_file.name}")
+
+        click.echo(f"\n{action} {len(candidates)} file(s).")
+        if dry_run:
+            click.echo("(Run without --dry-run to apply.)")

--- a/swebench/analyze/summary.py
+++ b/swebench/analyze/summary.py
@@ -26,8 +26,8 @@ def _parse_results(results_dir: Path) -> list[ArmResult]:
             continue
         name = name[: -len("_test")]  # django__django-16379_baseline_run1
 
-        # Extract run index
-        match = re.match(r"^(.+)_(baseline|onlycode)_run(\d+)$", name)
+        # Extract run index (supports baseline | onlycode | bash_only arms).
+        match = re.match(r"^(.+)_(baseline|onlycode|bash_only)_run(\d+)$", name)
         if not match:
             continue
 
@@ -35,13 +35,15 @@ def _parse_results(results_dir: Path) -> list[ArmResult]:
         arm = match.group(2)
         run_idx = int(match.group(3))
 
-        # Read verdict from last non-empty line
+        # Read verdict from last non-empty line.  ``env_fail`` (Issue #238) is
+        # treated as a first-class verdict here so it can be displayed as its
+        # own column and excluded from pass-rate aggregates.
         verdict = "ERROR"
         try:
             lines = test_file.read_text().strip().splitlines()
             if lines:
                 last_line = lines[-1].strip()
-                if last_line in ("PASS", "FAIL"):
+                if last_line in ("PASS", "FAIL", "env_fail"):
                     verdict = last_line
         except OSError:
             pass
@@ -81,6 +83,46 @@ def _parse_results(results_dir: Path) -> list[ArmResult]:
         )
 
     return results
+
+
+def _emit_arm_aggregates(results: list[ArmResult]) -> None:
+    """Print a per-arm aggregate footer with pass/fail/env_fail counts.
+
+    The pass-rate excludes ``env_fail`` (Issue #238): runs that never had any
+    tests to collect are not counted in either the numerator or the denominator.
+    ``ERROR`` rows are likewise excluded from the rate but reported separately.
+    The aggregate line is intentionally appended to stdout below the per-row
+    table so existing golden fixtures that pin the table format continue to
+    match prefix-wise; new fixtures should pin the aggregate too.
+    """
+    per_arm: dict[str, dict[str, int]] = {}
+    for r in results:
+        bucket = per_arm.setdefault(
+            r.arm, {"PASS": 0, "FAIL": 0, "env_fail": 0, "ERROR": 0}
+        )
+        if r.verdict in bucket:
+            bucket[r.verdict] += 1
+        else:
+            bucket["ERROR"] += 1
+
+    if not per_arm:
+        return
+
+    click.echo("")
+    click.echo("Per-arm aggregates (env_fail excluded from pass rate):")
+    for arm in sorted(per_arm):
+        counts = per_arm[arm]
+        passes = counts["PASS"]
+        fails = counts["FAIL"]
+        env_fails = counts["env_fail"]
+        errors = counts["ERROR"]
+        denom = passes + fails  # excludes env_fail AND ERROR
+        rate = f"{(passes / denom * 100):.1f}%" if denom > 0 else "n/a"
+        click.echo(
+            f"  {arm:<12} pass={passes:<3} fail={fails:<3} "
+            f"env_fail={env_fails:<3} error={errors:<3} "
+            f"pass_rate={rate} (denominator={denom})"
+        )
 
 
 def _register(analyze_command: click.Group) -> None:
@@ -146,6 +188,15 @@ def _register(analyze_command: click.Group) -> None:
                     f"{r.instance_id:<30} {r.arm:<12} {r.run_idx:<5} {r.verdict:<8} "
                     f"{cost_str:<10} {turns_str:<7}"
                 )
+
+        # ----------------------------------------------------------------
+        # Per-arm aggregate footer (Issue #238)
+        # ----------------------------------------------------------------
+        # env_fail is excluded from the pass-rate numerator *and* denominator
+        # — those runs never had any tests to pass or fail.  ERROR rows
+        # (missing/incomplete verdict) are likewise excluded from the rate
+        # but still surfaced for visibility.
+        _emit_arm_aggregates(results)
 
         # Optional CSV output
         if out_path:

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -837,14 +837,22 @@ def _looks_like_bare_test_name(token: str) -> bool:
 
 
 def _collect_node_ids(repo_dir: str, venv_python: str, bare_name: str) -> list[str]:
-    """Run ``pytest --collect-only -q <bare_name>`` and return matching node IDs.
+    """Run ``pytest --collect-only -q -k <bare_name>`` and return matching node IDs.
+
+    ``-k`` is required (not a positional arg): pytest treats positionals as
+    path-or-node-IDs and exits 4 ("file or directory not found") on a bare
+    function name, yielding zero collected items.  The ``-k`` keyword filter
+    walks the entire collection tree and emits any test whose name *contains*
+    ``bare_name``.  The post-filter on ``m.group("name") == bare_name`` keeps
+    only exact matches, so over-collection from substring matches is safely
+    discarded.
 
     Returns an empty list if pytest collects nothing or errors out — callers
     decide whether to fall back to the original command (resolver path) or
     record ``env_fail`` (pre-flight path).
     """
     proc = subprocess.run(
-        [venv_python, "-m", "pytest", "--collect-only", "-q", bare_name],
+        [venv_python, "-m", "pytest", "--collect-only", "-q", "-k", bare_name],
         cwd=repo_dir,
         capture_output=True,
         text=True,

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -792,20 +792,210 @@ def run_claude(
     )
 
 
+# ---------------------------------------------------------------------------
+# Per-repo test-node resolvers (Issue #238 / #227)
+# ---------------------------------------------------------------------------
+# Some SWE-bench instances store *bare* test function names (e.g.
+# ``test_issue_12420``) in ``test_cmd``.  Pytest treats a bare argument as a
+# path-or-node-id; when neither resolves it collects 0 items and the run
+# scores FAIL spuriously.  See issue #227 for the canonical sympy case.
+#
+# The resolver below runs ``pytest --collect-only -q <bare>`` inside the
+# instance's venv, parses any ``<path>::<bare>`` node IDs out of stdout, and
+# rewrites the test command to pass those node IDs explicitly.  On 0 results
+# it returns the original command unchanged — the pre-flight ``--collect-only``
+# check in ``run.py`` then catches the env failure and records ``env_fail``
+# instead of silently corrupting pass-rate aggregates.
+
+# Regex for a single pytest node-ID line as emitted by ``--collect-only -q``.
+# Matches forms like ``sympy/printing/tests/test_latex.py::test_latex_log``.
+import re as _re
+
+_NODE_ID_LINE_RE = _re.compile(
+    r"^(?P<path>[\w./\-]+\.py)::(?P<name>[\w\[\]\-]+)\s*$",
+    _re.MULTILINE,
+)
+
+
+def _looks_like_bare_test_name(token: str) -> bool:
+    """Return True if *token* is a bare pytest test name (no ``::``, no path).
+
+    Used to decide whether a pytest argument needs node-ID resolution.  A
+    token containing ``/`` or ``::`` is already a path or a node-ID and is
+    passed through untouched.  Flags (``-x``, ``--foo``) and ``.py`` paths
+    are also passed through.  Only ``test_*``-prefixed identifiers are
+    treated as bare names — this avoids accidentally rewriting positional
+    args that happen to be legitimate keyword expressions.
+    """
+    if not token or token.startswith("-"):
+        return False
+    if "/" in token or "::" in token:
+        return False
+    if token.endswith(".py"):
+        return False
+    return token.startswith("test_")
+
+
+def _collect_node_ids(repo_dir: str, venv_python: str, bare_name: str) -> list[str]:
+    """Run ``pytest --collect-only -q <bare_name>`` and return matching node IDs.
+
+    Returns an empty list if pytest collects nothing or errors out — callers
+    decide whether to fall back to the original command (resolver path) or
+    record ``env_fail`` (pre-flight path).
+    """
+    proc = subprocess.run(
+        [venv_python, "-m", "pytest", "--collect-only", "-q", bare_name],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+    # pytest returns exit 5 when no items collected; both 0 and 5 may still
+    # contain partial output worth parsing.  Anything else is a hard error
+    # and yields no node IDs.
+    if proc.returncode not in (0, 5):
+        return []
+    node_ids: list[str] = []
+    for m in _NODE_ID_LINE_RE.finditer(proc.stdout):
+        if m.group("name") == bare_name:
+            node_ids.append(f"{m.group('path')}::{bare_name}")
+    return node_ids
+
+
+# Repos whose ``test_cmd`` may carry bare test names that require resolution.
+# Keep this allow-list narrow so unrelated repos are never touched.
+_REPOS_WITH_BARE_TEST_NAMES: tuple[str, ...] = (
+    "sympy/sympy",
+)
+
+
+def resolve_test_node_ids(
+    test_cmd: str,
+    *,
+    repo_dir: str,
+    venv_dir: str,
+    repo_slug: str | None,
+) -> str:
+    """Rewrite a ``pytest`` test command, expanding bare test names to node IDs.
+
+    The rewrite is gated by ``repo_slug`` — only repos in
+    :data:`_REPOS_WITH_BARE_TEST_NAMES` are inspected.  Tokens that already
+    look like a path, node-ID, or pytest flag are passed through.
+
+    On a 0-result resolution the bare token is left in place so the caller's
+    pre-flight ``--collect-only`` check can detect the env failure and record
+    ``env_fail`` rather than silently corrupting the run.
+
+    Returns the (possibly unchanged) test command.
+    """
+    if not repo_slug or repo_slug not in _REPOS_WITH_BARE_TEST_NAMES:
+        return test_cmd
+    if "pytest" not in test_cmd:
+        return test_cmd
+
+    venv_python = os.path.join(venv_dir, "bin", "python")
+    parts = test_cmd.split()
+    rewritten: list[str] = []
+    changed = False
+    for tok in parts:
+        if not _looks_like_bare_test_name(tok):
+            rewritten.append(tok)
+            continue
+        node_ids = _collect_node_ids(repo_dir, venv_python, tok)
+        if node_ids:
+            rewritten.extend(node_ids)
+            changed = True
+        else:
+            # Resolution failed (0 collected).  Leave the bare token so the
+            # pre-flight check in run.py sees the same 0-items state and
+            # records env_fail.  Logging stays informational — never raise.
+            rewritten.append(tok)
+            print(
+                f"[harness] resolve_test_node_ids: 0 node IDs for {tok!r} in "
+                f"{repo_slug}; leaving bare name in command.",
+                flush=True,
+            )
+    if not changed:
+        return test_cmd
+    return " ".join(rewritten)
+
+
+def run_preflight_collect(
+    *,
+    repo_dir: str,
+    test_cmd: str,
+    venv_dir: str,
+) -> tuple[bool, str]:
+    """Run ``pytest --collect-only -q`` for *test_cmd* and report collection.
+
+    Returns ``(items_collected_gt_zero, raw_output)``.  The pre-flight check
+    is independent of the resolver: it operates on whatever final command
+    will be passed to pytest, so a bare-name command that the resolver could
+    not expand will still be caught here as 0-items.
+
+    Behaviour by exit code:
+
+    * **0** with at least one ``<path>::<name>`` node ID → ``(True, ...)``.
+    * **5** (pytest's "no tests collected") → ``(False, ...)``.
+    * Any other non-zero exit → ``(False, ...)`` — the pre-flight cannot
+      prove that tests would have run.
+
+    Non-pytest invocations (anything that isn't ``python -m pytest …`` or
+    ``python -m unittest …``) return ``(True, "")`` — the pre-flight does
+    not apply, so the agent runs normally and downstream PASS/FAIL parsing
+    captures reality.
+    """
+    venv_python = os.path.join(venv_dir, "bin", "python")
+    cmd_str = test_cmd
+    if cmd_str.startswith("python "):
+        cmd_str = cmd_str[len("python "):]
+    tokens = cmd_str.split()
+    if (
+        len(tokens) < 2
+        or tokens[0] != "-m"
+        or tokens[1] != "pytest"
+    ):
+        # Non-pytest invocation — pre-flight does not apply.
+        return True, ""
+    pytest_args = tokens[2:]
+    proc = subprocess.run(
+        [venv_python, "-m", "pytest", "--collect-only", "-q", *pytest_args],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+    has_node = bool(_NODE_ID_LINE_RE.search(proc.stdout))
+    if proc.returncode == 0 and has_node:
+        return True, proc.stdout
+    return False, proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
+
+
 def run_tests(
     *,
     repo_dir: str,
     test_cmd: str,
     venv_dir: str,
     result_file: str,
+    repo_slug: str | None = None,
 ) -> str:
-    """Run the test suite and write results. Returns 'PASS' or 'FAIL'."""
+    """Run the test suite and write results. Returns 'PASS' or 'FAIL'.
+
+    When *repo_slug* is supplied and matches a repo with known bare-test-name
+    instances (currently only ``sympy/sympy``), the command is first passed
+    through :func:`resolve_test_node_ids` to expand bare names like
+    ``test_issue_12420`` to ``<path>::test_issue_12420`` node IDs.  This is
+    required because pytest treats bare arguments as paths and collects 0
+    items, scoring legitimate fixes as FAIL (Issue #227/#238).
+    """
     # Replace leading 'python' with venv python
     venv_python = os.path.join(venv_dir, "bin", "python")
-    if test_cmd.startswith("python "):
-        effective_cmd = venv_python + test_cmd[len("python"):]
-    else:
-        effective_cmd = test_cmd
+    effective_cmd = resolve_test_node_ids(
+        test_cmd,
+        repo_dir=repo_dir,
+        venv_dir=venv_dir,
+        repo_slug=repo_slug,
+    )
+    if effective_cmd.startswith("python "):
+        effective_cmd = venv_python + effective_cmd[len("python"):]
 
     with open(result_file, "w") as out:
         proc = subprocess.run(

--- a/swebench/models.py
+++ b/swebench/models.py
@@ -59,9 +59,15 @@ class ArmResult:
     """Result of running one arm on one instance."""
 
     instance_id: str
-    arm: str            # "baseline" | "onlycode"
+    arm: str            # "baseline" | "onlycode" | "bash_only"
     run_idx: int
-    verdict: str        # "PASS" | "FAIL" | "ERROR"
+    verdict: str        # "PASS" | "FAIL" | "ERROR" | "env_fail"
+    #
+    # ``env_fail`` (Issue #238) signals that pre-flight ``pytest --collect-only``
+    # collected zero items, meaning no tests could possibly run.  The agent is
+    # not invoked in this state.  Downstream callers MUST exclude ``env_fail``
+    # from pass-rate numerators *and* denominators — counting it as ``FAIL``
+    # silently corrupts aggregates.
     cost_usd: float | None
     num_turns: int | None
     wall_secs: int

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -37,7 +37,9 @@ from swebench.harness import (
     find_claude_binary,
     get_claude_version,
     git_reset,
+    resolve_test_node_ids,
     run_claude,
+    run_preflight_collect,
     run_tests,
     setup_venv,
     strip_git_history,
@@ -100,7 +102,12 @@ def _is_triple_complete(
     - ``<results_dir>/<instance_id>_<arm>_run<N>.jsonl`` exists, AND
     - ``<results_dir>/<instance_id>_<arm>_run<N>_test.txt`` exists, AND
     - the test file's last non-empty line (stripped of trailing whitespace) is
-      exactly ``PASS`` or ``FAIL``.
+      one of ``PASS``, ``FAIL``, or ``env_fail``.
+
+    ``env_fail`` (Issue #238) is the verdict written by the pre-flight
+    ``pytest --collect-only`` check when zero items are collected — the agent
+    is never invoked in that case, so the jsonl will contain only the meta
+    record.  We still treat it as complete so ``--resume`` skips it.
 
     If any of those conditions fail (missing file, no verdict, empty file,
     mid-run kill leaving partial output), the triple is **incomplete** and the
@@ -125,7 +132,7 @@ def _is_triple_complete(
         line = raw.strip()
         if not line:
             continue
-        if line == "PASS" or line == "FAIL":
+        if line in ("PASS", "FAIL", "env_fail"):
             return line
         return None
 
@@ -151,7 +158,11 @@ def _run_arm(
 ) -> str:
     """Run a single arm (baseline or onlycode) for one instance.
 
-    Returns the verdict string ("PASS", "FAIL", or "ERROR").
+    Returns the verdict string ("PASS", "FAIL", "ERROR", or "env_fail").
+    ``env_fail`` is returned when the pre-flight ``pytest --collect-only``
+    check collects zero items (Issue #238): the agent is not invoked and the
+    run is excluded from pass-rate aggregates downstream.
+
     When *log_buffer* is provided, all output is written there instead of
     directly to stdout so that parallel runs don't interleave.
 
@@ -192,6 +203,62 @@ def _run_arm(
             _echo(f"  [{arm} run {run_idx}] Applied test patch.")
         else:
             _echo(f"  [{arm} run {run_idx}] WARNING: test patch failed to apply.")
+
+    # ------------------------------------------------------------------
+    # Pre-flight: pytest --collect-only (Issue #238 / #234)
+    # ------------------------------------------------------------------
+    # Resolve the test command first (sympy bare-name → file::test node IDs)
+    # so the collection check sees the same final command the test run will
+    # use.  If zero items collect, record env_fail and skip the agent
+    # entirely — there is nothing for the agent to fix, and counting this
+    # as FAIL silently corrupts pass-rate aggregates.
+    resolved_test_cmd = resolve_test_node_ids(
+        problem.test_cmd,
+        repo_dir=repo_dir,
+        venv_dir=venv_dir,
+        repo_slug=problem.repo_slug,
+    )
+    collected_ok, preflight_output = run_preflight_collect(
+        repo_dir=repo_dir,
+        test_cmd=resolved_test_cmd,
+        venv_dir=venv_dir,
+    )
+    if not collected_ok:
+        _echo(
+            f"  [{arm} run {run_idx}] Pre-flight collect FAILED — recording env_fail "
+            f"(0 items collected; skipping agent)."
+        )
+        result_file = os.path.join(
+            results_dir, f"{problem.instance_id}_{arm}_run{run_idx}.jsonl"
+        )
+        # Write a minimal meta record so downstream tools (analyze, summary,
+        # _is_triple_complete) see a properly-shaped jsonl file.
+        with open(result_file, "w") as _meta_f:
+            _meta_f.write(json.dumps({
+                "type": "meta",
+                "instance_id": problem.instance_id,
+                "arm": arm,
+                "run": run_idx,
+                "agent_surface": (runner.surface if runner is not None else "claude_code"),
+                "agent_binary": claude_binary,
+                "verdict": "env_fail",
+                "reason": "pytest --collect-only returned 0 items",
+            }) + "\n")
+        test_result_file = os.path.join(
+            results_dir, f"{problem.instance_id}_{arm}_run{run_idx}_test.txt"
+        )
+        with open(test_result_file, "w") as out:
+            out.write(
+                "# pre-flight pytest --collect-only (Issue #238) — "
+                "0 items collected; agent was not invoked.\n"
+            )
+            if preflight_output:
+                out.write("\n--- pytest --collect-only output ---\n")
+                out.write(preflight_output)
+                out.write("\n--- end ---\n")
+            out.write("\nenv_fail\n")
+        _echo(f"  [{arm} run {run_idx}] Verdict: env_fail")
+        return "env_fail"
 
     # Build prompt from problem_statement — eliminates hardcoded text bug
     venv_python = os.path.join(venv_dir, "bin", "python")
@@ -300,6 +367,7 @@ def _run_arm(
         test_cmd=problem.test_cmd,
         venv_dir=venv_dir,
         result_file=test_result_file,
+        repo_slug=problem.repo_slug,
     )
 
     _echo(f"  [{arm} run {run_idx}] Tests: {verdict} ({wall_secs}s wall)")

--- a/tests/fixtures/analyze/both_arms_stdout.golden.txt
+++ b/tests/fixtures/analyze/both_arms_stdout.golden.txt
@@ -1,3 +1,7 @@
 instance_id           arm         run  verdict    cost      turns
 django__django-16379  baseline      1  PASS       $0.123        7
 django__django-16379  onlycode      1  FAIL       $0.500       12
+
+Per-arm aggregates (env_fail excluded from pass rate):
+  baseline     pass=1   fail=0   env_fail=0   error=0   pass_rate=100.0% (denominator=1)
+  onlycode     pass=0   fail=1   env_fail=0   error=0   pass_rate=0.0% (denominator=1)

--- a/tests/fixtures/analyze/env_fail_arm/sympy__sympy-14180_baseline_run1.jsonl
+++ b/tests/fixtures/analyze/env_fail_arm/sympy__sympy-14180_baseline_run1.jsonl
@@ -1,0 +1,1 @@
+{"type":"meta","verdict":"env_fail","reason":"pytest --collect-only returned 0 items"}

--- a/tests/fixtures/analyze/env_fail_arm/sympy__sympy-14180_baseline_run1_test.txt
+++ b/tests/fixtures/analyze/env_fail_arm/sympy__sympy-14180_baseline_run1_test.txt
@@ -1,0 +1,7 @@
+# pre-flight pytest --collect-only — 0 items collected; agent was not invoked.
+
+--- pytest --collect-only output ---
+no tests ran in 0.05s
+--- end ---
+
+env_fail

--- a/tests/fixtures/analyze/orphan_arm_stdout.golden.txt
+++ b/tests/fixtures/analyze/orphan_arm_stdout.golden.txt
@@ -1,2 +1,5 @@
 instance_id              arm         run  verdict    cost      turns
 sphinx-doc__sphinx-8721  baseline      1  PASS       $0.025        3
+
+Per-arm aggregates (env_fail excluded from pass rate):
+  baseline     pass=1   fail=0   env_fail=0   error=0   pass_rate=100.0% (denominator=1)

--- a/tests/test_analyze_backfill.py
+++ b/tests/test_analyze_backfill.py
@@ -1,0 +1,162 @@
+"""Tests for ``analyze backfill`` (Issue #238).
+
+The subcommand rewrites the trailing ``FAIL`` line of any ``*_test.txt`` file
+whose body contains a zero-collection marker (``0 items collected``, ``no
+tests ran``, ``no tests collected``) into ``env_fail``.  Idempotent and
+supports ``--dry-run``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from swebench.analyze import analyze_command
+from swebench.analyze.backfill import (
+    _body_signals_zero_collection,
+    _rewrite_text,
+    _should_rewrite,
+    scan_results_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_body_marker_recognised():
+    assert _body_signals_zero_collection("ran 0 items collected in 0.03s")
+    assert _body_signals_zero_collection("no tests ran in 0.05s")
+    assert _body_signals_zero_collection("No tests collected")
+    assert _body_signals_zero_collection("Collected 0 items / 0 errors")
+
+
+def test_body_without_marker_not_recognised():
+    assert not _body_signals_zero_collection("collected 5 items")
+    assert not _body_signals_zero_collection("ERROR: test_something")
+
+
+def test_should_rewrite_requires_both_marker_and_fail_tail():
+    assert _should_rewrite("ran 0 items collected\nFAIL\n")
+    # Marker present but tail is PASS → no rewrite.
+    assert not _should_rewrite("ran 0 items collected\nPASS\n")
+    # FAIL tail but no marker → no rewrite (a real failure).
+    assert not _should_rewrite("ERROR: assertion\nFAIL\n")
+    # Already env_fail → no rewrite.
+    assert not _should_rewrite("ran 0 items collected\nenv_fail\n")
+
+
+def test_rewrite_replaces_only_the_terminal_fail():
+    text = "some FAIL token in middle\n0 items collected\nFAIL\n"
+    out = _rewrite_text(text)
+    # Only the last FAIL becomes env_fail.
+    assert out.count("env_fail") == 1
+    assert out.endswith("env_fail\n")
+    # The mid-text "FAIL token" is preserved (it's not on its own line).
+    assert "FAIL token" in out
+
+
+def test_rewrite_preserves_trailing_newline_absence():
+    text = "0 items collected\nFAIL"
+    out = _rewrite_text(text)
+    assert out == "0 items collected\nenv_fail"
+
+
+# ---------------------------------------------------------------------------
+# scan_results_dir
+# ---------------------------------------------------------------------------
+
+
+def test_scan_picks_up_only_matching_files(tmp_path: Path):
+    # Match: 0 items + FAIL tail
+    (tmp_path / "a_baseline_run1_test.txt").write_text(
+        "ran 0 items collected\nFAIL\n"
+    )
+    # No marker → skip
+    (tmp_path / "b_baseline_run1_test.txt").write_text(
+        "test_x failed: assertion error\nFAIL\n"
+    )
+    # Marker but PASS tail → skip
+    (tmp_path / "c_baseline_run1_test.txt").write_text(
+        "ran 0 items collected\nPASS\n"
+    )
+    # Already env_fail → skip
+    (tmp_path / "d_baseline_run1_test.txt").write_text(
+        "0 items collected\nenv_fail\n"
+    )
+
+    matches = scan_results_dir(tmp_path)
+    names = {p.name for p in matches}
+    assert names == {"a_baseline_run1_test.txt"}
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — invokes the registered command end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_cli_dry_run_does_not_mutate(tmp_path: Path):
+    f = tmp_path / "x_baseline_run1_test.txt"
+    original = "ran 0 items collected\nFAIL\n"
+    f.write_text(original)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        analyze_command,
+        ["backfill", "--results-dir", str(tmp_path), "--dry-run"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert f.read_text() == original  # untouched
+
+
+def test_backfill_cli_applies_rewrite(tmp_path: Path):
+    f = tmp_path / "x_baseline_run1_test.txt"
+    f.write_text("ran 0 items collected\nFAIL\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        analyze_command,
+        ["backfill", "--results-dir", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # File now ends with env_fail.
+    last = [line for line in f.read_text().splitlines() if line.strip()][-1]
+    assert last.strip() == "env_fail"
+
+
+def test_backfill_cli_is_idempotent(tmp_path: Path):
+    """Running twice doesn't double-rewrite."""
+    f = tmp_path / "x_baseline_run1_test.txt"
+    f.write_text("ran 0 items collected\nFAIL\n")
+
+    runner = CliRunner()
+    runner.invoke(
+        analyze_command,
+        ["backfill", "--results-dir", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    first = f.read_text()
+    result = runner.invoke(
+        analyze_command,
+        ["backfill", "--results-dir", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No FAIL→env_fail rewrites needed" in result.output
+    assert f.read_text() == first
+
+
+def test_backfill_cli_empty_dir(tmp_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(
+        analyze_command,
+        ["backfill", "--results-dir", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No FAIL→env_fail rewrites needed" in result.output

--- a/tests/test_analyze_summary.py
+++ b/tests/test_analyze_summary.py
@@ -135,5 +135,24 @@ def test_missing_results_dir_errors_out(tmp_path: Path):
     assert result.exit_code != 0
 
 
+# ---------------------------------------------------------------------------
+# env_fail (Issue #238) — verdict surfaces as its own row and is excluded
+# from the per-arm pass-rate aggregate.
+# ---------------------------------------------------------------------------
+
+
+def test_env_fail_appears_in_table_and_excluded_from_pass_rate():
+    fixture_dir = FIXTURES_DIR / "env_fail_arm"
+    result = _run(fixture_dir)
+    assert result.exit_code == 0, result.output
+    # env_fail verdict shows up in the per-row table.
+    assert "env_fail" in result.output
+    # The aggregate footer is emitted and pass_rate is n/a (denominator excludes env_fail).
+    assert "Per-arm aggregates" in result.output
+    assert "env_fail=1" in result.output
+    assert "denominator=0" in result.output
+    assert "pass_rate=n/a" in result.output
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/test_harness_node_resolve.py
+++ b/tests/test_harness_node_resolve.py
@@ -1,0 +1,286 @@
+"""Tests for sympy test-node resolution in ``harness.run_tests``.
+
+Issue #238 / #227: bare test names like ``test_issue_12420`` must be expanded
+to ``<path>::test_issue_12420`` node IDs before being passed to pytest.  The
+resolver only runs for repos in ``_REPOS_WITH_BARE_TEST_NAMES``; everything
+else passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import types
+from pathlib import Path
+
+import pytest
+
+from swebench import harness
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_collect_only_output(node_ids: list[str], extra: str = "") -> str:
+    """Compose pytest --collect-only -q output containing the given node IDs."""
+    lines = list(node_ids)
+    if extra:
+        lines.append(extra)
+    # Always end with the summary line pytest emits.
+    lines.append(f"{len(node_ids)} tests collected in 0.42s")
+    return "\n".join(lines) + "\n"
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_bare_test_name
+# ---------------------------------------------------------------------------
+
+
+def test_bare_test_name_recognised():
+    assert harness._looks_like_bare_test_name("test_issue_12420")
+    assert harness._looks_like_bare_test_name("test_latex_log")
+
+
+def test_path_token_is_not_bare():
+    assert not harness._looks_like_bare_test_name("sympy/printing/tests/test_x.py")
+
+
+def test_node_id_token_is_not_bare():
+    assert not harness._looks_like_bare_test_name("foo.py::test_x")
+
+
+def test_flag_token_is_not_bare():
+    assert not harness._looks_like_bare_test_name("-x")
+    assert not harness._looks_like_bare_test_name("--collect-only")
+
+
+def test_non_test_prefix_is_not_bare():
+    # Don't rewrite arbitrary positional args that happen to look like words.
+    assert not harness._looks_like_bare_test_name("foo")
+    assert not harness._looks_like_bare_test_name("verbose")
+
+
+# ---------------------------------------------------------------------------
+# resolve_test_node_ids — non-sympy repos pass through
+# ---------------------------------------------------------------------------
+
+
+def test_non_sympy_repo_passes_through(monkeypatch, tmp_path: Path):
+    """Repos not on the allow-list must never have their command rewritten."""
+    def _boom(*a, **kw):  # pragma: no cover — should never be called
+        raise AssertionError("subprocess.run must not be invoked for non-sympy repos")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    cmd = "python -m pytest test_something"
+    out = harness.resolve_test_node_ids(
+        cmd,
+        repo_dir=str(tmp_path),
+        venv_dir=str(tmp_path / "venv"),
+        repo_slug="django/django",
+    )
+    assert out == cmd
+
+
+def test_no_repo_slug_passes_through(monkeypatch, tmp_path: Path):
+    def _boom(*a, **kw):  # pragma: no cover
+        raise AssertionError("subprocess.run must not be invoked when repo_slug is None")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    cmd = "python -m pytest test_something"
+    out = harness.resolve_test_node_ids(
+        cmd,
+        repo_dir=str(tmp_path),
+        venv_dir=str(tmp_path / "venv"),
+        repo_slug=None,
+    )
+    assert out == cmd
+
+
+def test_non_pytest_command_passes_through(monkeypatch, tmp_path: Path):
+    """Even for sympy, a non-pytest command must pass through unchanged."""
+    def _boom(*a, **kw):  # pragma: no cover
+        raise AssertionError("non-pytest command should not trigger resolution")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    cmd = "python tests/runtests.py test_x"
+    out = harness.resolve_test_node_ids(
+        cmd,
+        repo_dir=str(tmp_path),
+        venv_dir=str(tmp_path / "venv"),
+        repo_slug="sympy/sympy",
+    )
+    assert out == cmd
+
+
+# ---------------------------------------------------------------------------
+# resolve_test_node_ids — sympy with successful resolution
+# ---------------------------------------------------------------------------
+
+
+def test_sympy_bare_name_is_rewritten(monkeypatch, tmp_path: Path):
+    """Sympy + bare test name → command rewritten with node IDs."""
+    def _fake_run(cmd, **kw):
+        # Confirm we ARE calling pytest --collect-only.
+        assert "--collect-only" in cmd
+        assert "test_issue_12420" in cmd
+        return _FakeCompleted(
+            returncode=0,
+            stdout=_fake_collect_only_output(
+                ["sympy/simplify/tests/test_sqrtdenest.py::test_issue_12420"]
+            ),
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    out = harness.resolve_test_node_ids(
+        "python -m pytest test_issue_12420",
+        repo_dir=str(tmp_path),
+        venv_dir=str(tmp_path / "venv"),
+        repo_slug="sympy/sympy",
+    )
+    assert out == (
+        "python -m pytest "
+        "sympy/simplify/tests/test_sqrtdenest.py::test_issue_12420"
+    )
+
+
+def test_sympy_multiple_node_ids_all_collected(monkeypatch, tmp_path: Path):
+    """When one bare name matches multiple files, all node IDs are emitted."""
+    def _fake_run(cmd, **kw):
+        return _FakeCompleted(
+            returncode=0,
+            stdout=_fake_collect_only_output([
+                "sympy/a/test_x.py::test_foo",
+                "sympy/b/test_y.py::test_foo",
+            ]),
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    out = harness.resolve_test_node_ids(
+        "python -m pytest test_foo",
+        repo_dir=str(tmp_path),
+        venv_dir=str(tmp_path / "venv"),
+        repo_slug="sympy/sympy",
+    )
+    # Both node IDs appear in the rewritten command.
+    assert "sympy/a/test_x.py::test_foo" in out
+    assert "sympy/b/test_y.py::test_foo" in out
+
+
+# ---------------------------------------------------------------------------
+# resolve_test_node_ids — sympy with failed resolution (fall through)
+# ---------------------------------------------------------------------------
+
+
+def test_sympy_zero_results_leaves_bare_name(monkeypatch, tmp_path: Path):
+    """Resolution that returns 0 node IDs must leave the bare name in place
+    so the pre-flight check downstream can detect the env failure."""
+    def _fake_run(cmd, **kw):
+        # pytest exits 5 when nothing collected.
+        return _FakeCompleted(returncode=5, stdout="no tests ran in 0.05s\n")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    cmd = "python -m pytest test_missing"
+    out = harness.resolve_test_node_ids(
+        cmd,
+        repo_dir=str(tmp_path),
+        venv_dir=str(tmp_path / "venv"),
+        repo_slug="sympy/sympy",
+    )
+    assert out == cmd
+
+
+def test_sympy_collector_error_leaves_command_unchanged(monkeypatch, tmp_path: Path):
+    """A pytest crash (exit != 0 and != 5) yields no node IDs; command is unchanged."""
+    def _fake_run(cmd, **kw):
+        return _FakeCompleted(returncode=4, stdout="", stderr="usage error")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    cmd = "python -m pytest test_x"
+    out = harness.resolve_test_node_ids(
+        cmd,
+        repo_dir=str(tmp_path),
+        venv_dir=str(tmp_path / "venv"),
+        repo_slug="sympy/sympy",
+    )
+    assert out == cmd
+
+
+# ---------------------------------------------------------------------------
+# run_preflight_collect
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_returns_true_when_items_collected(monkeypatch, tmp_path: Path):
+    def _fake_run(cmd, **kw):
+        # Confirm we issue a pytest --collect-only call.
+        assert "--collect-only" in cmd
+        return _FakeCompleted(
+            returncode=0,
+            stdout=_fake_collect_only_output(["a/test_x.py::test_one"]),
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    ok, _ = harness.run_preflight_collect(
+        repo_dir=str(tmp_path),
+        test_cmd="python -m pytest a/test_x.py::test_one",
+        venv_dir=str(tmp_path / "venv"),
+    )
+    assert ok is True
+
+
+def test_preflight_returns_false_on_zero_collection(monkeypatch, tmp_path: Path):
+    def _fake_run(cmd, **kw):
+        return _FakeCompleted(
+            returncode=5,
+            stdout="no tests ran in 0.05s\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    ok, _ = harness.run_preflight_collect(
+        repo_dir=str(tmp_path),
+        test_cmd="python -m pytest test_missing",
+        venv_dir=str(tmp_path / "venv"),
+    )
+    assert ok is False
+
+
+def test_preflight_returns_false_on_pytest_error(monkeypatch, tmp_path: Path):
+    """Any non-zero exit that isn't accompanied by collected items is env_fail."""
+    def _fake_run(cmd, **kw):
+        return _FakeCompleted(
+            returncode=3,
+            stdout="ERROR: import error in conftest\n",
+            stderr="Traceback ...",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    ok, output = harness.run_preflight_collect(
+        repo_dir=str(tmp_path),
+        test_cmd="python -m pytest test_x",
+        venv_dir=str(tmp_path / "venv"),
+    )
+    assert ok is False
+    assert "Traceback" in output
+
+
+def test_preflight_non_pytest_command_passes(monkeypatch, tmp_path: Path):
+    """unittest-style invocations are not gated by the pre-flight."""
+    def _boom(*a, **kw):  # pragma: no cover
+        raise AssertionError("non-pytest command should not trigger collection")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    ok, output = harness.run_preflight_collect(
+        repo_dir=str(tmp_path),
+        test_cmd="python tests/runtests.py test_x",
+        venv_dir=str(tmp_path / "venv"),
+    )
+    assert ok is True
+    assert output == ""

--- a/tests/test_harness_node_resolve.py
+++ b/tests/test_harness_node_resolve.py
@@ -284,3 +284,62 @@ def test_preflight_non_pytest_command_passes(monkeypatch, tmp_path: Path):
     )
     assert ok is True
     assert output == ""
+
+
+# ---------------------------------------------------------------------------
+# Real-pytest integration: _collect_node_ids against an actual pytest run
+# ---------------------------------------------------------------------------
+# These tests do NOT monkeypatch subprocess. They exercise the resolver
+# against a real pytest invocation on a minimal pytest tree. Without ``-k``,
+# pytest treats a bare name as a path and exits 4 ("file or directory not
+# found"), and the resolver returns []. With ``-k``, pytest walks the
+# collection tree and emits node IDs whose name *contains* the bare token;
+# the resolver's post-filter on exact-name equality narrows to the right one.
+
+
+def _write_pytest_tree(root: Path) -> None:
+    """Create a minimal two-file pytest tree under *root*.
+
+    test_alpha.py contains two tests whose names both contain the resolver
+    target — this verifies the exact-name post-filter discards ``-k`` over-
+    matches. test_beta.py contains an unrelated test.
+    """
+    (root / "tests").mkdir()
+    (root / "tests" / "__init__.py").write_text("")
+    (root / "tests" / "test_alpha.py").write_text(
+        "def test_resolver_target_xyz():\n"
+        "    assert True\n"
+        "\n"
+        "def test_resolver_target_xyz_extra():\n"
+        "    assert True\n"
+    )
+    (root / "tests" / "test_beta.py").write_text(
+        "def test_unrelated():\n"
+        "    assert True\n"
+    )
+    # Empty conftest avoids pytest discovering an unrelated parent project.
+    (root / "conftest.py").write_text("")
+
+
+def test_collect_node_ids_real_pytest_finds_bare_name(tmp_path: Path):
+    """Real pytest run: bare name resolves to its node ID via -k."""
+    import sys as _sys
+    _write_pytest_tree(tmp_path)
+    node_ids = harness._collect_node_ids(
+        str(tmp_path), _sys.executable, "test_resolver_target_xyz",
+    )
+    assert node_ids == ["tests/test_alpha.py::test_resolver_target_xyz"], (
+        f"Expected exact-match node ID, got {node_ids!r}.  If this returned "
+        f"[], the resolver is not using -k and pytest is exiting 4 on the "
+        f"bare positional arg (Issue #238 regression)."
+    )
+
+
+def test_collect_node_ids_real_pytest_missing_name_returns_empty(tmp_path: Path):
+    """Real pytest run: a bare name with no matching test yields []."""
+    import sys as _sys
+    _write_pytest_tree(tmp_path)
+    node_ids = harness._collect_node_ids(
+        str(tmp_path), _sys.executable, "test_no_such_function_anywhere",
+    )
+    assert node_ids == []

--- a/tests/test_run_preflight.py
+++ b/tests/test_run_preflight.py
@@ -1,0 +1,218 @@
+"""Tests for the pre-flight ``pytest --collect-only`` integration in run.py.
+
+Issue #238 / #234.  The pre-flight check must:
+  - Run after ``apply_test_patch`` and before ``run_claude``.
+  - Record ``env_fail`` and skip the agent when zero items collect.
+  - Mark the run as a "complete" triple for ``--resume`` purposes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from swebench.models import Problem
+from swebench.run import _is_triple_complete
+
+
+# ---------------------------------------------------------------------------
+# _is_triple_complete recognises env_fail
+# ---------------------------------------------------------------------------
+
+
+INSTANCE = "sympy__sympy-14180"
+ARM = "baseline"
+RUN_IDX = 1
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _paths(tmp_path: Path) -> tuple[Path, Path]:
+    jsonl = tmp_path / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
+    test_txt = tmp_path / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
+    return jsonl, test_txt
+
+
+def test_env_fail_verdict_is_treated_as_complete(tmp_path: Path):
+    """``env_fail`` in the test file's last non-empty line → triple is complete."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"type": "meta", "verdict": "env_fail"}\n')
+    _write(test_txt, "pre-flight collected 0 items\n\nenv_fail\n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) == "env_fail"
+
+
+def test_env_fail_with_trailing_blank_lines(tmp_path: Path):
+    """Trailing whitespace after env_fail is still complete."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"type": "meta"}\n')
+    _write(test_txt, "some output\nenv_fail\n\n   \n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) == "env_fail"
+
+
+def test_unknown_terminal_token_is_incomplete(tmp_path: Path):
+    """Any token other than PASS/FAIL/env_fail → incomplete (must re-run)."""
+    jsonl, test_txt = _paths(tmp_path)
+    _write(jsonl, '{"type": "meta"}\n')
+    _write(test_txt, "stuff\nPENDING\n")
+
+    assert _is_triple_complete(tmp_path, INSTANCE, ARM, RUN_IDX) is None
+
+
+# ---------------------------------------------------------------------------
+# _run_arm short-circuits on pre-flight failure
+# ---------------------------------------------------------------------------
+
+
+def _make_problem(tmp_path: Path) -> Problem:
+    """Build a minimal Problem instance for the env_fail flow."""
+    return Problem(
+        instance_id=INSTANCE,
+        repo_slug="sympy/sympy",
+        base_commit="abc123",
+        test_cmd="python -m pytest test_latex_log",
+        problem_statement="dummy",
+        patch_file=None,  # avoid file system patch operations
+        added_at="2026-01-01",
+        hf_split="test",
+    )
+
+
+def test_run_arm_writes_env_fail_when_preflight_fails(monkeypatch, tmp_path: Path):
+    """When pre-flight reports 0 items, _run_arm must skip the agent and
+    write ``env_fail`` to both the jsonl and the test file."""
+    from swebench import run as run_mod
+
+    # Pre-flight returns False (0 items collected).
+    monkeypatch.setattr(
+        run_mod,
+        "run_preflight_collect",
+        lambda **kw: (False, "no tests ran in 0.05s\n"),
+    )
+    # Resolver passes through unchanged.
+    monkeypatch.setattr(
+        run_mod,
+        "resolve_test_node_ids",
+        lambda cmd, **kw: cmd,
+    )
+    # If git_reset or run_claude is called we want the test to fail.
+    monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+
+    def _boom(*a, **kw):  # pragma: no cover
+        raise AssertionError(
+            "run_claude must not be invoked when pre-flight fails"
+        )
+
+    monkeypatch.setattr(run_mod, "run_claude", _boom)
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    problem = _make_problem(tmp_path)
+
+    verdict = run_mod._run_arm(
+        problem=problem,
+        arm=ARM,
+        run_idx=RUN_IDX,
+        repo_dir=str(repo_dir),
+        venv_dir=str(venv_dir),
+        results_dir=str(results_dir),
+        claude_binary="/usr/bin/claude",
+        mcp_config_path=str(tmp_path / "mcp.json"),
+        root=tmp_path,
+    )
+
+    assert verdict == "env_fail"
+
+    test_txt = results_dir / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
+    assert test_txt.exists()
+    # Last non-empty line is env_fail.
+    last = [line for line in test_txt.read_text().splitlines() if line.strip()][-1]
+    assert last.strip() == "env_fail"
+
+    jsonl = results_dir / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
+    assert jsonl.exists()
+    # Meta record present and well-formed JSON.
+    import json
+    first = json.loads(jsonl.read_text().splitlines()[0])
+    assert first["verdict"] == "env_fail"
+    assert first["instance_id"] == INSTANCE
+
+
+def test_run_arm_proceeds_when_preflight_passes(monkeypatch, tmp_path: Path):
+    """Pre-flight True must NOT short-circuit; downstream agent is invoked."""
+    from swebench import run as run_mod
+
+    monkeypatch.setattr(
+        run_mod,
+        "run_preflight_collect",
+        lambda **kw: (True, ""),
+    )
+    monkeypatch.setattr(
+        run_mod,
+        "resolve_test_node_ids",
+        lambda cmd, **kw: cmd,
+    )
+    monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+
+    invoked = {"count": 0}
+
+    class _StubRunner:
+        surface = "claude_code"
+
+        def build_tools_flags(self, arm, cfg):
+            return []
+
+        def get_version(self, binary):
+            return "test"
+
+        def extract_metadata(self, path):
+            return (None, None)
+
+        def invoke(self, **kw):
+            invoked["count"] += 1
+            # Touch the result file so downstream code does not blow up on
+            # missing-file reads.
+            Path(kw["result_file"]).write_text(
+                '{"type": "result", "total_cost_usd": 0.0, "num_turns": 0}\n'
+            )
+
+    def _stub_run_tests(**kw):
+        Path(kw["result_file"]).write_text("PASS\n")
+        return "PASS"
+
+    monkeypatch.setattr(run_mod, "run_tests", _stub_run_tests)
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    problem = _make_problem(tmp_path)
+
+    verdict = run_mod._run_arm(
+        problem=problem,
+        arm=ARM,
+        run_idx=RUN_IDX,
+        repo_dir=str(repo_dir),
+        venv_dir=str(venv_dir),
+        results_dir=str(results_dir),
+        claude_binary="/usr/bin/claude",
+        mcp_config_path=str(tmp_path / "mcp.json"),
+        root=tmp_path,
+        runner=_StubRunner(),
+    )
+
+    assert verdict == "PASS"
+    assert invoked["count"] == 1


### PR DESCRIPTION
Closes #238 (closes #227, closes #234)

## What changed

Adds two related defenses against the "0 items collected → spurious FAIL" class of bug observed on four sympy SWE-bench instances (sympy-14180, sympy-17318, sympy-19016, sympy-21596). Before this PR these instances stored bare test-function names (`test_issue_12420`) in `test_cmd`; pytest treated them as paths, collected 0 items, and the harness scored legitimate fixes as FAIL.

## Implementation walkthrough

### Sympy bare-name resolver (`swebench/harness.py`)

New `resolve_test_node_ids(test_cmd, *, repo_dir, venv_dir, repo_slug)` helper. When `repo_slug == "sympy/sympy"`, the helper runs `pytest --collect-only -q <bare_name>` inside the instance's venv and rewrites every bare `test_*` token in the command to its full `<path>::<test>` node ID. Non-sympy repos are gated out by the `_REPOS_WITH_BARE_TEST_NAMES` allow-list and never touched. On a 0-result resolution the bare name is left in place so the pre-flight check catches the env failure.

The resolver is wired in two places:
- `run_tests()` accepts a new optional `repo_slug` kwarg and rewrites the command before executing the actual test run.
- `_run_arm()` in `run.py` invokes the resolver explicitly before the pre-flight check, so collection runs against the same final command the tests will use.

### Pre-flight collection check (`swebench/run.py`)

New `run_preflight_collect(repo_dir, test_cmd, venv_dir)` helper in `harness.py`. `_run_arm()` calls it after `apply_test_patch()` and before `run_claude()`. Behaviour:
- 0 items collected (pytest exit 5, or non-zero with no node IDs) → write `env_fail` to both the jsonl meta record and the `*_test.txt` file, skip agent invocation entirely, return `"env_fail"`.
- Items collected → proceed to agent invocation as before.
- Non-pytest test commands (e.g. `python tests/runtests.py …`) → bypass the pre-flight (it does not apply) and run normally.

### `env_fail` plumbing

- `ArmResult.verdict` type comment extended to include `"env_fail"`; no dataclass schema change (still a plain `str`).
- `_is_triple_complete()` treats `env_fail` as a complete verdict so `--resume` skips such runs.
- `swebench/analyze/summary.py` parses `env_fail`, includes it in the per-row table, and emits a per-arm aggregate footer that excludes `env_fail` from both numerator and denominator of `pass_rate`. The arm regex now also recognises `bash_only`.

### Backfill (`swebench/analyze/backfill.py`)

New `python -m swebench analyze backfill` subcommand registered under the `analyze` group. Walks `*_test.txt` files in a results dir; for any file whose body contains a zero-collection marker (`0 items collected`, `no tests ran`, `no tests collected`, `collected 0 items`) and whose terminal line is `FAIL`, rewrites that line to `env_fail`. Idempotent. Supports `--dry-run` for preview.

### Default execution path

**Before**: `git_reset → apply_test_patch → run_claude → run_tests → PASS|FAIL|ERROR`

**After**: `git_reset → apply_test_patch → resolve_test_node_ids → run_preflight_collect → {env_fail | run_claude → run_tests → PASS|FAIL|ERROR}` — pre-flight failure short-circuits the agent and yields `env_fail`. Resolver runs on all paths; pre-flight runs on all paths but is a no-op for non-pytest commands.

## Tier / approach

Tier 2 — Planner → Coder A (harness) + Coder B (run/models) + Coder C (summary/backfill/wiring) + Tester. ADR with 4 open questions resolved before implementation (see `.agent-work/ISSUE_238_ADR.md`).

## Acceptance criteria

- [x] Sympy instances pass full `file::test` node IDs to pytest (no bare test names)
- [x] Pre-flight `pytest --collect-only` runs post-setup, post-patch, pre-agent for every arm
- [x] Results with 0 items collected are recorded as `env_fail`, not `FAIL`
- [x] `analyze summary` shows `env_fail` and excludes it from pass-rate
- [x] Backfill mechanism exists (`python -m swebench analyze backfill`)
- [x] Existing tests pass; new tests cover resolver, pre-flight, env_fail flow, summary, and backfill (456 tests pass)
- [ ] Re-run of sympy-14180, sympy-17318, sympy-19016, sympy-21596 collects > 0 items _(verification deferred to live SWE-bench re-run)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)