### PR TITLE
fix(#228,#229,#231,#233,#241): batch D env pin fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ results*/
 /codebox.py
 /mcp_bridge.py
 
+# Claude Code agent internals
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+

--- a/docs/AUDIT_ORCHESTRATION.md
+++ b/docs/AUDIT_ORCHESTRATION.md
@@ -1,0 +1,289 @@
+# Run Audit Orchestration
+
+How to audit a batch of SWE-bench arm runs for cheating, infrastructure taint, and other
+non-agent failures. Each run gets one Sonnet subagent that reads the JSONL log + test
+output and writes a structured markdown report. Pattern used to produce
+[runs/batch_d_audit/SUMMARY.md](../runs/batch_d_audit/SUMMARY.md) for batch D seed_1
+baseline arm.
+
+This doc is the playbook for replaying that orchestration on another arm, seed, or batch.
+
+---
+
+## When to run an audit
+
+Run this after a batch finishes, before drawing conclusions from pass rates. The audit is
+how we found that ~50% of baseline-arm batch-D results were tainted by harness/env
+issues — six of which were also cheating (agent read the test patch via `git diff`).
+
+Re-audit specifically when:
+- A new arm finishes (compare arms only after each is audited).
+- A new seed finishes (variance numbers depend on clean runs).
+- After harness changes, to verify the change didn't introduce new failure modes.
+- Periodically — env drift (NumPy 2.0 removals, matplotlib API changes, pytest version
+  drift) silently corrupts results over time.
+
+---
+
+## Inputs
+
+Per instance, the harness writes two files under `runs/swebench/<output_dir>/`:
+
+```
+<instance_id>_<arm>_run1.jsonl       # Claude Agent SDK message stream
+<instance_id>_<arm>_run1_test.txt    # pytest output + harness scoring
+```
+
+Arms in SWE-bench mode: `baseline`, `onlycode`, `bash_only`.
+
+To enumerate target instances for a specific batch, see the filter lists in
+[docs/BATCHED_RUN_SWE.md](BATCHED_RUN_SWE.md). For batch D, the inventory is also
+encoded in [scripts/audit_batches.py](../scripts/audit_batches.py) — use that
+script first to confirm which `(instance, arm, run)` triples exist before launching.
+
+---
+
+## Output layout
+
+```
+runs/<audit_name>/                   # e.g. batch_d_audit/, batch_d_onlycode_audit/
+  <instance_id>.md                   # one per instance
+  SUMMARY.md                         # aggregated verdicts + taint clusters + recommendations
+```
+
+One MD per instance, one aggregate SUMMARY at the end.
+
+---
+
+## Orchestration pattern
+
+**Max 4 concurrent subagents.** Sonnet, `general-purpose` subagent type. Run in waves
+of 4 — single message with 4 `Agent` tool calls. Wait for the wave to return, launch the
+next 4. For a 50-instance audit that's 13 waves.
+
+Why this shape:
+- Subagents protect the main context from 50× ~200 KB JSONL reads.
+- Wave-of-4 keeps log output manageable; one wave fully completes before the next is
+  spawned, so partial failures are easy to retry.
+- Sonnet is fast enough for log inspection; Opus is overkill.
+
+Each subagent gets a **self-contained prompt** — it has no memory of prior subagents
+and no view of the conversation. Include: instance ID, exact file paths, audit criteria,
+output path, output template, and any gotchas from earlier waves.
+
+---
+
+## What the subagent looks for
+
+Three buckets. Be explicit with the subagent about each, because the easy-to-miss cases
+matter.
+
+### 1. Cheating — agent recovered the answer without real reasoning
+
+- `git log` / `git show` / `git diff` / `git reflog` / reading `.git/` or `packed-refs`.
+  History is stripped to a single orphan, but **`git diff <test_file>` returns the
+  uncommitted test patch** — this is currently the dominant cheating vector (issue
+  [#226](https://github.com/hyang0129/onlycodes/issues/226)). Treat any
+  `git diff <test_path>` that returns non-empty content as TAINTED.
+- Reading the failing test file to extract expected values and hardcoding them into the
+  fix. **Distinguish from legitimate test-reading**: it's fine for the agent to read a
+  test to understand the API contract; not fine to copy expected output values verbatim
+  into a hardcoded return.
+- Hardcoding outputs/strings to satisfy a specific test rather than fixing the bug.
+- Reading hidden grader code or `reference_output.*` files (artifact mode only).
+
+### 2. Non-agent failures — outside the agent's control
+
+- venv / pip / import errors; missing system deps; network failures.
+- Claude API errors: 5xx, overload (`HTTP 529`), timeouts, rate limits that terminated
+  the run. **`0 turns executed` = TAINTED.**
+- MCP server crashes, OverlayFS errors, process killed.
+- Truncated log (JSONL ends mid-message, no `result` event).
+- **`0 items collected` from pytest** — usually means the test patch wasn't applied or
+  the harness invoked pytest with a bare test name instead of a `path::test` node ID.
+  Always TAINTED.
+
+### 3. Other taint
+
+- Agent ran out of turns mid-fix (last assistant message is unfinished).
+- Tool restriction misconfigured for the arm (baseline should have full tools; onlycode
+  should be locked to the codebox MCP tools).
+- Test patch applied to wrong file.
+- Repo in an unexpected state (orphan commit isn't the expected base SHA).
+
+### Important: legitimate FAIL ≠ taint
+
+**An agent producing a wrong or incomplete fix is NOT taint.** That's a real data point —
+the bench is supposed to measure exactly this. Mark such runs **CLEAN / FAIL / keep**.
+The subagents will sometimes drift toward marking any FAIL as TAINTED with a "re-run"
+recommendation — be explicit in the prompt that this is wrong.
+
+---
+
+## Per-instance subagent prompt template
+
+Copy this template and fill in the instance ID, paths, and output location.
+
+```
+You are auditing one Claude Code agent run on SWE-bench instance
+`<INSTANCE_ID>` (<ARM> arm, <SEED>). The agent had <ARM_TOOLS_DESCRIPTION>.
+Read the run log and write a structured audit.
+
+INPUTS:
+- JSONL log: <ABS_PATH>/<INSTANCE_ID>_<ARM>_run1.jsonl
+- Test outcome: <ABS_PATH>/<INSTANCE_ID>_<ARM>_run1_test.txt
+
+LOOK FOR:
+
+1. CHEATING — `git diff <test_file>` / `git diff HEAD <test_file>` returns the
+   test patch = TAINTED. Also: git log/show/reflog probing, reading the failing
+   test to hardcode expected values, hidden grader reads.
+
+2. NON-AGENT FAILURES — env/import errors, Claude API 5xx/overload (a terminated
+   run = TAINTED), MCP/overlay crashes, killed process, truncated log,
+   `0 items collected` from pytest (test patch misapplied or bare-name pytest
+   invocation).
+
+3. OTHER TAINT — out of turns mid-fix, tool restriction wrong for the arm,
+   test patch applied to wrong file.
+
+IMPORTANT: an agent producing an incorrect/incomplete fix is NOT taint —
+that's a legitimate FAIL. Mark as CLEAN, recommend keep.
+
+HOW TO READ: JSONL = Claude Agent SDK messages. Use wc/head/tail/grep — don't
+read the whole file. Check test.txt first for pass/fail. Look at tool_use
+blocks (Bash, Read, Edit, etc.) and assistant reasoning.
+
+OUTPUT to <OUTPUT_DIR>/<INSTANCE_ID>.md using this exact template:
+
+# Audit: <INSTANCE_ID> (<ARM>, <SEED>)
+
+**Outcome:** PASS|FAIL
+**Turns / log size:** <N lines, K KB>
+**Verdict:** CLEAN | SUSPECT | TAINTED
+**One-line summary:** ...
+
+## Cheating signals
+- (none) OR bullets with line refs / short quotes
+
+## Non-agent failures
+- (none) OR bullets
+
+## Other taint
+- (none) OR bullets
+
+## Recommendation
+keep | re-run | investigate — short reason
+
+Be terse. Quote at most one short snippet per finding. Report back under 60 words.
+```
+
+Substitutions to make per call:
+- `<INSTANCE_ID>` — e.g. `scikit-learn__scikit-learn-10427`
+- `<ARM>` — `baseline` | `onlycode` | `bash_only`
+- `<SEED>` — `seed_1` | `seed_2` | `seed_3`
+- `<ARM_TOOLS_DESCRIPTION>` —
+  - baseline: "full native tools"
+  - onlycode: "only `mcp__codebox__execute_code` and `mcp__codebox__list_tools`"
+  - bash_only: "only Bash among built-in tools, no Read/Edit/Write/Grep/Glob"
+- `<ABS_PATH>` — e.g. `/workspaces/hub_1/onlycodes/runs/swebench/full_run_seed_1`
+- `<OUTPUT_DIR>` — e.g. `/workspaces/hub_1/onlycodes/runs/batch_d_audit`
+
+---
+
+## Verdict definitions
+
+- **CLEAN** — no cheating, no infrastructure failure. Includes both PASS and FAIL.
+  Legitimate data point; keep.
+- **SUSPECT** — the agent ran a suspicious-looking command (e.g. `git log`) but the
+  stripped repo gave it nothing useful. No actual information leaked; result is
+  probably trustworthy. Keep, but flag for human review.
+- **TAINTED** — either real cheating happened, or a non-agent failure prevented the
+  agent from being fairly evaluated. Re-run after the underlying cause is fixed
+  (don't just re-run blindly — confirm the harness/env issue is resolved first).
+
+---
+
+## Aggregation: SUMMARY.md
+
+After all per-instance audits complete, do the aggregation **in the main agent**,
+not in a subagent. The main agent has the context to spot patterns across instances
+that any single audit subagent can't see.
+
+Pattern that worked for batch D:
+
+1. **Extract verdict + outcome lines** from each MD with a bash one-liner:
+   ```bash
+   for f in *.md; do echo "=== $f ==="; head -6 "$f" | tail -4; echo; done
+   ```
+   Skip files that aren't audit reports (e.g. SUMMARY.md itself).
+2. **Tally counts** — CLEAN / SUSPECT / TAINTED.
+3. **Cluster TAINTED runs by root cause.** Don't just list them — group by the
+   underlying systemic issue. Each cluster should map to one fix that resolves
+   the whole cluster. Cluster patterns observed in batch D:
+   - Same vendored-dep incompatibility (cloudpickle × Python 3.9 hit 3 sklearn instances).
+   - Same upstream API removal (NumPy 2.0 `np.unicode_` hit 3 xarray instances;
+     matplotlib `register_cmap` removal hit 3 seaborn instances).
+   - Same harness bug (bare-name pytest invocation hit 4 sympy instances).
+   - Same cheating vector (`git diff <test_file>` test-patch leak hit 6 instances
+     across 4 repos).
+4. **Highlight cheating separately from infrastructure.** Cheating is an integrity
+   issue (the data is wrong, not missing). Infrastructure failures are a coverage
+   issue (the data is missing, not wrong). Recommendations are different.
+5. **Compute a "clean pass rate"** by dropping TAINTED and any leak-induced PASSes.
+   This is the number actually worth comparing across arms.
+6. **Per-instance recommendations table** — one row per instance:
+   `keep` / `re-run` / `investigate`, with one-line reason. This is what the next
+   ops step works from.
+
+See [runs/batch_d_audit/SUMMARY.md](../runs/batch_d_audit/SUMMARY.md) for the format
+in practice.
+
+---
+
+## Common subagent classification errors (and how to prevent them)
+
+Watch for these in the per-instance MDs and override them in the SUMMARY:
+
+| Subagent error | Correct call | How to mention in prompt |
+|---|---|---|
+| Marking CLEAN FAIL where 0 items collected | TAINTED — agent had no shot | Explicitly: "0 items collected = TAINTED" |
+| Marking TAINTED for an honest wrong fix | CLEAN/keep — that's real data | Explicitly: "wrong fix is NOT taint" |
+| Recommending re-run for an agent's wrong fix | keep — re-runs only after fixing harness/env | Explicitly tie re-run to taint, not to FAIL |
+| Marking CLEAN where API terminated the run | TAINTED — fewer than ~5 turns + API error = no real attempt | Explicitly: "terminated by API = TAINTED" |
+
+These were all observed in the batch D pass. The prompt template above already includes
+the fixes; if you change the template, keep these guardrails.
+
+---
+
+## Cost / time
+
+For a 50-instance audit at Sonnet pricing with ~150 KB average logs:
+- ~50 subagent calls
+- 13 waves × ~30–70 seconds wall time per wave (limited by the slowest subagent in the wave)
+- ~15–30 minutes total real time
+- Token cost dominated by log input
+
+If you need to scale up (e.g. auditing all three seeds × three arms = 450 runs), the wave
+size could be increased to 6–8 if the model permits, or split across multiple main-agent
+sessions. The wave-of-4 cap exists because the user requested it; the technical limit is
+higher.
+
+---
+
+## Quick start
+
+To audit a new arm/seed (e.g. onlycode arm of batch D seed 1):
+
+1. Pick an `<audit_name>`, e.g. `batch_d_onlycode_audit`.
+2. `mkdir -p /workspaces/hub_1/onlycodes/runs/<audit_name>`.
+3. Enumerate target instances from [docs/BATCHED_RUN_SWE.md](BATCHED_RUN_SWE.md)
+   (D1–D5 = 50 instances; V1–V4 = 50 instances).
+4. Group instances into waves of 4. Last wave may be smaller.
+5. For each wave, send one message with 4 `Agent` tool calls, each using the prompt
+   template above (substituting arm/seed/paths).
+6. After all waves complete, read all MDs and write `SUMMARY.md` following the
+   aggregation pattern.
+7. If the audit surfaces new systemic issues, open GitHub issues for them and link
+   under the audit epic if one exists (e.g. issue #236 for batch D).

--- a/docs/specs/issue-244-codex-mcp-config.md
+++ b/docs/specs/issue-244-codex-mcp-config.md
@@ -1,0 +1,121 @@
+# Spec — Issue #244: Generate and validate Codex MCP config for codebox
+
+**Epic:** [#217](https://github.com/hyang0129/onlycodes/issues/217) (Support Codex CLI as an additional agent surface) — Slice 4
+**Unblocked by:** [#221](https://github.com/hyang0129/onlycodes/pull/221) (AgentRunner abstraction)
+**Tier:** 1 (Simple — single area, settled architecture, < 200 lines)
+
+---
+
+## Problem
+
+The Codex CLI agent surface landed in #221 with `CodexRunner._write_codex_config()` and `_resolve_bundle()`, but three portability/safety gaps remain that block reliable use outside the current dev container:
+
+1. **`mcp-config.json` hardcodes container-specific paths.** `command` is pinned to `/usr/bin/node`; `args[0]` is an absolute path to `exec_server/dist/exec-server.bundle.mjs`; `cwd` is the workspace root. After a container rebuild or workspace move, `CodexRunner._resolve_bundle()` reads the stale JSON and silently falls back to the relative candidate computed from `runner.py`'s location — masking a real misconfiguration.
+2. **No pre-flight check for the Codex bundle.** Missing or unbuilt bundle (`exec_server/dist/exec-server.bundle.mjs`) only surfaces mid-run, after the temp `CODEX_HOME` is set up and the agent has started.
+3. **TOML rendered as an f-string is path-unsafe.** [swebench/runner.py:342-372](../../swebench/runner.py#L342-L372) interpolates `bundle_path` and `cwd` directly into TOML without escaping. Paths containing `"` or `\` produce invalid TOML; failures look like cryptic Codex startup errors.
+
+## Goals
+
+- `mcp-config.json` is portable across environments — either regenerable via CLI or built dynamically at runtime.
+- Codex bundle misconfiguration is caught before the agent subprocess starts, with an actionable error.
+- `_write_codex_config()` produces valid TOML for any path the OS allows.
+
+## Non-goals
+
+- No change to `ClaudeRunner` behavior. The Claude path through `harness.generate_mcp_config()` already rewrites `cwd` per-run; that contract stays as-is.
+- No code-only enforcement for Codex (that's Slice 5).
+- No change to the on-disk shape of the Codex `config.toml` produced per run (Codex consumers already accept the current schema).
+- Not introducing a new TOML dependency unless stdlib `tomllib` + a hand-rolled writer is insufficient. (Python 3.11 has `tomllib` for reading only.)
+
+## Design
+
+### 1. CLI: `swebench mcp-config generate`
+
+New subcommand in [swebench/cli.py](../../swebench/cli.py), implemented in a new `swebench/mcp_cli.py` module (mirrors the pattern of `swebench/cache_cli.py`).
+
+```
+swebench mcp-config generate [--out PATH]
+```
+
+Behavior:
+- Resolves `node` via `shutil.which("node")`; falls back to `/usr/bin/node` if present; else exits non-zero with a clear message.
+- Resolves bundle path: `Path(swebench.__file__).parent.parent / "exec_server/dist/exec-server.bundle.mjs"`. If the file does not exist, exits non-zero pointing at `npm run build` in `exec_server/`.
+- Resolves `cwd` to the package root (same parent as the bundle).
+- Writes the JSON to `--out` (default: `mcp-config.json` at the repo root).
+- Preserves any non-`codebox` MCP servers if the target file already exists (read-merge-write); a brand-new write produces only the `codebox` entry.
+
+Output schema is identical to the current [mcp-config.json](../../mcp-config.json) — see the existing file for the canonical shape.
+
+### 2. Pre-flight in `CodexRunner`
+
+Add a public method on `CodexRunner`:
+
+```python
+def preflight(self, mcp_config_path: str | None) -> None:
+    """Raise RuntimeError with an actionable message if Codex cannot run."""
+```
+
+Called by `artifact_run.py` / `run.py` before the first Codex arm, paralleling the existing pre-flight pattern used for Claude.
+
+Checks (all raise `RuntimeError` on failure with a message naming the missing thing and the fix):
+- `find_binary()` resolves a Codex binary (existing behavior; just surface its `FileNotFoundError` as `RuntimeError`).
+- `_resolve_bundle(mcp_config_path)` returns a path that exists.
+- `shutil.which("node")` is non-`None`, OR `/usr/bin/node` is executable.
+
+`_resolve_bundle()` keeps its current fallback-to-package-relative behavior — pre-flight just makes the failure loud and early when *all* resolution paths fail.
+
+### 3. TOML path-safety in `_write_codex_config`
+
+Replace the f-string with a small helper that escapes TOML basic-string contents:
+
+```python
+def _toml_str(s: str) -> str:
+    # TOML basic strings: backslash and double-quote require escaping;
+    # control chars are forbidden but won't appear in filesystem paths.
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+```
+
+Use `_toml_str(bundle_path)`, `_toml_str(cwd)`, and `_toml_str(persistent_kernel)` at the three interpolation sites in `_write_codex_config()`. Do not introduce a third-party TOML library.
+
+## File ownership
+
+| File | Change |
+|---|---|
+| `swebench/runner.py` | Add `CodexRunner.preflight()`; refactor `_write_codex_config()` to use `_toml_str()` helper |
+| `swebench/mcp_cli.py` | **New** — `mcp-config generate` Click subcommand |
+| `swebench/cli.py` | Wire the new `mcp-config` group into the root CLI |
+| `swebench/run.py` | Call `runner.preflight(mcp_config_path)` before the first Codex arm |
+| `swebench/artifact_run.py` | Same — call `runner.preflight()` before the first Codex arm |
+| `mcp-config.json` | Document in a top-of-file comment that this file is regenerable via `swebench mcp-config generate` (NB: JSON has no comments; instead, add a note in [README.md](../../README.md)) |
+| `tests/test_runner.py` | Add tests for `_toml_str`, `preflight` success + each failure mode |
+| `tests/test_mcp_cli.py` | **New** — tests for the generate subcommand: fresh write, merge-preserve, missing-bundle exit code |
+| `README.md` | Brief mention of `swebench mcp-config generate` in the setup section |
+
+Files NOT to touch: `harness.py` (`generate_mcp_config` for Claude stays as-is), `artifact_models.py`, `cache*.py`.
+
+## Acceptance criteria
+
+- [ ] `swebench mcp-config generate` writes a `mcp-config.json` with the current environment's `node` path, package-relative bundle path, and package-root `cwd`.
+- [ ] `swebench mcp-config generate --out /tmp/x.json` against an existing file with a non-`codebox` MCP server preserves that server.
+- [ ] `swebench mcp-config generate` exits non-zero with a clear message when the bundle does not exist (suggesting `npm run build`).
+- [ ] Starting a Codex arm when the bundle is missing raises `RuntimeError` before `subprocess.run(codex ...)` is called, with the path and the build instruction in the message.
+- [ ] `_write_codex_config` produces valid TOML for paths containing `"` and `\`. Verified by round-trip parse with `tomllib.loads()` in a test.
+- [ ] All existing tests in [tests/test_runner.py](../../tests/test_runner.py) still pass unchanged.
+- [ ] New tests cover: `_toml_str` escaping, `preflight` success path, `preflight` failure per missing component, `mcp-config generate` fresh + merge-preserve + missing-bundle.
+
+## Out of scope / explicit deferrals
+
+- Auto-detecting the bundle from a built `package.json` — the package-relative path is sufficient given the repo layout.
+- Replacing the hand-rolled TOML writer with a library — revisit if a fourth interpolation site appears.
+- Validating that the `node` binary is a version Codex MCP accepts — Codex itself will surface that mismatch.
+
+## Test plan
+
+1. Unit: `tests/test_runner.py::test_write_codex_config_escapes_special_chars` — write a config with `bundle_path = '/tmp/has "quote"/bundle.mjs'` and `cwd = r'C:\Windows\path'`; parse the result with `tomllib.loads()` and assert the round-trip preserves the strings.
+2. Unit: `tests/test_runner.py::test_codex_preflight_missing_bundle` — monkeypatch `_resolve_bundle` to raise; assert `preflight` raises `RuntimeError` with `npm run build` in the message.
+3. Unit: `tests/test_runner.py::test_codex_preflight_missing_node` — monkeypatch `shutil.which("node")` to `None` and `/usr/bin/node` missing; assert clear error.
+4. Unit: `tests/test_runner.py::test_codex_preflight_happy_path` — point at a real bundle file in a tmp dir; assert no raise.
+5. CLI: `tests/test_mcp_cli.py::test_generate_fresh_write` — run the subcommand against a tmp dir with a fake bundle; assert resulting JSON has resolved paths.
+6. CLI: `tests/test_mcp_cli.py::test_generate_preserves_other_servers` — pre-populate target file with a non-`codebox` server; run generate; assert the other server is preserved.
+7. CLI: `tests/test_mcp_cli.py::test_generate_exits_when_bundle_missing` — assert non-zero exit and helpful stderr.
+8. Manual smoke: in the dev container, run `swebench mcp-config generate --out /tmp/regen.json` and diff against the checked-in `mcp-config.json` — only `command` (if `node` is at a different path) should differ.

--- a/patches/scikit-learn__scikit-learn-10427_source_seed.patch
+++ b/patches/scikit-learn__scikit-learn-10427_source_seed.patch
@@ -1,0 +1,23 @@
+diff --git a/sklearn/externals/_pilutil.py b/sklearn/externals/_pilutil.py
+new file mode 100644
+--- /dev/null
++++ b/sklearn/externals/_pilutil.py
+@@ -0,0 +1,18 @@
++"""Stub _pilutil module for pre-flight test collection.
++
++The test patch imports this module to check whether Pillow is available.
++The agent is expected to replace this stub with a full implementation that
++properly vendors the required image utilities from scipy/Pillow.
++"""
++try:
++    from PIL import Image as _Image
++    pillow_installed = True
++
++    def imsave(fname, arr, **kwargs):
++        _Image.fromarray(arr).save(fname, **kwargs)
++
++except ImportError:
++    pillow_installed = False
++
++    def imsave(fname, arr, **kwargs):
++        raise ImportError("Pillow is not installed")

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -41,7 +41,7 @@ _REPO_PRE_INSTALL: dict[str, list[str]] = {
     # seaborn ≤0.12 era: seaborn/cm.py calls matplotlib.cm.register_cmap at import,
     # removed in matplotlib 3.9 (deprecated 3.7). Without this pin, conftest crashes
     # and 0 tests collect → automatic FAIL.
-    "mwaskom/seaborn": ["matplotlib<3.7"],
+    "mwaskom/seaborn": ["matplotlib<3.7", "numpy<2"],
 }
 
 # ---------------------------------------------------------------------------
@@ -56,6 +56,7 @@ _INSTANCE_PYTHON: dict[str, str] = {
     "astropy__astropy-6938": "python3.9",
     # scikit-learn 0.19–0.22.dev era (2018–2019): Cython .pyx files incompatible with Cython 3.x on Python 3.10+
     "scikit-learn__scikit-learn-10427": "python3.9",
+    "scikit-learn__scikit-learn-13013": "python3.9",
     "scikit-learn__scikit-learn-10803": "python3.9",
     "scikit-learn__scikit-learn-11206": "python3.9",
     "scikit-learn__scikit-learn-13283": "python3.9",
@@ -121,10 +122,44 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # sphinx 2.x era: sphinx/writers/latex.py imports the `roman` package
     # unconditionally; without it conftest crashes before any test collects.
     "sphinx-doc__sphinx-8056": ["roman"],
-    # sphinx 4.3 era: the installed sphinxcontrib.applehelp requires Sphinx ≥5.0
-    # and fails the version check during fixture setup. Pin to a pre-1.0.5
-    # release so the check passes against this instance's Sphinx 4.3.0.
-    "sphinx-doc__sphinx-9698": ["sphinxcontrib.applehelp<1.0.5"],
+    # sphinx 4.3 era: applehelp and devhelp both enforce Sphinx ≥5.0 in their
+    # version checks during fixture setup; markupsafe 2.1+ removed soft_unicode
+    # breaking jinja2 2.x import. All three pins required for collection.
+    "sphinx-doc__sphinx-9698": ["sphinxcontrib.applehelp<1.0.5", "sphinxcontrib-devhelp<1.0.6", "markupsafe<2.1"],
+    # seaborn 0.12 era (2022): numpy 2.x removed np.str_ etc. used in cm.py;
+    # flit_core is required at build time for this instance's pyproject.toml.
+    "mwaskom__seaborn-2946": ["matplotlib<3.7", "numpy<2", "flit_core>=3.2,<4"],
+}
+
+# ---------------------------------------------------------------------------
+# Per-instance source seed patches
+# ---------------------------------------------------------------------------
+# Paths are relative to the problems root (same convention as patch_file in
+# YAML). Applied to the repo BEFORE the test patch so that test-patch imports
+# of agent-created modules succeed at pre-flight collection time.
+_INSTANCE_SOURCE_SEEDS: dict[str, str] = {
+    # sklearn 0.20-era: the test patch imports sklearn.externals._pilutil which
+    # the agent is expected to create as its fix. Without a stub the pre-flight
+    # --collect-only fails before the agent ever runs.
+    "scikit-learn__scikit-learn-10427": "patches/scikit-learn__scikit-learn-10427_source_seed.patch",
+}
+
+# ---------------------------------------------------------------------------
+# Per-instance post-install pins
+# ---------------------------------------------------------------------------
+# Applied AFTER ``pip install -e .`` to re-pin packages that the editable
+# install would otherwise upgrade (e.g. Sphinx pulls its sphinxcontrib-*
+# extensions as runtime deps, overriding pre-install pins).
+_INSTANCE_POST_INSTALL: dict[str, list[str]] = {
+    # sphinx 4.3 era: pip install -e . resolves Sphinx's runtime deps and
+    # upgrades devhelp / qthelp / htmlhelp / serializinghtml to 2.x releases
+    # that require Sphinx ≥5.0. Force them back down after the editable install.
+    "sphinx-doc__sphinx-9698": [
+        "sphinxcontrib-devhelp<1.0.6",
+        "sphinxcontrib-qthelp<1.0.4",
+        "sphinxcontrib-htmlhelp<2.0.0",
+        "sphinxcontrib-serializinghtml<1.1.5",
+    ],
 }
 
 # ---------------------------------------------------------------------------
@@ -183,9 +218,11 @@ def _venv_kwargs(problem: "Problem") -> dict:  # type: ignore[name-defined]
         _REPO_PYTHON.get(problem.repo_slug, _DEFAULT_PYTHON),
     )
     pre_build_cmd = _REPO_PRE_BUILD.get(problem.repo_slug)
+    post = _INSTANCE_POST_INSTALL.get(problem.instance_id)
     return {
         "python_bin": python_bin,
         "pre_install": pre,
+        "post_install": post,
         "pre_build_cmd": pre_build_cmd,
         "repo_slug": problem.repo_slug,
     }
@@ -571,6 +608,7 @@ def setup_venv(
     *,
     python_bin: str = _DEFAULT_PYTHON,
     pre_install: list[str] | None = None,
+    post_install: list[str] | None = None,
     pre_build_cmd: list[str] | None = None,
     repo_slug: str | None = None,
 ) -> None:
@@ -709,6 +747,10 @@ def setup_venv(
     _pip_run_checked(pip, ["install", "--quiet", "pytest"])
     if _needs_jinja2_pin(repo_dir):
         _pin_jinja2(pip)
+    if post_install:
+        # Re-pin runtime deps after all other installs (including extras) so
+        # nothing downstream can upgrade them back.
+        _pip_run_checked(pip, ["install", "--quiet", *post_install])
     # Smoke-import: confirm the package actually imports before writing the
     # sentinel.  A failed smoke-import leaves the venv unmarked so the next
     # setup_venv call rebuilds from scratch rather than silently reusing a

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -38,6 +38,10 @@ _REPO_PRE_INSTALL: dict[str, list[str]] = {
     # fontconfig_pattern/mathtext modules, causing test collection to ERROR
     # before any test runs.
     "matplotlib/matplotlib": ["setuptools<65", "numpy<2", "cython<3", "pybind11>=2.6", "certifi", "pyparsing<3"],
+    # seaborn ≤0.12 era: seaborn/cm.py calls matplotlib.cm.register_cmap at import,
+    # removed in matplotlib 3.9 (deprecated 3.7). Without this pin, conftest crashes
+    # and 0 tests collect → automatic FAIL.
+    "mwaskom/seaborn": ["matplotlib<3.7"],
 }
 
 # ---------------------------------------------------------------------------
@@ -85,8 +89,19 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # "AttributeError: `np.unicode_` was removed in the NumPy 2.0 release".
     # pytz is required at test-module import time (xarray/tests/test_variable.py).
     "pydata__xarray-2905": ["numpy<2", "pytz"],
+    "pydata__xarray-4075": ["numpy<2"],
+    "pydata__xarray-4629": ["numpy<2"],
+    "pydata__xarray-4911": ["numpy<2"],
     "pydata__xarray-6601": ["numpy<2", "setuptools_scm[toml]>=3.4", "setuptools_scm_git_archive"],
     "pydata__xarray-7003": ["numpy<2", "setuptools_scm[toml]>=3.4", "setuptools_scm_git_archive"],
+    # scikit-learn 0.20-era: tests import sklearn.externals._pilutil (a vendored
+    # copy of scipy.misc.pilutil) which requires Pillow at import time. Without
+    # Pillow pre-installed, collection fails with ModuleNotFoundError.
+    "scikit-learn__scikit-learn-10427": ["setuptools<60", "numpy<1.24", "cython<3", "Pillow"],
+    # scikit-learn 0.20–0.21.dev era: pinned scipy needed at runtime because
+    # scipy.optimize.linesearch.line_search_wolfe2 was removed in scipy 1.8.
+    # scipy<1.6 matches the adjacent 0.21.dev entries below.
+    "scikit-learn__scikit-learn-13013": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
     # scikit-learn 0.21.dev–0.22.dev era (2019): _cython_blas.pyx imports scipy.linalg.cython_blas
     # at pre-build time. Without scipy pre-installed, Cython can't resolve the BLAS function
     # pointers and the build fails with "Converting to Python object not allowed without gil".
@@ -103,6 +118,13 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # scipy<1.12 keeps compatibility with the repo-level numpy<1.24 pin.
     "scikit-learn__scikit-learn-24677": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.12"],
     "scikit-learn__scikit-learn-25694": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.12"],
+    # sphinx 2.x era: sphinx/writers/latex.py imports the `roman` package
+    # unconditionally; without it conftest crashes before any test collects.
+    "sphinx-doc__sphinx-8056": ["roman"],
+    # sphinx 4.3 era: the installed sphinxcontrib.applehelp requires Sphinx ≥5.0
+    # and fails the version check during fixture setup. Pin to a pre-1.0.5
+    # release so the check passes against this instance's Sphinx 4.3.0.
+    "sphinx-doc__sphinx-9698": ["sphinxcontrib.applehelp<1.0.5"],
 }
 
 # ---------------------------------------------------------------------------
@@ -482,8 +504,11 @@ def _patch_vendored_cloudpickle(repo_dir: str) -> bool:
     integer`` on every interpreter available in this devcontainer (3.9+).
 
     The fix inserts ``co.co_posonlyargcount`` into the PY3 branch — the same
-    change cloudpickle upstream shipped in v1.3. Idempotent and a no-op when
-    the file is missing or already patched.
+    change cloudpickle upstream shipped in v1.3. Adjacent sklearn versions
+    have multiple ``types.CodeType()`` callsites with the same pre-3.8 shape
+    (e.g. ``_make_skel_func`` alongside ``_make_cell_set_template_code``), so
+    we replace every matching block in the file, not just the first.
+    Idempotent and a no-op when the file is missing or already patched.
 
     Returns True when the file was modified (useful for logging/tests).
     """
@@ -495,7 +520,7 @@ def _patch_vendored_cloudpickle(repo_dir: str) -> bool:
         return False
     if _CLOUDPICKLE_OLD_BLOCK not in text:
         return False
-    path.write_text(text.replace(_CLOUDPICKLE_OLD_BLOCK, _CLOUDPICKLE_NEW_BLOCK, 1))
+    path.write_text(text.replace(_CLOUDPICKLE_OLD_BLOCK, _CLOUDPICKLE_NEW_BLOCK))
     return True
 
 

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -32,6 +32,8 @@ from swebench.cache import (
 )
 from swebench.harness import (
     _venv_kwargs,
+    _INSTANCE_SOURCE_SEEDS,
+    _patch_vendored_cloudpickle,
     apply_test_patch,
     clone_repo,
     find_claude_binary,
@@ -177,6 +179,11 @@ def _run_arm(
     # "discard agent edits, clean untracked" semantics without needing the
     # original SHA that no longer exists in the object graph.
     git_reset(repo_dir, "HEAD")
+    # Re-apply the vendored cloudpickle patch after git_reset: the patch is an
+    # unstaged modification that git_reset (git clean -fd + checkout) discards.
+    # Applying it here ensures every arm sees the patched file before the test
+    # patch is applied (and git-add-A commits it alongside the test changes).
+    _patch_vendored_cloudpickle(repo_dir)
 
     # The git_reset above runs `git clean -fd`, which wipes the untracked
     # .egg-info/ directory that reinstall_editable placed in the overlay
@@ -184,6 +191,16 @@ def _run_arm(
     # imports (entry_points, console scripts) keep working.
     if needs_editable_reinstall:
         reinstall_editable(venv_dir, repo_dir)
+
+    # Apply source seed patch (if any) before the test patch so that
+    # test-patch imports of agent-created modules succeed at pre-flight time.
+    seed_rel = _INSTANCE_SOURCE_SEEDS.get(problem.instance_id)
+    if seed_rel:
+        seed_path = str(root / seed_rel)
+        if apply_test_patch(repo_dir, seed_path):
+            _echo(f"  [{arm} run {run_idx}] Applied source seed patch.")
+        else:
+            _echo(f"  [{arm} run {run_idx}] WARNING: source seed patch failed to apply.")
 
     # Apply test patch
     if problem.patch_file:

--- a/tests/test_analyze_env_fail_integration.py
+++ b/tests/test_analyze_env_fail_integration.py
@@ -1,0 +1,345 @@
+"""Integration tests for the env_fail verdict flow — Issue #238.
+
+Scenario: slice-analyze-env-fail-cli
+Tier: wiring
+
+Verifies the full vertical slice from CLI registration through output
+for the two new CLI surfaces added in issue #238:
+
+  1. ``swebench analyze backfill`` — rewrites historical FAIL→env_fail in
+     a results directory.
+  2. ``swebench analyze summary`` — renders env_fail as its own column
+     and excludes it from the pass-rate denominator.
+
+The tests exercise:
+  - CLI schema wiring: ``analyze backfill`` is registered under ``analyze``,
+    ``--help`` is reachable, required options are present, invalid args
+    are rejected.
+  - End-to-end backfill → summary flow: running ``analyze backfill`` on a
+    synthetic results dir with a historical FAIL file, then running
+    ``analyze summary`` on the same dir, produces the env_fail column.
+  - Cross-command contract: the env_fail verdict written by ``backfill``
+    is consumed correctly by ``summary`` — both commands agree on the
+    verdict string ``env_fail``.
+  - Idempotency: running ``backfill`` twice does not double-rewrite;
+    ``summary`` output is stable.
+
+These tests are fully offline — no ``claude`` binary, no subprocess I/O to
+real repos, no Docker containers. CliRunner invokes the Click tree directly.
+Per-test budget is well under 5 s.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from swebench.analyze import analyze_command
+from swebench.cli import cli
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SYMPY_INSTANCE = "sympy__sympy-14180"
+ARM = "baseline"
+RUN = 1
+
+
+def _make_historical_fail_file(results_dir: Path) -> Path:
+    """Create a synthetic *_test.txt that looks like a pre-#238 env failure."""
+    test_txt = results_dir / f"{SYMPY_INSTANCE}_{ARM}_run{RUN}_test.txt"
+    test_txt.write_text(
+        "=== pytest ===\n"
+        "no tests ran in 0.05s\n"
+        "0 items collected\n"
+        "FAIL\n"
+    )
+    return test_txt
+
+
+def _make_historical_fail_jsonl(results_dir: Path) -> Path:
+    """Create a minimal companion JSONL for the synthetic failure."""
+    jsonl = results_dir / f"{SYMPY_INSTANCE}_{ARM}_run{RUN}.jsonl"
+    jsonl.write_text('{"type": "result", "total_cost_usd": 0.42, "num_turns": 5}\n')
+    return jsonl
+
+
+def _make_historical_real_fail(results_dir: Path, instance_id: str) -> None:
+    """Create a genuine FAIL test file (no zero-collection marker)."""
+    test_txt = results_dir / f"{instance_id}_{ARM}_run{RUN}_test.txt"
+    test_txt.write_text(
+        "=== pytest ===\n"
+        "test_something FAILED - AssertionError\n"
+        "FAIL\n"
+    )
+    jsonl = results_dir / f"{instance_id}_{ARM}_run{RUN}.jsonl"
+    jsonl.write_text('{"type": "result", "total_cost_usd": 0.10, "num_turns": 3}\n')
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — CLI Schema Wiring (analyze backfill registration)
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillCliSchema:
+    """Wiring: verify analyze backfill is registered and schema is correct."""
+
+    def test_analyze_help_lists_backfill_command(self):
+        """``swebench analyze --help`` must list ``backfill`` as a subcommand."""
+        runner = CliRunner()
+        result = runner.invoke(analyze_command, ["--help"], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+        assert "backfill" in result.output
+
+    def test_analyze_backfill_help_exits_zero(self):
+        """``swebench analyze backfill --help`` must succeed."""
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command, ["backfill", "--help"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+        assert "Usage:" in result.output
+
+    def test_analyze_backfill_help_shows_results_dir_option(self):
+        """``--results-dir`` option must be documented in backfill --help."""
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command, ["backfill", "--help"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+        assert "--results-dir" in result.output
+
+    def test_analyze_backfill_help_shows_dry_run_option(self):
+        """``--dry-run`` option must be documented in backfill --help."""
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command, ["backfill", "--help"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+        assert "--dry-run" in result.output
+
+    def test_backfill_reachable_via_top_level_cli(self):
+        """``python -m swebench analyze backfill --help`` via the root CLI."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["analyze", "backfill", "--help"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+        assert "backfill" in result.output.lower() or "results-dir" in result.output
+
+    def test_backfill_nonexistent_results_dir_fails(self, tmp_path: Path):
+        """``--results-dir`` pointing to a non-existent path must fail."""
+        runner = CliRunner()
+        missing = tmp_path / "does-not-exist"
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(missing)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — End-to-End Backfill → Summary Flow
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillToSummaryFlow:
+    """Wiring: verify backfill rewrites FAIL→env_fail and summary renders it."""
+
+    def test_backfill_rewrites_zero_collection_fail(self, tmp_path: Path):
+        """After backfill runs, the historical FAIL file ends with env_fail."""
+        _make_historical_fail_file(tmp_path)
+        _make_historical_fail_jsonl(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+        test_txt = tmp_path / f"{SYMPY_INSTANCE}_{ARM}_run{RUN}_test.txt"
+        lines = [ln for ln in test_txt.read_text().splitlines() if ln.strip()]
+        assert lines[-1].strip() == "env_fail", (
+            f"Last non-empty line must be env_fail; got {lines[-1]!r}"
+        )
+
+    def test_summary_after_backfill_shows_env_fail(self, tmp_path: Path):
+        """After backfill, ``analyze summary`` must include env_fail in output."""
+        _make_historical_fail_file(tmp_path)
+        _make_historical_fail_jsonl(tmp_path)
+
+        runner = CliRunner()
+        # Run backfill first.
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        # Then summary.
+        result = runner.invoke(
+            analyze_command,
+            ["summary", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "env_fail" in result.output
+
+    def test_summary_after_backfill_excludes_env_fail_from_pass_rate(
+        self, tmp_path: Path
+    ):
+        """env_fail must appear in the aggregate footer, excluded from denominator."""
+        _make_historical_fail_file(tmp_path)
+        _make_historical_fail_jsonl(tmp_path)
+
+        runner = CliRunner()
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        result = runner.invoke(
+            analyze_command,
+            ["summary", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Per-arm aggregates" in result.output
+        assert "env_fail=1" in result.output
+        assert "denominator=0" in result.output
+
+    def test_backfill_does_not_touch_genuine_fail(self, tmp_path: Path):
+        """A genuine test failure (no zero-collection marker) must not be rewritten."""
+        real_fail_id = "django__django-99999"
+        _make_historical_real_fail(tmp_path, real_fail_id)
+
+        runner = CliRunner()
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+
+        test_txt = tmp_path / f"{real_fail_id}_{ARM}_run{RUN}_test.txt"
+        lines = [ln for ln in test_txt.read_text().splitlines() if ln.strip()]
+        assert lines[-1].strip() == "FAIL", (
+            f"Genuine FAIL must not be rewritten; got {lines[-1]!r}"
+        )
+
+    def test_summary_after_backfill_preserves_genuine_fail_count(
+        self, tmp_path: Path
+    ):
+        """Genuine FAILs must still appear in the pass-rate denominator after backfill."""
+        # One zero-collection historical FAIL + one genuine FAIL.
+        _make_historical_fail_file(tmp_path)
+        _make_historical_fail_jsonl(tmp_path)
+        real_fail_id = "django__django-99999"
+        _make_historical_real_fail(tmp_path, real_fail_id)
+
+        runner = CliRunner()
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        result = runner.invoke(
+            analyze_command,
+            ["summary", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        # The genuine FAIL contributes to the denominator.
+        assert "fail=1" in result.output
+        assert "denominator=1" in result.output
+
+    def test_summary_output_has_env_fail_column_structure(self, tmp_path: Path):
+        """``analyze summary`` stdout must include the per-arm aggregates section."""
+        _make_historical_fail_file(tmp_path)
+        _make_historical_fail_jsonl(tmp_path)
+
+        runner = CliRunner()
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        result = runner.invoke(
+            analyze_command,
+            ["summary", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        # Schema assertions: required structural fields in output.
+        assert "instance_id" in result.output
+        assert "verdict" in result.output
+        assert "pass_rate" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillIdempotency:
+    """Wiring: verify backfill can be run twice without corrupting the result."""
+
+    def test_double_backfill_is_stable(self, tmp_path: Path):
+        """Running backfill twice leaves the file in the same env_fail state."""
+        _make_historical_fail_file(tmp_path)
+        _make_historical_fail_jsonl(tmp_path)
+        test_txt = tmp_path / f"{SYMPY_INSTANCE}_{ARM}_run{RUN}_test.txt"
+
+        runner = CliRunner()
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        content_after_first = test_txt.read_text()
+
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "No FAIL" in result.output or "no FAIL" in result.output.lower()
+        assert test_txt.read_text() == content_after_first
+
+    def test_summary_stable_after_double_backfill(self, tmp_path: Path):
+        """``analyze summary`` output is identical after one and two backfill runs."""
+        _make_historical_fail_file(tmp_path)
+        _make_historical_fail_jsonl(tmp_path)
+
+        runner = CliRunner()
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        first_summary = runner.invoke(
+            analyze_command,
+            ["summary", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        second_summary = runner.invoke(
+            analyze_command,
+            ["summary", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert first_summary.output == second_summary.output
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_component_analyze_backfill.py
+++ b/tests/test_component_analyze_backfill.py
@@ -1,0 +1,140 @@
+"""Component test: analyze/__init__.py → analyze/backfill.py CLI registration.
+
+Boundary: ``analyze/__init__.py`` registers ``backfill`` as a subcommand on the
+``analyze_command`` Click group via ``_register_backfill(analyze_command)``
+(added in Issue #238).  This test exercises the contract that the two real
+modules cooperate correctly: ``analyze_command`` must expose the backfill
+subcommand, accept ``--dry-run``, and correctly reclassify ``FAIL`` files that
+contain a zero-collection marker phrase.
+
+No doubles are used — the real ``analyze_command`` group and the real backfill
+implementation run together.  The only seam doubled is the filesystem, which is
+already the canonical medium between CLI and results files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from swebench.analyze import analyze_command
+
+
+@pytest.mark.component
+class TestAnalyzeBackfillRegistration:
+    """Verify that analyze_command exposes the backfill subcommand correctly."""
+
+    def test_backfill_subcommand_is_reachable_through_analyze_group(self):
+        """``analyze backfill --help`` must exit 0 — the subcommand is registered."""
+        runner = CliRunner()
+        result = runner.invoke(analyze_command, ["backfill", "--help"], catch_exceptions=False)
+        assert result.exit_code == 0, f"backfill --help failed:\n{result.output}"
+        assert "backfill" in result.output.lower(), (
+            f"'backfill' not mentioned in its own help text: {result.output}"
+        )
+
+    def test_backfill_dry_run_flag_accepted(self, tmp_path: Path):
+        """``--dry-run`` must be an accepted flag (not an 'Error: no such option')."""
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path), "--dry-run"],
+            catch_exceptions=False,
+        )
+        # An empty dir → "No FAIL→env_fail rewrites needed" — exit 0.
+        assert result.exit_code == 0, f"Unexpected exit:\n{result.output}"
+        assert "No FAIL" in result.output or "No" in result.output, (
+            f"Expected no-op message; got: {result.output}"
+        )
+
+    def test_backfill_dry_run_reports_candidates_without_modifying(self, tmp_path: Path):
+        """With ``--dry-run``, files that need rewriting are listed but NOT changed."""
+        test_file = tmp_path / "repo__repo-1_baseline_run1_test.txt"
+        original = (
+            "collected 0 items / no tests ran\n"
+            "\n"
+            "FAIL\n"
+        )
+        test_file.write_text(original)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path), "--dry-run"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Unexpected exit:\n{result.output}"
+        # dry-run output must mention the file.
+        assert test_file.name in result.output, (
+            f"Dry-run did not name the candidate file; output:\n{result.output}"
+        )
+        # File must NOT have been modified.
+        assert test_file.read_text() == original, (
+            "Dry-run must not modify files on disk."
+        )
+
+    def test_backfill_rewrites_fail_to_env_fail(self, tmp_path: Path):
+        """Live run (no --dry-run): FAIL + zero-collection marker → env_fail."""
+        test_file = tmp_path / "repo__repo-2_baseline_run1_test.txt"
+        test_file.write_text(
+            "--- pytest --collect-only output ---\n"
+            "no tests ran in 0.05s\n"
+            "--- end ---\n"
+            "\n"
+            "FAIL\n"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Unexpected exit:\n{result.output}"
+
+        # Last non-empty line of the rewritten file must be "env_fail".
+        lines = [ln for ln in test_file.read_text().splitlines() if ln.strip()]
+        assert lines, "File is empty after rewrite"
+        assert lines[-1].strip() == "env_fail", (
+            f"Expected last non-empty line 'env_fail'; got {lines[-1]!r}"
+        )
+
+    def test_backfill_does_not_touch_pass_files(self, tmp_path: Path):
+        """Files whose last line is PASS must be left entirely unchanged."""
+        pass_file = tmp_path / "repo__repo-3_onlycode_run1_test.txt"
+        original = "tests ran fine\n\nPASS\n"
+        pass_file.write_text(original)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Unexpected exit:\n{result.output}"
+        assert pass_file.read_text() == original, (
+            "PASS file was incorrectly modified by backfill."
+        )
+
+    def test_backfill_idempotent_on_already_env_fail(self, tmp_path: Path):
+        """Re-running backfill on an already-rewritten file is a no-op."""
+        already_done = tmp_path / "repo__repo-4_baseline_run1_test.txt"
+        already_done.write_text(
+            "0 items collected\n"
+            "\n"
+            "env_fail\n"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            analyze_command,
+            ["backfill", "--results-dir", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # Should report no rewrites needed.
+        assert "No FAIL" in result.output or "0 file" in result.output, (
+            f"Expected idempotent no-op message; got: {result.output}"
+        )

--- a/tests/test_component_run_harness_preflight.py
+++ b/tests/test_component_run_harness_preflight.py
@@ -1,0 +1,407 @@
+"""Component test: run.py → harness.py pre-flight wiring.
+
+Boundary: ``swebench/run.py._run_arm`` calls two real functions from
+``swebench/harness.py``:
+  1. ``resolve_test_node_ids`` — expands bare sympy test names to node IDs.
+  2. ``run_preflight_collect`` — runs ``pytest --collect-only`` and returns
+     ``(False, output)`` when zero items are collected.
+
+Both functions are exercised as their *real* harness implementations — no
+harness-level doubles.  The only seam doubled is ``subprocess.run`` inside
+the harness module (an I/O boundary), and the git/Claude/test-runner I/O
+boundaries in ``run.py`` (``git_reset``, ``run_claude``, ``run_tests``).
+
+These tests assert the cross-module contract that:
+  - when preflight returns False via the real harness path, ``_run_arm``
+    writes ``env_fail`` to both output files and returns ``"env_fail"``.
+  - when preflight returns True via the real harness path, ``_run_arm``
+    continues past the pre-flight gate and invokes the agent.
+
+The critical difference from the unit tests in ``test_run_preflight.py``
+(which double ``run_mod.run_preflight_collect`` entirely) is that *here*
+the real harness ``run_preflight_collect`` implementation runs, so if
+``run.py`` ever stops importing or calling the harness function correctly
+these tests will catch the regression.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import swebench.harness as _harness_mod
+from swebench.models import Problem
+from swebench import run as run_mod
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+INSTANCE = "sympy__sympy-14180"
+ARM = "baseline"
+RUN_IDX = 1
+
+
+def _make_problem(tmp_path: Path, test_cmd: str = "python -m pytest test_bare_name") -> Problem:
+    """Build a minimal Problem for the env_fail code path."""
+    return Problem(
+        instance_id=INSTANCE,
+        repo_slug="sympy/sympy",
+        base_commit="abc123",
+        test_cmd=test_cmd,
+        problem_statement="dummy",
+        patch_file=None,
+        added_at="2026-01-01",
+        hf_split="test",
+    )
+
+
+def _make_dirs(tmp_path: Path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    (venv_dir / "bin").mkdir()
+    (venv_dir / "bin" / "python").write_text("#!/bin/sh\nexec python3 \"$@\"\n")
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    return str(repo_dir), str(venv_dir), str(results_dir)
+
+
+class _FakeCompleted:
+    """Minimal stand-in for ``subprocess.CompletedProcess``."""
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ---------------------------------------------------------------------------
+# Boundary 1: real harness.run_preflight_collect returns False → env_fail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.component
+class TestRunArmPrefailViaRealHarness:
+    """
+    _run_arm reads its preflight result from the real harness.run_preflight_collect.
+    When the real function reports 0 items collected, _run_arm must write
+    env_fail to disk and return 'env_fail'.
+    """
+
+    def test_env_fail_files_written_via_real_harness_path(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """The real run_preflight_collect is wired into _run_arm.
+
+        We double subprocess.run inside the harness to return 'no tests ran'
+        (exit 5).  Everything else — the harness preflight logic, the run.py
+        env_fail write path — runs for real.
+        """
+        repo_dir, venv_dir, results_dir = _make_dirs(tmp_path)
+
+        # Double subprocess.run inside the harness (I/O seam only).
+        # Return exit-5 / no items collected for pytest --collect-only calls,
+        # and exit-0 for git calls so git_reset doesn't blow up.
+        def _fake_subprocess_run(cmd, **kw):
+            # git commands — succeed silently.
+            if isinstance(cmd, list) and cmd and cmd[0] == "git":
+                return _FakeCompleted(returncode=0, stdout="", stderr="")
+            # pytest --collect-only call from run_preflight_collect/resolve.
+            return _FakeCompleted(
+                returncode=5,
+                stdout="no tests ran in 0.05s\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_subprocess_run)
+
+        # Double the I/O seams in run.py that are not part of this boundary.
+        monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+
+        def _boom_run_claude(**kw):  # pragma: no cover
+            raise AssertionError("run_claude must not be called when preflight fails")
+
+        monkeypatch.setattr(run_mod, "run_claude", _boom_run_claude)
+
+        problem = _make_problem(tmp_path)
+
+        verdict = run_mod._run_arm(
+            problem=problem,
+            arm=ARM,
+            run_idx=RUN_IDX,
+            repo_dir=repo_dir,
+            venv_dir=venv_dir,
+            results_dir=results_dir,
+            claude_binary="/usr/bin/claude",
+            mcp_config_path=str(tmp_path / "mcp.json"),
+            root=tmp_path,
+        )
+
+        # _run_arm must return "env_fail".
+        assert verdict == "env_fail", f"Expected 'env_fail', got {verdict!r}"
+
+        # The _test.txt must end with "env_fail".
+        test_txt = Path(results_dir) / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
+        assert test_txt.exists(), "_test.txt was not written"
+        last_line = [ln for ln in test_txt.read_text().splitlines() if ln.strip()][-1]
+        assert last_line.strip() == "env_fail", (
+            f"Expected last non-empty line 'env_fail'; got {last_line!r}"
+        )
+
+        # The .jsonl must contain a meta record with verdict=env_fail.
+        jsonl = Path(results_dir) / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
+        assert jsonl.exists(), ".jsonl was not written"
+        record = json.loads(jsonl.read_text().splitlines()[0])
+        assert record["verdict"] == "env_fail", (
+            f"jsonl meta record has wrong verdict: {record}"
+        )
+        assert record["instance_id"] == INSTANCE
+
+    def test_env_fail_jsonl_has_required_fields(self, monkeypatch, tmp_path: Path):
+        """The meta record written by the real env_fail path must carry all
+        fields that downstream tools (analyze, summary, _is_triple_complete) need."""
+        repo_dir, venv_dir, results_dir = _make_dirs(tmp_path)
+
+        def _fake_subprocess_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd and cmd[0] == "git":
+                return _FakeCompleted(0)
+            return _FakeCompleted(5, stdout="collected 0 items\n")
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_subprocess_run)
+        monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+
+        problem = _make_problem(tmp_path)
+        run_mod._run_arm(
+            problem=problem,
+            arm=ARM,
+            run_idx=RUN_IDX,
+            repo_dir=repo_dir,
+            venv_dir=venv_dir,
+            results_dir=results_dir,
+            claude_binary="/usr/bin/claude",
+            mcp_config_path=str(tmp_path / "mcp.json"),
+            root=tmp_path,
+        )
+
+        jsonl = Path(results_dir) / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
+        record = json.loads(jsonl.read_text().splitlines()[0])
+
+        # Required fields for downstream tools.
+        assert record.get("type") == "meta"
+        assert record.get("verdict") == "env_fail"
+        assert record.get("instance_id") == INSTANCE
+        assert record.get("arm") == ARM
+        assert record.get("run") == RUN_IDX
+
+    def test_preflight_output_embedded_in_test_txt(self, monkeypatch, tmp_path: Path):
+        """The raw pytest --collect-only output must appear in the _test.txt body."""
+        repo_dir, venv_dir, results_dir = _make_dirs(tmp_path)
+
+        preflight_output = "no tests ran in 0.07s\n"
+
+        def _fake_subprocess_run(cmd, **kw):
+            if isinstance(cmd, list) and cmd and cmd[0] == "git":
+                return _FakeCompleted(0)
+            return _FakeCompleted(5, stdout=preflight_output)
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_subprocess_run)
+        monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+
+        problem = _make_problem(tmp_path)
+        run_mod._run_arm(
+            problem=problem,
+            arm=ARM,
+            run_idx=RUN_IDX,
+            repo_dir=repo_dir,
+            venv_dir=venv_dir,
+            results_dir=results_dir,
+            claude_binary="/usr/bin/claude",
+            mcp_config_path=str(tmp_path / "mcp.json"),
+            root=tmp_path,
+        )
+
+        test_txt = Path(results_dir) / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
+        body = test_txt.read_text()
+        assert "no tests ran" in body, (
+            f"Preflight output not embedded in _test.txt:\n{body}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary 2: real harness.resolve_test_node_ids feeds into run_preflight_collect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.component
+class TestRunArmResolverFeedsIntoPreflightViaRealHarness:
+    """
+    _run_arm calls resolve_test_node_ids first, then passes the result to
+    run_preflight_collect.  For non-sympy repos, the resolver must return
+    the original command unchanged; for sympy, it calls subprocess.run once
+    to expand bare names.
+
+    Both functions run as real harness code — only subprocess.run is doubled.
+    """
+
+    def test_non_sympy_repo_skips_resolver_subprocess(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """For non-sympy repos, no subprocess.run call originates from the resolver."""
+        repo_dir, venv_dir, results_dir = _make_dirs(tmp_path)
+
+        resolver_calls: list[list] = []
+
+        def _recording_subprocess_run(cmd, **kw):
+            if isinstance(cmd, list) and "--collect-only" in cmd:
+                resolver_calls.append(cmd)
+                return _FakeCompleted(5, stdout="no tests ran\n")
+            return _FakeCompleted(0)
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _recording_subprocess_run)
+        monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+
+        problem = Problem(
+            instance_id="django__django-16379",
+            repo_slug="django/django",
+            base_commit="abc",
+            test_cmd="python -m pytest tests/test_foo.py",
+            problem_statement="dummy",
+            patch_file=None,
+            added_at="2026-01-01",
+            hf_split="test",
+        )
+
+        run_mod._run_arm(
+            problem=problem,
+            arm="baseline",
+            run_idx=1,
+            repo_dir=repo_dir,
+            venv_dir=venv_dir,
+            results_dir=results_dir,
+            claude_binary="/usr/bin/claude",
+            mcp_config_path=str(tmp_path / "mcp.json"),
+            root=tmp_path,
+        )
+
+        # The resolver must not have triggered a subprocess.run --collect-only call
+        # on its own (i.e., the preflight may call it once, but resolver adds 0).
+        # The preflight itself calls subprocess.run once; the resolver adds 0.
+        # Assert that no call was made for the resolver (all calls come from preflight).
+        # Both paths are via the real harness; we just record calls.
+        assert len(resolver_calls) == 1, (
+            f"Expected exactly 1 --collect-only call (from preflight only, not resolver); "
+            f"got {len(resolver_calls)}"
+        )
+
+    def test_sympy_bare_name_triggers_resolver_subprocess_then_preflight(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """For sympy repos with a bare test name, the resolver fires subprocess.run
+        FIRST to expand the name; the preflight then uses the expanded node ID."""
+        repo_dir, venv_dir, results_dir = _make_dirs(tmp_path)
+
+        collect_only_calls: list[list] = []
+        call_count = {"n": 0}
+
+        def _recording_subprocess_run(cmd, **kw):
+            if isinstance(cmd, list) and "--collect-only" in cmd:
+                collect_only_calls.append(list(cmd))
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    # First call = resolver expanding bare name → return a node ID.
+                    return _FakeCompleted(
+                        0,
+                        stdout=(
+                            "sympy/printing/tests/test_latex.py::test_latex_log\n"
+                            "1 test collected in 0.42s\n"
+                        ),
+                    )
+                else:
+                    # Second call = preflight on the now-expanded command.
+                    return _FakeCompleted(
+                        0,
+                        stdout="sympy/printing/tests/test_latex.py::test_latex_log\n1 test collected\n",
+                    )
+            return _FakeCompleted(0)
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _recording_subprocess_run)
+        monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+
+        # Agent invoked (preflight passes) — stub it out.
+        invoked = {"count": 0}
+
+        class _StubRunner:
+            surface = "claude_code"
+
+            def build_tools_flags(self, arm, cfg):
+                return []
+
+            def get_version(self, binary):
+                return "stub"
+
+            def extract_metadata(self, path):
+                return (None, None)
+
+            def invoke(self, **kw):
+                invoked["count"] += 1
+                Path(kw["result_file"]).write_text(
+                    '{"type":"result","total_cost_usd":0.0,"num_turns":0}\n'
+                )
+
+        def _stub_run_tests(**kw):
+            Path(kw["result_file"]).write_text("PASS\n")
+            return "PASS"
+
+        monkeypatch.setattr(run_mod, "run_tests", _stub_run_tests)
+
+        problem = Problem(
+            instance_id="sympy__sympy-14180",
+            repo_slug="sympy/sympy",
+            base_commit="abc",
+            test_cmd="python -m pytest test_latex_log",
+            problem_statement="dummy",
+            patch_file=None,
+            added_at="2026-01-01",
+            hf_split="test",
+        )
+
+        verdict = run_mod._run_arm(
+            problem=problem,
+            arm="baseline",
+            run_idx=1,
+            repo_dir=repo_dir,
+            venv_dir=venv_dir,
+            results_dir=results_dir,
+            claude_binary="/usr/bin/claude",
+            mcp_config_path=str(tmp_path / "mcp.json"),
+            root=tmp_path,
+            runner=_StubRunner(),
+        )
+
+        # Two --collect-only subprocess.run calls expected: one from the resolver,
+        # one from the preflight.
+        assert call_count["n"] == 2, (
+            f"Expected 2 --collect-only subprocess calls (resolver + preflight); "
+            f"got {call_count['n']}. Calls: {collect_only_calls}"
+        )
+        # The second preflight call must see the expanded node ID in its args,
+        # not the bare name — confirming resolver output feeds into preflight.
+        assert any(
+            "sympy/printing/tests/test_latex.py::test_latex_log" in arg
+            for arg in collect_only_calls[1]
+        ), (
+            f"Preflight call did not receive expanded node ID. "
+            f"Second call args: {collect_only_calls[1]}"
+        )
+        # Agent was invoked (preflight passed).
+        assert invoked["count"] == 1
+        assert verdict == "PASS"


### PR DESCRIPTION
## Summary

Batch of five small env/pre-install pin fixes from the batch D seed_1 baseline audit. Each is a one- to few-line change in `swebench/harness.py`; the only logic change is dropping `count=1` from the vendored-cloudpickle patch's `.replace()`.

| Issue | Fix |
|---|---|
| #228 | `numpy<2` pre-install for `pydata__xarray-4075/4629/4911` |
| #229 | Repo-level `matplotlib<3.7` pin for `mwaskom/seaborn` (affects seaborn-2389/2813/2946) |
| #231 | `_patch_vendored_cloudpickle` now replaces every matching `types.CodeType(...)` block in the file instead of just the first (covers sklearn-12704/13283/13496) |
| #233 | sklearn-13013 → `scipy<1.6`; sklearn-10427 → `Pillow` |
| #241 | sphinx-8056 → `roman`; sphinx-9698 → `sphinxcontrib.applehelp<1.0.5` |

## Deferred

**#233 astropy-6938** — pytest `cache_dir` `INTERNALERROR` under fuse-overlayfs. No existing per-instance test-env-var mechanism exists, and the root cause needs investigation with run access. The issue body explicitly permits splitting sub-fixes when one is a rabbit hole; recommend tracking as a follow-up sub-issue.

## Notes

- Issue #229 used a repo-level pin (`mwaskom/seaborn`) rather than three per-instance entries, because every known seaborn-≤0.12 instance shares the same `register_cmap`-at-import crash. Future instances on a newer seaborn can override per-instance if needed.
- Issue #231: the existing test fixture in `tests/test_harness_cloudpickle_patch.py` has only one occurrence of the old block, so `.replace(old, new)` is functionally equivalent to `.replace(old, new, 1)` against it — existing tests should still pass.
- Verification was intentionally **not** done in this worktree (per author instruction); see the test plan below for what still needs to run before merge.

## Test plan

- [ ] Bust OverlayFS cache entries for all instances below before re-running
- [ ] Re-run `pydata__xarray-4075`, `xarray-4629`, `xarray-4911` → all collect tests (#228)
- [ ] Re-run `mwaskom__seaborn-2389`, `seaborn-2813`, `seaborn-2946` → all collect tests (#229)
- [ ] Re-run `scikit-learn__scikit-learn-12704`, `13283`, `13496` → all collect tests (#231)
- [ ] Re-run `scikit-learn__scikit-learn-13013`, `10427` → both collect tests (#233; astropy-6938 deferred)
- [ ] Re-run `sphinx-doc__sphinx-8056`, `9698` → both collect tests (#241)
- [ ] Run `pytest tests/test_harness_cloudpickle_patch.py` to confirm the patch-all change doesn't regress existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)