### PR TITLE
fix(#239): co-pin markupsafe<2.1 with jinja2<3.0 for old Sphinx instances

### DIFF
--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -505,16 +505,20 @@ def _needs_jinja2_pin(repo_dir: str) -> bool:
 
 
 def _pin_jinja2(pip: str) -> None:
-    """Pin Jinja2 to >=2.11,<3.0 — the last series compatible with Python 3.11
-    that still exports environmentfilter."""
+    """Pin Jinja2 >=2.11,<3.0 and markupsafe<2.1 together.
+
+    Jinja2 2.x calls markupsafe.soft_unicode, which was removed in markupsafe
+    2.1. Without the co-pin, pytest crashes at import with ImportError before
+    any test collects.
+    """
     result = subprocess.run(
-        [pip, "install", "--quiet", "jinja2<3.0,>=2.11"],
+        [pip, "install", "--quiet", "jinja2<3.0,>=2.11", "markupsafe<2.1"],
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
         print(
-            f"[harness] jinja2 pin failed (rc={result.returncode}):\n{result.stderr}",
+            f"[harness] jinja2/markupsafe pin failed (rc={result.returncode}):\n{result.stderr}",
             flush=True,
         )
         raise subprocess.CalledProcessError(

--- a/tests/test_harness_jinja2_pin.py
+++ b/tests/test_harness_jinja2_pin.py
@@ -56,14 +56,14 @@ def test_pin_jinja2_calls_correct_constraint() -> None:
         mock_run.return_value = MagicMock(returncode=0)
         _pin_jinja2("/venv/bin/pip")
     args = mock_run.call_args[0][0]
-    assert args == ["/venv/bin/pip", "install", "--quiet", "jinja2<3.0,>=2.11"]
+    assert args == ["/venv/bin/pip", "install", "--quiet", "jinja2<3.0,>=2.11", "markupsafe<2.1"]
 
 
 def test_pin_jinja2_raises_on_failure() -> None:
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
-            args=["/venv/bin/pip", "install", "--quiet", "jinja2<3.0,>=2.11"],
+            args=["/venv/bin/pip", "install", "--quiet", "jinja2<3.0,>=2.11", "markupsafe<2.1"],
             stdout="",
             stderr="Could not find a version",
         )


### PR DESCRIPTION
## Summary

- Extends `_pin_jinja2` in `swebench/harness.py` to co-install `markupsafe<2.1` alongside `jinja2<3.0,>=2.11` in a single pip call
- Jinja2 2.x calls `markupsafe.soft_unicode`, which was removed in markupsafe 2.1 — without the co-pin, pytest crashes at conftest/fixture import before any tests collect
- Updates `tests/test_harness_jinja2_pin.py` to assert the new install args

Closes #239

## Root cause

The existing `_needs_jinja2_pin` / `_pin_jinja2` pair (from #196, baa8984) correctly downgrades Jinja2 to `<3.0` for old Sphinx instances that use `environmentfilter`. However it left markupsafe at the system version (2.1+), where `soft_unicode` no longer exists. Jinja2 2.x imports `markupsafe.soft_unicode` at import time, so pytest crashes before the agent ever runs.

## Affected instances fixed

| Instance | Symptom |
|---|---|
| sphinx-doc__sphinx-7757 | `ImportError: cannot import name 'soft_unicode' from 'markupsafe'` |
| sphinx-doc__sphinx-8269 | same |
| sphinx-doc__sphinx-8475 | same |
| sphinx-doc__sphinx-8721 | same |

## Test plan

- [x] `tests/test_harness_jinja2_pin.py` — all 6 tests pass with updated args assertions
- [x] Full non-integration test suite — 580 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)