### PR TITLE
fix(#240): pin sphinx-9230/9281 to Python 3.9 (types.Union ImportError)

### DIFF
--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -71,6 +71,15 @@ _INSTANCE_PYTHON: dict[str, str] = {
     "sympy__sympy-11232": "python3.9",
     "sympy__sympy-13259": "python3.9",
     "sympy__sympy-14180": "python3.9",
+    # sphinx 4.0.x era (May 2021): sphinx/util/typing.py has a buggy guard
+    # ``if sys.version_info > (3, 10): from types import Union as types_Union``.
+    # ``types.Union`` never existed; the line was a typo for ``UnionType``
+    # (later fixed upstream). The tuple comparison is True on Python 3.10.x as
+    # well as 3.11+ (longer tuple > shorter), so pinning must be ≤3.9 to skip
+    # the branch entirely. Only these two instances are affected — the
+    # adjacent 9229's test target doesn't import ``sphinx/util/typing``.
+    "sphinx-doc__sphinx-9230": "python3.9",
+    "sphinx-doc__sphinx-9281": "python3.9",
 }
 
 _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {

--- a/tests/test_harness_venv.py
+++ b/tests/test_harness_venv.py
@@ -360,6 +360,23 @@ def test_astropy_6938_uses_python39() -> None:
     )
 
 
+def test_sphinx_types_union_instances_use_python39() -> None:
+    """sphinx 4.0.x era: instances whose tests transitively import
+    ``sphinx/util/typing.py`` must run on Python 3.9.
+
+    The base commits for these two instances ship a typo in typing.py:
+    ``if sys.version_info > (3, 10): from types import Union as types_Union``.
+    ``types.Union`` does not exist on any released Python. The guard fires on
+    Python 3.10.x too (``(3, 10, x) > (3, 10)`` is True by tuple length), so
+    pinning anything above 3.9 still hits the broken import.
+    """
+    for instance_id in ("sphinx-doc__sphinx-9230", "sphinx-doc__sphinx-9281"):
+        assert _INSTANCE_PYTHON.get(instance_id) == "python3.9", (
+            f"{instance_id} must use python3.9 to skip the broken "
+            "`from types import Union` branch in sphinx/util/typing.py"
+        )
+
+
 def test_astropy_5x_pre_install_pins() -> None:
     """Test 15: astropy 5.x instances have the required pre-install pins."""
     for instance_id in ("astropy__astropy-12962", "astropy__astropy-13842"):


### PR DESCRIPTION
## Summary

Closes #240.

- `sphinx-doc__sphinx-9230` and `sphinx-doc__sphinx-9281` crash at pytest collection on Python 3.11 with `ImportError: cannot import name 'Union' from 'types'`.
- Root cause: `sphinx/util/typing.py` at both base commits ships a typo — `if sys.version_info > (3, 10): from types import Union as types_Union`. `types.Union` has never existed; the line was meant to be `UnionType` (fixed upstream after these commits).
- Pin both instances to `python3.9` in `_INSTANCE_PYTHON`, mirroring the existing astropy/sklearn/sympy entries.

## Why not Python 3.10 as suggested in the issue?

The issue recommends "Python ≤3.10", but Python tuple comparison makes that too loose:

```
(3, 10, 12) > (3, 10)  →  True   # longer tuple wins after equal prefix
```

Verified on `python3.10.12`: `sys.version_info > (3, 10)` returns `True`, so the broken import still fires. `python3.9` is the highest version that skips the branch.

## Why not also pin sphinx-9229?

`sphinx-9229` has the same buggy source line at its base commit, but its test target (`test_class_alias_having_doccomment` in `test_ext_autodoc_autoclass.py`) does not transitively import `sphinx/util/typing`, so collection succeeds. The seed_1 baseline audit confirms 9229 PASSED on python3.11.

## Test plan

- [x] `pytest tests/test_harness_venv.py` passes locally (27 tests, includes new `test_sphinx_types_union_instances_use_python39`)
- [ ] Re-run `sphinx-doc__sphinx-9230` and `sphinx-doc__sphinx-9281` end-to-end and confirm test collection succeeds (no `types.Union` ImportError in `*_test.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)