### PR TITLE
fix(#232): pin pytest<7 for sklearn 0.18–0.22 instances with pytest-drift failures

### DIFF
--- a/swebench/analyze/summary.py
+++ b/swebench/analyze/summary.py
@@ -10,6 +10,7 @@ import click
 
 from swebench import repo_root
 from swebench.models import ArmResult
+from swebench.runner import CodexRunner
 
 
 def _parse_results(results_dir: Path) -> list[ArmResult]:
@@ -55,18 +56,48 @@ def _parse_results(results_dir: Path) -> list[ArmResult]:
         cost_usd: float | None = None
         num_turns: int | None = None
         wall_secs = 0
+        # Default surface for backward compat with old result files that lack
+        # the agent_surface field in their meta line.
+        agent_surface = "claude_code"
 
         if jsonl_path.exists():
+            # Detect agent_surface from the meta line so we can route cost
+            # parsing to the right path (Claude's total_cost_usd vs. Codex's
+            # turn.completed usage + price-table estimate).
             try:
-                content = jsonl_path.read_text()
-                cost_matches = re.findall(r'"total_cost_usd":\s*([\d.]+)', content)
-                turns_matches = re.findall(r'"num_turns":\s*(\d+)', content)
-                if cost_matches:
-                    cost_usd = float(cost_matches[-1])
-                if turns_matches:
-                    num_turns = int(turns_matches[-1])
-            except (OSError, ValueError):
+                first_line = jsonl_path.read_text().splitlines()[0] if jsonl_path.stat().st_size else ""
+                if first_line:
+                    import json as _json
+                    try:
+                        meta = _json.loads(first_line)
+                        if isinstance(meta, dict) and meta.get("type") == "meta":
+                            _surface = meta.get("agent_surface")
+                            if isinstance(_surface, str):
+                                agent_surface = _surface
+                    except (_json.JSONDecodeError, ValueError):
+                        pass
+            except (OSError, IndexError):
                 pass
+
+            if agent_surface == "codex_cli":
+                # Reuse the runner's extract_metadata so the cost formula and
+                # price-table loader stay in one place. The model is in the
+                # meta line; the runner instance's own model attr is unused.
+                try:
+                    cost_usd, num_turns = CodexRunner().extract_metadata(jsonl_path)
+                except Exception:
+                    cost_usd, num_turns = None, None
+            else:
+                try:
+                    content = jsonl_path.read_text()
+                    cost_matches = re.findall(r'"total_cost_usd":\s*([\d.]+)', content)
+                    turns_matches = re.findall(r'"num_turns":\s*(\d+)', content)
+                    if cost_matches:
+                        cost_usd = float(cost_matches[-1])
+                    if turns_matches:
+                        num_turns = int(turns_matches[-1])
+                except (OSError, ValueError):
+                    pass
 
         results.append(
             ArmResult(
@@ -79,10 +110,29 @@ def _parse_results(results_dir: Path) -> list[ArmResult]:
                 wall_secs=wall_secs,
                 jsonl_path=str(jsonl_path),
                 test_txt_path=str(test_file),
+                agent_surface=agent_surface,
             )
         )
 
     return results
+
+
+def _format_cost(r: ArmResult) -> str:
+    """Format the cost column for a single ArmResult row.
+
+    Claude rows show the authoritative ``total_cost_usd`` from the agent's
+    own metering — display as ``$0.123``. Codex rows show a price-table
+    estimate derived from token counts — prepend ``~`` so reviewers know it
+    is not an exact billed amount.
+
+    Issue #253: ``~`` is a display-only marker. ``ArmResult.cost_usd`` stays
+    a plain ``float | None`` for CSV/JSON consumers, which simply gives the
+    estimate as the number (one source of truth).
+    """
+    if r.cost_usd is None:
+        return "N/A"
+    prefix = "~$" if r.agent_surface == "codex_cli" else "$"
+    return f"{prefix}{r.cost_usd:.3f}"
 
 
 def _emit_arm_aggregates(results: list[ArmResult]) -> None:
@@ -171,7 +221,7 @@ def _register(analyze_command: click.Group) -> None:
                     r.arm,
                     r.run_idx,
                     r.verdict,
-                    f"${r.cost_usd:.3f}" if r.cost_usd is not None else "N/A",
+                    _format_cost(r),
                     r.num_turns if r.num_turns is not None else "N/A",
                 ]
                 for r in results
@@ -182,7 +232,7 @@ def _register(analyze_command: click.Group) -> None:
             header = f"{'instance_id':<30} {'arm':<12} {'run':<5} {'verdict':<8} {'cost':<10} {'turns':<7}"
             click.echo(header)
             for r in results:
-                cost_str = f"${r.cost_usd:.3f}" if r.cost_usd is not None else "N/A"
+                cost_str = _format_cost(r)
                 turns_str = str(r.num_turns) if r.num_turns is not None else "N/A"
                 click.echo(
                     f"{r.instance_id:<30} {r.arm:<12} {r.run_idx:<5} {r.verdict:<8} "

--- a/swebench/codex_prices.toml
+++ b/swebench/codex_prices.toml
@@ -1,0 +1,48 @@
+# Codex CLI model price table — USD per 1,000,000 tokens.
+#
+# Used by swebench.runner.CodexRunner.extract_metadata to estimate cost_usd
+# from `turn.completed` token-usage events in the JSONL log. ChatGPT Pro
+# sessions never emit a USD cost field, so this table is the only way the
+# harness can produce a comparable cost figure for Codex runs.
+#
+# Schema per model (3 columns):
+#   input         — USD/1M for non-cached prompt tokens
+#   cached_input  — USD/1M for cached prompt tokens (typically 10% of input)
+#   output        — USD/1M for completion tokens (already includes
+#                   reasoning_output_tokens per OpenAI Responses-API convention)
+#
+# Cost formula in code:
+#   non_cached_input = input_tokens - cached_input_tokens
+#   cost = non_cached_input * input
+#        + cached_input_tokens * cached_input
+#        + output_tokens * output
+#   (then divided by 1_000_000)
+#
+# Prices last verified: 2026-05-16
+# Sources (cross-checked, all three agree):
+#   - https://developers.openai.com/api/docs/pricing
+#   - https://openrouter.ai/openai/gpt-5.5
+#   - https://pricepertoken.com/pricing-page/model/openai-gpt-5.4-mini
+#
+# These are Standard processing rates. Codex CLI exec sessions use Standard
+# (not Batch/Flex/Priority), so the Standard column is the right one.
+#
+# Unknown models fall through to cost=None (preserved per acceptance criteria).
+
+[gpt-5_5]
+model = "gpt-5.5"
+input = 5.00
+cached_input = 0.50
+output = 30.00
+
+[gpt-5_4]
+model = "gpt-5.4"
+input = 2.50
+cached_input = 0.25
+output = 15.00
+
+[gpt-5_4-mini]
+model = "gpt-5.4-mini"
+input = 0.75
+cached_input = 0.075
+output = 4.50

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -59,6 +59,10 @@ _INSTANCE_PYTHON: dict[str, str] = {
     "scikit-learn__scikit-learn-13013": "python3.9",
     "scikit-learn__scikit-learn-10803": "python3.9",
     "scikit-learn__scikit-learn-11206": "python3.9",
+    # sklearn 0.21.dev era (2019): distutils.version.LooseVersion emits DeprecationWarning
+    # on Python 3.10+ (deprecated there, removed 3.12); pytest collection aborts
+    # when warnings-as-errors is active.  Python 3.9 sidesteps the deprecation.
+    "scikit-learn__scikit-learn-11596": "python3.9",
     "scikit-learn__scikit-learn-13283": "python3.9",
     "scikit-learn__scikit-learn-13496": "python3.9",
     "scikit-learn__scikit-learn-13864": "python3.9",
@@ -113,10 +117,21 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     "pydata__xarray-4911": ["numpy<2"],
     "pydata__xarray-6601": ["numpy<2", "setuptools_scm[toml]>=3.4", "setuptools_scm_git_archive"],
     "pydata__xarray-7003": ["numpy<2", "setuptools_scm[toml]>=3.4", "setuptools_scm_git_archive"],
+    # scikit-learn 0.18 era (2017): tests use nose-style yield parametrize which
+    # the pytest nose plugin supported until pytest 7.2 removed it.  pytest<7
+    # keeps the nose compatibility layer active so yield tests are collected.
+    "scikit-learn__scikit-learn-3840": ["setuptools<60", "numpy<1.24", "cython<3", "pytest<7"],
     # scikit-learn 0.20-era: tests import sklearn.externals._pilutil (a vendored
     # copy of scipy.misc.pilutil) which requires Pillow at import time. Without
     # Pillow pre-installed, collection fails with ModuleNotFoundError.
     "scikit-learn__scikit-learn-10427": ["setuptools<60", "numpy<1.24", "cython<3", "Pillow"],
+    # scikit-learn 0.21.dev era (2019): test_print_versions.py imports
+    # distutils.version.LooseVersion which emits a DeprecationWarning on Python
+    # 3.10+ that pytest promotes to an error, aborting collection.  pytest<7
+    # avoids this via older internal handling (and the python3.9 pin in
+    # _INSTANCE_PYTHON also sidesteps the deprecation).  scipy<1.6 is required
+    # for the same _cython_blas.pyx build reason as adjacent 0.21.dev instances.
+    "scikit-learn__scikit-learn-11596": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6", "pytest<7"],
     # scikit-learn 0.20–0.21.dev era: pinned scipy needed at runtime because
     # scipy.optimize.linesearch.line_search_wolfe2 was removed in scipy 1.8.
     # scipy<1.6 matches the adjacent 0.21.dev entries below.
@@ -127,7 +142,10 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # scipy<1.6 is the last release supporting Python 3.9 with old numpy.
     "scikit-learn__scikit-learn-13283": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
     "scikit-learn__scikit-learn-13496": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
-    "scikit-learn__scikit-learn-13864": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
+    # pytest<7 added: pytest.warns(None) as a context manager that suppresses
+    # warnings was changed in pytest 7.0 to raise TypeError; pytest 6.x accepts
+    # the legacy usage that sklearn 0.22.dev tests rely on.
+    "scikit-learn__scikit-learn-13864": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6", "pytest<7"],
     "scikit-learn__scikit-learn-14125": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
     "scikit-learn__scikit-learn-14710": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
     "scikit-learn__scikit-learn-15094": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -765,8 +765,14 @@ def setup_venv(
                 raise subprocess.CalledProcessError(
                     result.returncode, result.args, result.stdout, result.stderr
                 )
+            # Honour any pytest version constraint from pre_install so the reuse
+            # path doesn't silently upgrade past a pinned version (e.g. pytest<7).
+            _pytest_spec = next(
+                (p for p in (pre_install or []) if p.lower().startswith("pytest")),
+                "pytest",
+            )
             result = subprocess.run(
-                [pip, "install", "--quiet", "pytest"],
+                [pip, "install", "--quiet", _pytest_spec],
                 capture_output=True,
                 text=True,
             )
@@ -827,8 +833,13 @@ def setup_venv(
             capture_output=True,
             text=True,
         )
-    # Always ensure pytest is present as a final fallback.
-    _pip_run_checked(pip, ["install", "--quiet", "pytest"])
+    # Always ensure pytest is present as a final fallback, honouring any
+    # version constraint from pre_install (e.g. "pytest<7" for era-pinned instances).
+    _pytest_spec = next(
+        (p for p in (pre_install or []) if p.lower().startswith("pytest")),
+        "pytest",
+    )
+    _pip_run_checked(pip, ["install", "--quiet", _pytest_spec])
     if _needs_jinja2_pin(repo_dir):
         _pin_jinja2(pip)
     if post_install:

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -157,6 +157,7 @@ def _run_arm(
     log_buffer: io.StringIO | None = None,
     needs_editable_reinstall: bool = False,
     runner: AgentRunner | None = None,
+    codex_model: str | None = None,
 ) -> str:
     """Run a single arm (baseline or onlycode) for one instance.
 
@@ -252,17 +253,23 @@ def _run_arm(
         )
         # Write a minimal meta record so downstream tools (analyze, summary,
         # _is_triple_complete) see a properly-shaped jsonl file.
+        _meta_surface = runner.surface if runner is not None else "claude_code"
+        _meta_record: dict[str, object] = {
+            "type": "meta",
+            "instance_id": problem.instance_id,
+            "arm": arm,
+            "run": run_idx,
+            "agent_surface": _meta_surface,
+            "agent_binary": agent_binary,
+            "verdict": "env_fail",
+            "reason": "pytest --collect-only returned 0 items",
+        }
+        # Pin the model for codex_cli runs so extract_metadata can price the
+        # (empty) usage record and so the result file is self-describing.
+        if _meta_surface == "codex_cli" and codex_model is not None:
+            _meta_record["model"] = codex_model
         with open(result_file, "w") as _meta_f:
-            _meta_f.write(json.dumps({
-                "type": "meta",
-                "instance_id": problem.instance_id,
-                "arm": arm,
-                "run": run_idx,
-                "agent_surface": (runner.surface if runner is not None else "claude_code"),
-                "agent_binary": agent_binary,
-                "verdict": "env_fail",
-                "reason": "pytest --collect-only returned 0 items",
-            }) + "\n")
+            _meta_f.write(json.dumps(_meta_record) + "\n")
         test_result_file = os.path.join(
             results_dir, f"{problem.instance_id}_{arm}_run{run_idx}_test.txt"
         )
@@ -352,16 +359,21 @@ def _run_arm(
     start_time = time.time()
 
     agent_version = _runner.get_version(agent_binary)
+    _meta_record: dict[str, object] = {
+        "type": "meta",
+        "instance_id": problem.instance_id,
+        "arm": arm,
+        "run": run_idx,
+        "agent_surface": _runner.surface,
+        "agent_binary": agent_binary,
+        "agent_version": agent_version,
+    }
+    # Pin the model for codex_cli runs so extract_metadata can look up prices
+    # in codex_prices.toml and so the result file is self-describing.
+    if _runner.surface == "codex_cli" and codex_model is not None:
+        _meta_record["model"] = codex_model
     with open(result_file, "w") as _meta_f:
-        _meta_f.write(json.dumps({
-            "type": "meta",
-            "instance_id": problem.instance_id,
-            "arm": arm,
-            "run": run_idx,
-            "agent_surface": _runner.surface,
-            "agent_binary": agent_binary,
-            "agent_version": agent_version,
-        }) + "\n")
+        _meta_f.write(json.dumps(_meta_record) + "\n")
 
     _runner.invoke(
         prompt=prompt,
@@ -394,7 +406,10 @@ def _run_arm(
     _echo(f"  [{arm} run {run_idx}] Tests: {verdict} ({wall_secs}s wall)")
 
     cost_usd, num_turns = _runner.extract_metadata(Path(result_file))
-    cost = f"${cost_usd}" if cost_usd is not None else "N/A"
+    # Codex costs are derived from token counts × codex_prices.toml — mark as
+    # estimate with `~` to distinguish from Claude's authoritative USD figure.
+    _cost_prefix = "~$" if _runner.surface == "codex_cli" else "$"
+    cost = f"{_cost_prefix}{cost_usd:.4f}" if cost_usd is not None else "N/A"
     turns = str(num_turns) if num_turns is not None else "N/A"
 
     _echo(f"  [{arm} run {run_idx}] Cost: {cost}, Turns: {turns}, Wall: {wall_secs}s")
@@ -679,6 +694,20 @@ def _cleanup_stale_overlays(
     show_default=True,
     help="Agent surface to use for running evaluations.",
 )
+@click.option(
+    "--codex-model",
+    "codex_model",
+    type=str,
+    default="gpt-5.5",
+    show_default=True,
+    help=(
+        "Codex CLI model slug to pin (e.g. gpt-5.5, gpt-5.4, gpt-5.4-mini). "
+        "Written to config.toml AND passed as `codex exec -m <model>` so the "
+        "run is reproducible across CLI upgrades. The same value is recorded "
+        "in the JSONL meta line and looked up in swebench/codex_prices.toml "
+        "by extract_metadata. Ignored when --agent-surface=claude_code."
+    ),
+)
 def run_command(
     filter_ids: str | None,
     arms: str,
@@ -691,6 +720,7 @@ def run_command(
     output_dir: str | None,
     resume: bool,
     agent_surface: str,
+    codex_model: str,
 ) -> None:
     """Run SWE-bench evaluation arms on problem instances."""
     if parallel < 1:
@@ -708,7 +738,7 @@ def run_command(
 
     # Create runner and resolve binary (preflight)
     try:
-        runner = make_runner(agent_surface)
+        runner = make_runner(agent_surface, codex_model=codex_model)
         agent_binary = runner.find_binary()
         runner.verify_auth()
     except (ValueError, FileNotFoundError) as e:
@@ -972,6 +1002,7 @@ def run_command(
                         persistent_kernel=persistent_kernel,
                         needs_editable_reinstall=task.needs_editable_reinstall,
                         runner=runner,
+                        codex_model=codex_model if agent_surface == "codex_cli" else None,
                     )
                 except BaseException:
                     _teardown_all_overlays()
@@ -1027,6 +1058,7 @@ def run_command(
                         log_buffer=buf,
                         needs_editable_reinstall=task.needs_editable_reinstall,
                         runner=runner,
+                        codex_model=codex_model if agent_surface == "codex_cli" else None,
                     )
                 except Exception as exc:
                     stderr_detail = getattr(exc, "stderr", None)

--- a/swebench/runner.py
+++ b/swebench/runner.py
@@ -238,10 +238,24 @@ class ClaudeRunner(AgentRunner):
 # CodexRunner
 # ---------------------------------------------------------------------------
 
+DEFAULT_CODEX_MODEL = "gpt-5.5"
+
+
 class CodexRunner(AgentRunner):
-    """Runs OpenAI Codex CLI (the ``codex`` binary)."""
+    """Runs OpenAI Codex CLI (the ``codex`` binary).
+
+    ``model`` pins the underlying ChatGPT model for reproducibility. The value
+    is written into ``config.toml`` *and* passed as ``codex exec -m <model>``
+    (belt-and-braces — the CLI flag wins on conflict, but having both means a
+    config-write bug cannot silently drop the pin). The same value is recorded
+    in the JSONL ``meta`` line by ``run.py``, then read back by
+    ``extract_metadata`` to look up prices in ``codex_prices.toml``.
+    """
 
     surface = "codex_cli"
+
+    def __init__(self, model: str = DEFAULT_CODEX_MODEL) -> None:
+        self.model = model
 
     def find_binary(self) -> str:
         path = shutil.which("codex")
@@ -303,7 +317,9 @@ class CodexRunner(AgentRunner):
 
         bundle_path = self._resolve_bundle(mcp_config_path)
         persistent = os.environ.get("ONLYCODES_PERSISTENT_KERNEL", "0")
-        _write_codex_config(cfg_dir, bundle_path, cwd, persistent, arm=arm)
+        _write_codex_config(
+            cfg_dir, bundle_path, cwd, persistent, arm=arm, model=self.model
+        )
 
         return cfg_dir
 
@@ -329,6 +345,7 @@ class CodexRunner(AgentRunner):
                 "--ephemeral",
                 "--dangerously-bypass-approvals-and-sandbox",
                 "--json",
+                "-m", self.model,
                 prompt,
             ]
             env = os.environ.copy()
@@ -346,17 +363,82 @@ class CodexRunner(AgentRunner):
             shutil.rmtree(cfg_dir, ignore_errors=True)
 
     def extract_metadata(self, jsonl_path: Path) -> tuple[float | None, int | None]:
+        """Return ``(cost_usd, num_turns)`` for a Codex JSONL log.
+
+        ``cost_usd`` is an **estimate** derived from ``turn.completed.usage``
+        token counts and a price table in ``codex_prices.toml``. ChatGPT Pro
+        sessions never emit a true USD cost, so this is the best we can do.
+
+        Degrades gracefully — returns ``cost=None`` when:
+        - the file cannot be read
+        - the JSONL contains no ``meta`` line with a ``model`` field
+        - the ``model`` is not in the price table
+        - no ``turn.completed`` line carries a usage block
+
+        Cost formula (Responses-API convention — see issue #253 investigation
+        comment): ``output_tokens`` already includes ``reasoning_output_tokens``,
+        and ``input_tokens`` already includes ``cached_input_tokens``::
+
+            non_cached_input = input_tokens - cached_input_tokens
+            cost = (non_cached_input * price.input
+                  + cached_input_tokens * price.cached_input
+                  + output_tokens * price.output) / 1_000_000
+        """
         try:
             content = jsonl_path.read_text()
         except OSError:
             return (None, None)
-        turns = sum(
-            1
-            for line in content.splitlines()
-            if _safe_json_type(line) == "turn.started"
-        )
-        # Codex does not expose a cost field for ChatGPT Pro sessions.
-        return (None, turns if turns > 0 else None)
+
+        lines = content.splitlines()
+        turns = sum(1 for line in lines if _safe_json_type(line) == "turn.started")
+        turns_val = turns if turns > 0 else None
+
+        # Read the model name from the `meta` JSONL record written by run.py.
+        model = _read_meta_model(lines)
+        if model is None:
+            return (None, turns_val)
+
+        prices = _load_codex_prices().get(model)
+        if prices is None:
+            return (None, turns_val)
+
+        # Sum usage across all turn.completed events (a run can have many).
+        total_input = 0
+        total_cached = 0
+        total_output = 0
+        saw_usage = False
+        for line in lines:
+            try:
+                obj = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if obj.get("type") != "turn.completed":
+                continue
+            usage = obj.get("usage")
+            if not isinstance(usage, dict):
+                continue
+            # Only count this turn if the usage dict carries at least one
+            # known token field. An empty dict — or a turn.completed without
+            # a usage key — is treated as missing data, not zero usage.
+            if not any(k in usage for k in ("input_tokens", "output_tokens", "cached_input_tokens")):
+                continue
+            saw_usage = True
+            total_input += int(usage.get("input_tokens", 0) or 0)
+            total_cached += int(usage.get("cached_input_tokens", 0) or 0)
+            total_output += int(usage.get("output_tokens", 0) or 0)
+
+        if not saw_usage:
+            return (None, turns_val)
+
+        # Defensive: cached_input may exceed input if the JSONL is malformed —
+        # clamp to keep the non-cached term non-negative.
+        non_cached_input = max(0, total_input - total_cached)
+        cost = (
+            non_cached_input * prices["input"]
+            + total_cached * prices["cached_input"]
+            + total_output * prices["output"]
+        ) / 1_000_000.0
+        return (cost, turns_val)
 
     def preflight(self, mcp_config_path: str | None = None) -> None:
         """Verify all Codex runtime dependencies before starting a run.
@@ -428,6 +510,7 @@ def _write_codex_config(
     cwd: str,
     persistent_kernel: str,
     arm: str = "baseline",
+    model: str = DEFAULT_CODEX_MODEL,
 ) -> None:
     """Write config.toml into cfg_dir for a Codex run.
 
@@ -442,6 +525,11 @@ def _write_codex_config(
     - All other arms (``baseline``, ``tool_rich``, ``bash_only``): no extra
       restrictions beyond the baseline ``shell_tool = false`` and
       ``apply_patch_freeform = false`` that are always emitted.
+
+    ``model`` pins the underlying ChatGPT model at the top of config.toml so
+    runs are reproducible across CLI upgrades — Codex would otherwise silently
+    fall back to its compiled-in default. This is belt-and-braces with the
+    ``codex exec -m <model>`` CLI flag (which takes precedence on conflict).
 
     Note: ``shell_tool = false`` and ``apply_patch_freeform = false`` are
     always present because the codebox MCP server runs code in a sandboxed
@@ -458,6 +546,7 @@ def _write_codex_config(
         )
 
     toml = (
+        f'model = "{_toml_str(model)}"\n'
         'web_search = "disabled"\n'
         "\n"
         "[features]\n"
@@ -481,6 +570,75 @@ def _write_codex_config(
         f.write(toml)
 
 
+def _read_meta_model(lines: list[str]) -> str | None:
+    """Return the ``model`` field from the first ``type: meta`` JSONL record.
+
+    Returns ``None`` if no meta line exists, the meta line has no ``model``
+    field, or all candidates are malformed. Defensive by design — a missing
+    or broken meta line must not raise, only degrade ``cost`` to ``None``.
+    """
+    for line in lines:
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(obj, dict) and obj.get("type") == "meta":
+            model = obj.get("model")
+            if isinstance(model, str) and model:
+                return model
+            return None  # meta found but no usable model field
+    return None
+
+
+# Cache of the parsed codex_prices.toml. Reloaded on each call so a manual edit
+# during a long-running multi-arm session takes effect without a restart; the
+# cost is one file read per result file, which is negligible.
+def _load_codex_prices() -> dict[str, dict[str, float]]:
+    """Load the Codex CLI price table.
+
+    Returns a mapping ``{model_slug: {"input": .., "cached_input": .., "output": ..}}``.
+    Returns ``{}`` if the file is missing or unparseable (so unknown-model fallthrough
+    to ``cost=None`` is the only consequence).
+    """
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        try:
+            import tomli as tomllib  # type: ignore[import-not-found]
+        except ModuleNotFoundError:
+            return {}
+
+    path = Path(__file__).parent / "codex_prices.toml"
+    if not path.is_file():
+        return {}
+
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, ValueError):
+        return {}
+
+    # Each table is keyed by an arbitrary section name; the canonical model
+    # slug is the ``model`` field inside the section. This avoids TOML key
+    # quoting issues for names like ``gpt-5.5``.
+    out: dict[str, dict[str, float]] = {}
+    for section in data.values():
+        if not isinstance(section, dict):
+            continue
+        name = section.get("model")
+        if not isinstance(name, str):
+            continue
+        try:
+            out[name] = {
+                "input": float(section["input"]),
+                "cached_input": float(section["cached_input"]),
+                "output": float(section["output"]),
+            }
+        except (KeyError, TypeError, ValueError):
+            continue
+    return out
+
+
 def _safe_json_type(line: str) -> str | None:
     """Parse a JSONL line and return its 'type' field, or None on error."""
     try:
@@ -493,12 +651,17 @@ def _safe_json_type(line: str) -> str | None:
 # Factory
 # ---------------------------------------------------------------------------
 
-def make_runner(surface: str) -> AgentRunner:
-    """Return an AgentRunner for the given surface name."""
+def make_runner(surface: str, *, codex_model: str = DEFAULT_CODEX_MODEL) -> AgentRunner:
+    """Return an AgentRunner for the given surface name.
+
+    ``codex_model`` is only consulted when ``surface == "codex_cli"``. It is
+    threaded down into ``CodexRunner.__init__`` so the pin is applied to both
+    ``config.toml`` and the ``codex exec -m`` CLI flag.
+    """
     if surface == "claude_code":
         return ClaudeRunner()
     if surface == "codex_cli":
-        return CodexRunner()
+        return CodexRunner(model=codex_model)
     raise ValueError(
         f"Unknown agent surface: {surface!r}. "
         f"Valid values: 'claude_code', 'codex_cli'."

--- a/tests/test_analyze_summary.py
+++ b/tests/test_analyze_summary.py
@@ -154,5 +154,140 @@ def test_env_fail_appears_in_table_and_excluded_from_pass_rate():
     assert "pass_rate=n/a" in result.output
 
 
+# ---------------------------------------------------------------------------
+# Issue #253 — Codex cost estimates: ~$ prefix and price-table lookup
+# ---------------------------------------------------------------------------
+
+
+def _write_codex_run_fixture(
+    fixture_dir: Path,
+    *,
+    instance_id: str,
+    arm: str,
+    run_idx: int,
+    model: str | None,
+    verdict: str,
+    input_tokens: int = 0,
+    cached_input_tokens: int = 0,
+    output_tokens: int = 0,
+) -> None:
+    """Build a minimal Codex JSONL + _test.txt pair for a single arm/run."""
+    import json as _json
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+    jsonl = fixture_dir / f"{instance_id}_{arm}_run{run_idx}.jsonl"
+    lines = []
+    meta: dict = {
+        "type": "meta",
+        "instance_id": instance_id,
+        "arm": arm,
+        "run": run_idx,
+        "agent_surface": "codex_cli",
+    }
+    if model is not None:
+        meta["model"] = model
+    lines.append(_json.dumps(meta))
+    lines.append(_json.dumps({"type": "turn.started"}))
+    if input_tokens or output_tokens:
+        lines.append(_json.dumps({
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": input_tokens,
+                "cached_input_tokens": cached_input_tokens,
+                "output_tokens": output_tokens,
+            },
+        }))
+    else:
+        lines.append(_json.dumps({"type": "turn.completed"}))
+    jsonl.write_text("\n".join(lines) + "\n")
+    (fixture_dir / f"{instance_id}_{arm}_run{run_idx}_test.txt").write_text(
+        f"{verdict}\n"
+    )
+
+
+def test_codex_cli_cost_displayed_with_tilde_prefix(tmp_path: Path):
+    """``analyze summary`` prepends ``~`` to costs from codex_cli runs.
+
+    Acceptance criterion for issue #253: the cost column for a codex_cli row
+    must be visually distinguishable from a claude_code row to make clear it
+    is an estimate (token-count × price table) rather than a billed figure.
+    """
+    _write_codex_run_fixture(
+        tmp_path,
+        instance_id="myrepo__test-1",
+        arm="baseline",
+        run_idx=1,
+        model="gpt-5.5",
+        verdict="PASS",
+        input_tokens=10_000,
+        cached_input_tokens=2_000,
+        output_tokens=500,
+    )
+    result = _run(tmp_path)
+    assert result.exit_code == 0, result.output
+    # The dollar amount comes from CodexRunner.extract_metadata; we only assert
+    # the marker prefix is present so the test does not break on minor price
+    # rounding.
+    assert "~$" in result.output, result.output
+
+
+def test_codex_cli_unknown_model_shows_na(tmp_path: Path):
+    """Unknown model → cost=None → 'N/A' in the table (no ~$ prefix)."""
+    _write_codex_run_fixture(
+        tmp_path,
+        instance_id="myrepo__test-2",
+        arm="baseline",
+        run_idx=1,
+        model="totally-fake-model-99",
+        verdict="PASS",
+        input_tokens=1000,
+        output_tokens=100,
+    )
+    result = _run(tmp_path)
+    assert result.exit_code == 0, result.output
+    # Confirm the row exists and has N/A (no ~$).
+    assert "totally-fake-model" not in result.output  # we don't print model
+    assert "myrepo__test-2" in result.output
+    assert "N/A" in result.output
+    assert "~$" not in result.output
+
+
+def test_codex_cli_missing_model_in_meta_shows_na(tmp_path: Path):
+    """Meta line without a 'model' field → cost=None → 'N/A'."""
+    _write_codex_run_fixture(
+        tmp_path,
+        instance_id="myrepo__test-3",
+        arm="baseline",
+        run_idx=1,
+        model=None,  # no model key in meta
+        verdict="PASS",
+        input_tokens=1000,
+        output_tokens=100,
+    )
+    result = _run(tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "N/A" in result.output
+    assert "~$" not in result.output
+
+
+def test_summary_parses_agent_surface_from_meta(tmp_path: Path):
+    """`_parse_results` populates ArmResult.agent_surface from the meta line."""
+    from swebench.analyze.summary import _parse_results
+    _write_codex_run_fixture(
+        tmp_path,
+        instance_id="myrepo__test-4",
+        arm="baseline",
+        run_idx=1,
+        model="gpt-5.4",
+        verdict="PASS",
+        input_tokens=1000,
+        output_tokens=100,
+    )
+    results = _parse_results(tmp_path)
+    assert len(results) == 1
+    assert results[0].agent_surface == "codex_cli"
+    assert results[0].cost_usd is not None
+    assert results[0].cost_usd > 0
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/test_component_codex_cost_estimate.py
+++ b/tests/test_component_codex_cost_estimate.py
@@ -1,0 +1,473 @@
+"""Component tests for the codex cost-estimate boundary introduced in PR #253.
+
+Two boundaries are covered here:
+
+1. summary._parse_results → runner.CodexRunner.extract_metadata
+   ``_parse_results`` now dispatches to the real ``CodexRunner().extract_metadata``
+   for any ``codex_cli`` row. Tests verify: (a) the model slug flows from the
+   JSONL meta line through ``_parse_results`` into ``ArmResult.cost_usd`` via
+   the real price-table lookup; (b) unknown model → ``cost_usd is None``; (c)
+   missing model field → ``cost_usd is None``.
+
+2. summary._format_cost → ArmResult.agent_surface (the ~$ prefix contract)
+   ``_format_cost`` must emit ``~$`` for ``codex_cli`` rows and ``$`` for
+   ``claude_code`` rows. Tests verify the prefix reflects the ``agent_surface``
+   field populated by ``_parse_results`` from the meta line — exercising the
+   full chain: JSONL file → _parse_results → ArmResult → _format_cost → string.
+
+Both boundaries exercise two or more real modules co-operating. The only doubled
+seam is the filesystem (synthetic JSONL + _test.txt fixtures written under
+``tmp_path``). No subprocess, no network, no external binaries.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from swebench.analyze.summary import _format_cost, _parse_results
+
+
+# ---------------------------------------------------------------------------
+# Shared test-fixture builder
+# ---------------------------------------------------------------------------
+
+
+def _write_run_fixture(
+    fixture_dir: Path,
+    *,
+    instance_id: str,
+    arm: str,
+    run_idx: int,
+    agent_surface: str,
+    model: str | None = None,
+    verdict: str = "PASS",
+    usages: list[dict] | None = None,
+) -> Path:
+    """Write a minimal JSONL + _test.txt pair under fixture_dir.
+
+    ``usages`` is a list of dicts; each produces a ``turn.completed`` line.
+    When ``usages`` is empty or ``None``, only a bare ``turn.completed``
+    (no usage block) is emitted — which yields ``cost_usd=None``.
+
+    Returns the JSONL path.
+    """
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+    jsonl = fixture_dir / f"{instance_id}_{arm}_run{run_idx}.jsonl"
+    lines: list[str] = []
+
+    # First line must be the meta record
+    meta: dict = {
+        "type": "meta",
+        "instance_id": instance_id,
+        "arm": arm,
+        "run": run_idx,
+        "agent_surface": agent_surface,
+    }
+    if model is not None:
+        meta["model"] = model
+    lines.append(json.dumps(meta))
+
+    # Turns
+    if usages:
+        for usage in usages:
+            lines.append(json.dumps({"type": "turn.started"}))
+            lines.append(json.dumps({"type": "turn.completed", "usage": usage}))
+    else:
+        lines.append(json.dumps({"type": "turn.started"}))
+        lines.append(json.dumps({"type": "turn.completed"}))
+
+    jsonl.write_text("\n".join(lines) + "\n")
+    test_txt = fixture_dir / f"{instance_id}_{arm}_run{run_idx}_test.txt"
+    test_txt.write_text(f"{verdict}\n")
+    return jsonl
+
+
+# ---------------------------------------------------------------------------
+# Boundary 1a: _parse_results → CodexRunner.extract_metadata (known model)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.component
+class TestSummaryParseResultsCallsCodexExtractMetadata:
+    """summary._parse_results must delegate cost extraction to the real
+    CodexRunner.extract_metadata for codex_cli rows.
+
+    These tests use real filesystem fixtures and real module co-operation:
+    swebench/analyze/summary.py → swebench/runner.py::CodexRunner.extract_metadata
+    → swebench/codex_prices.toml (loaded by the real _load_codex_prices helper).
+
+    The only seam doubled is the directory of JSONL files (tmp_path).
+    """
+
+    def test_known_model_produces_nonzero_cost_via_real_extract_metadata(
+        self, tmp_path: Path
+    ):
+        """codex_cli row with known model + usage tokens → ArmResult.cost_usd > 0.
+
+        This fails if summary.py stops calling CodexRunner.extract_metadata
+        (e.g. reverts to the old regex-only path) or if the price-table lookup
+        is broken.
+        """
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-km-1",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="gpt-5.5",
+            verdict="PASS",
+            usages=[
+                {
+                    "input_tokens": 10_000,
+                    "cached_input_tokens": 2_000,
+                    "output_tokens": 500,
+                }
+            ],
+        )
+        results = _parse_results(tmp_path)
+        assert len(results) == 1, f"Expected 1 ArmResult, got {results}"
+        r = results[0]
+        assert r.agent_surface == "codex_cli"
+        assert r.cost_usd is not None, (
+            "cost_usd must be a float for a known model (gpt-5.5) with usage data; "
+            "got None — _parse_results is not calling CodexRunner.extract_metadata correctly"
+        )
+        assert r.cost_usd > 0, f"cost_usd must be positive; got {r.cost_usd}"
+
+    def test_cost_matches_price_table_formula(self, tmp_path: Path):
+        """The cost reported by _parse_results must equal the formula applied
+        to the price table entries loaded by the real _load_codex_prices().
+
+        This is the cross-module contract: summary.py delegates to runner.py,
+        and runner.py reads the real codex_prices.toml. Any drift between the
+        formula and the table is caught here.
+
+        gpt-5.4-mini prices: input=$0.75/M, cached_input=$0.075/M, output=$4.50/M
+        """
+        input_tokens = 8_000
+        cached_tokens = 1_000
+        output_tokens = 400
+
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-km-2",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="gpt-5.4-mini",
+            verdict="PASS",
+            usages=[
+                {
+                    "input_tokens": input_tokens,
+                    "cached_input_tokens": cached_tokens,
+                    "output_tokens": output_tokens,
+                }
+            ],
+        )
+
+        # Compute expected cost using the published gpt-5.4-mini prices.
+        # (These match codex_prices.toml — if the table changes, this test
+        # must be updated in tandem, which is the desired coupling.)
+        non_cached = input_tokens - cached_tokens
+        expected_cost = (
+            non_cached * 0.75 + cached_tokens * 0.075 + output_tokens * 4.50
+        ) / 1_000_000.0
+
+        results = _parse_results(tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        assert r.cost_usd == pytest.approx(expected_cost, rel=1e-9), (
+            f"cost_usd={r.cost_usd} does not match expected={expected_cost}. "
+            "Either the price table or the formula in CodexRunner.extract_metadata "
+            "has drifted from the expected formula."
+        )
+
+    def test_multiple_turns_summed_by_real_extract_metadata(self, tmp_path: Path):
+        """Multiple turn.completed events are summed by the real extract_metadata.
+
+        This validates the cross-module contract at the multi-turn code path.
+        gpt-5.4 prices: input=$2.50/M, cached=$0.25/M, output=$15.00/M
+        """
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-km-3",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="gpt-5.4",
+            verdict="PASS",
+            usages=[
+                {"input_tokens": 1_000, "cached_input_tokens": 0, "output_tokens": 100},
+                {"input_tokens": 2_000, "cached_input_tokens": 500, "output_tokens": 200},
+            ],
+        )
+
+        # Totals: input=3000, cached=500, output=300
+        non_cached = 3_000 - 500
+        expected_cost = (
+            non_cached * 2.50 + 500 * 0.25 + 300 * 15.00
+        ) / 1_000_000.0
+
+        results = _parse_results(tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        assert r.cost_usd == pytest.approx(expected_cost, rel=1e-9), (
+            f"Multi-turn cost mismatch: got {r.cost_usd}, expected {expected_cost}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary 1b: _parse_results → CodexRunner.extract_metadata (degraded paths)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.component
+class TestSummaryParseResultsCodexDegradedPaths:
+    """_parse_results must degrade gracefully to cost_usd=None when the codex
+    JSONL is missing the data needed for a price estimate.
+
+    These tests confirm that the real CodexRunner.extract_metadata returns
+    (None, ...) for these cases and that _parse_results faithfully propagates
+    cost_usd=None into the ArmResult.
+    """
+
+    def test_unknown_model_yields_none_cost(self, tmp_path: Path):
+        """A model slug not in codex_prices.toml → cost_usd=None.
+
+        The cross-module contract: summary.py must not hard-code model names;
+        it delegates to CodexRunner.extract_metadata which reads the table.
+        """
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-deg-1",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="totally-fake-model-xyz-99",
+            verdict="PASS",
+            usages=[{"input_tokens": 1000, "output_tokens": 100}],
+        )
+        results = _parse_results(tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        assert r.cost_usd is None, (
+            f"Expected cost_usd=None for an unknown model; got {r.cost_usd}. "
+            "The price-table lookup in CodexRunner.extract_metadata must fall through "
+            "to None for unlisted models."
+        )
+        # turns should still be extracted even when cost is unavailable
+        assert r.num_turns is not None and r.num_turns >= 1, (
+            "num_turns must be populated even when cost cannot be estimated"
+        )
+
+    def test_missing_model_field_in_meta_yields_none_cost(self, tmp_path: Path):
+        """When the meta line has agent_surface='codex_cli' but no 'model' field,
+        cost_usd must be None.
+
+        The real _read_meta_model() in runner.py returns None when the meta line
+        lacks a ``model`` key. summary.py must propagate this as cost_usd=None.
+        """
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-deg-2",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model=None,  # meta line will have no 'model' key
+            verdict="PASS",
+            usages=[{"input_tokens": 1000, "output_tokens": 100}],
+        )
+        results = _parse_results(tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        assert r.cost_usd is None, (
+            "cost_usd must be None when the meta line lacks a 'model' field; "
+            f"got {r.cost_usd}"
+        )
+
+    def test_no_usage_block_yields_none_cost(self, tmp_path: Path):
+        """Known model but no turn.completed carries a usage dict → cost_usd=None."""
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-deg-3",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="gpt-5.5",
+            verdict="PASS",
+            usages=None,  # turn.completed with no usage block
+        )
+        results = _parse_results(tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        assert r.cost_usd is None, (
+            "cost_usd must be None when turn.completed carries no usage block; "
+            f"got {r.cost_usd}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary 2: _format_cost → ArmResult.agent_surface (~$ vs $ prefix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.component
+class TestFormatCostTildePrefixFromParsedArmResult:
+    """_format_cost must emit ~$ for codex_cli rows and $ for claude_code rows.
+
+    The prefix decision depends on ``ArmResult.agent_surface``, which is
+    populated by ``_parse_results`` from the JSONL meta line. These tests
+    drive the full chain: JSONL file → _parse_results → ArmResult → _format_cost,
+    asserting that the surface field flows correctly across the summary→models
+    boundary.
+    """
+
+    def test_codex_cli_row_uses_tilde_dollar_prefix(self, tmp_path: Path):
+        """The complete chain must produce ``~$`` for a codex_cli row.
+
+        Failure here means the surface detection or prefix logic is broken:
+        either _parse_results is not reading agent_surface from the meta line,
+        or _format_cost is not checking ArmResult.agent_surface correctly.
+        """
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-pfx-1",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="gpt-5.5",
+            verdict="PASS",
+            usages=[{"input_tokens": 10_000, "cached_input_tokens": 0, "output_tokens": 500}],
+        )
+        results = _parse_results(tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        formatted = _format_cost(r)
+        assert formatted.startswith("~$"), (
+            f"codex_cli cost must be formatted as '~$<amount>'; got {formatted!r}. "
+            "The ~$ prefix signals 'estimate' to reviewers (issue #253 acceptance criteria)."
+        )
+
+    def test_claude_code_row_uses_plain_dollar_prefix(self, tmp_path: Path):
+        """The complete chain must produce ``$`` (no tilde) for a claude_code row.
+
+        claude_code rows report the authoritative billed cost from the agent's
+        own stream-json output, so the tilde must NOT appear.
+        """
+        fixture_dir = tmp_path
+        fixture_dir.mkdir(parents=True, exist_ok=True)
+        instance_id = "myrepo__test-pfx-2"
+        arm = "baseline"
+        run_idx = 1
+        jsonl = fixture_dir / f"{instance_id}_{arm}_run{run_idx}.jsonl"
+        # claude_code JSONL has total_cost_usd in a result line, no turn.completed usage
+        jsonl.write_text(
+            json.dumps({
+                "type": "meta",
+                "instance_id": instance_id,
+                "arm": arm,
+                "run": run_idx,
+                "agent_surface": "claude_code",
+            }) + "\n"
+            + json.dumps({
+                "type": "result",
+                "total_cost_usd": 0.1234,
+                "num_turns": 5,
+            }) + "\n"
+        )
+        (fixture_dir / f"{instance_id}_{arm}_run{run_idx}_test.txt").write_text("PASS\n")
+
+        results = _parse_results(fixture_dir)
+        assert len(results) == 1
+        r = results[0]
+        assert r.agent_surface == "claude_code", (
+            f"Expected agent_surface='claude_code'; got {r.agent_surface!r}"
+        )
+        assert r.cost_usd == pytest.approx(0.1234, rel=1e-6), (
+            f"Expected cost_usd~0.1234 for claude_code row; got {r.cost_usd}"
+        )
+        formatted = _format_cost(r)
+        assert formatted.startswith("$") and not formatted.startswith("~$"), (
+            f"claude_code cost must be formatted as '$<amount>' (no tilde); got {formatted!r}"
+        )
+
+    def test_codex_none_cost_formats_as_na(self, tmp_path: Path):
+        """Unknown model → cost_usd=None → _format_cost must return 'N/A' (no ~$ prefix).
+
+        This exercises the None-guard in _format_cost across the full pipeline.
+        """
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__test-pfx-3",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="unknown-model-xyz",
+            verdict="PASS",
+            usages=[{"input_tokens": 1000, "output_tokens": 100}],
+        )
+        results = _parse_results(tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        assert r.cost_usd is None
+        formatted = _format_cost(r)
+        assert formatted == "N/A", (
+            f"cost_usd=None must format as 'N/A'; got {formatted!r}. "
+            "Neither '~$' nor '$' must appear for uncosted rows."
+        )
+
+    def test_codex_prefix_persists_across_multiple_rows(self, tmp_path: Path):
+        """When both codex_cli and claude_code rows are in the same results dir,
+        each must get the correct prefix independently.
+
+        This guards the iteration contract: the surface routing inside _parse_results
+        must not leak between rows (e.g. a mutable default carrying state).
+        """
+        # Codex row
+        _write_run_fixture(
+            tmp_path,
+            instance_id="myrepo__alpha",
+            arm="baseline",
+            run_idx=1,
+            agent_surface="codex_cli",
+            model="gpt-5.5",
+            verdict="PASS",
+            usages=[{"input_tokens": 5_000, "cached_input_tokens": 0, "output_tokens": 200}],
+        )
+        # Claude row — write manually so we control total_cost_usd
+        claude_jsonl = tmp_path / "myrepo__bravo_baseline_run1.jsonl"
+        claude_jsonl.write_text(
+            json.dumps({
+                "type": "meta",
+                "instance_id": "myrepo__bravo",
+                "arm": "baseline",
+                "run": 1,
+                "agent_surface": "claude_code",
+            }) + "\n"
+            + json.dumps({"type": "result", "total_cost_usd": 0.05, "num_turns": 3}) + "\n"
+        )
+        (tmp_path / "myrepo__bravo_baseline_run1_test.txt").write_text("PASS\n")
+
+        results = _parse_results(tmp_path)
+        assert len(results) == 2, f"Expected 2 results; got {len(results)}"
+
+        # Sort by instance_id for determinism
+        by_id = {r.instance_id: r for r in results}
+        codex_r = by_id["myrepo__alpha"]
+        claude_r = by_id["myrepo__bravo"]
+
+        assert codex_r.agent_surface == "codex_cli"
+        assert claude_r.agent_surface == "claude_code"
+
+        codex_fmt = _format_cost(codex_r)
+        claude_fmt = _format_cost(claude_r)
+
+        assert codex_fmt.startswith("~$"), (
+            f"codex row must use ~$ prefix; got {codex_fmt!r}"
+        )
+        assert claude_fmt.startswith("$") and not claude_fmt.startswith("~$"), (
+            f"claude_code row must use plain $ prefix; got {claude_fmt!r}"
+        )

--- a/tests/test_component_codex_onlycode_arm.py
+++ b/tests/test_component_codex_onlycode_arm.py
@@ -541,3 +541,129 @@ class TestRunArmExtraPytestArgsForwardedToPreflight:
             f"'no:cacheprovider' must not appear in preflight cmd for "
             f"django__django-16379. cmd={cmd}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Boundary 4: run.py → JSONL meta line (Issue #253 — codex_model in meta)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.component
+class TestRunArmWritesCodexModelToMeta:
+    """``_run_arm`` writes the ``model`` field to the JSONL ``type: meta`` line
+    when ``agent_surface == 'codex_cli'`` and omits it for ``claude_code``.
+
+    Covers both meta-write sites: the env_fail short-circuit (when pytest
+    collects 0 items) and the happy-path write before agent invocation.
+    """
+
+    INSTANCE = "django__django-16379"
+
+    def _problem(self) -> Problem:
+        return Problem(
+            instance_id=self.INSTANCE,
+            repo_slug="django/django",
+            base_commit="abc123",
+            test_cmd="python -m pytest tests/foo.py",
+            problem_statement="dummy",
+            patch_file=None,
+            added_at="2026-01-01",
+            hf_split="test",
+        )
+
+    def _dirs(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        venv_dir = tmp_path / "venv"
+        (venv_dir / "bin").mkdir(parents=True)
+        (venv_dir / "bin" / "python").write_text("#!/bin/sh\nexec python3 \"$@\"\n")
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        return str(repo_dir), str(venv_dir), str(results_dir)
+
+    def _read_meta(self, results_dir: str) -> dict:
+        """Read the first JSONL line from the run's result file."""
+        results_path = Path(results_dir)
+        jsonl_files = list(results_path.glob("*.jsonl"))
+        assert len(jsonl_files) == 1, f"expected exactly one jsonl, got {jsonl_files}"
+        first = jsonl_files[0].read_text().splitlines()[0]
+        return json.loads(first)
+
+    def _patch_to_env_fail(self, monkeypatch):
+        """Force the preflight `pytest --collect-only` path to return 0 items."""
+        def _fake_run(cmd, **kw):
+            if isinstance(cmd, list) and "--collect-only" in cmd:
+                return _FakeCompleted(returncode=5, stdout="collected 0 items\n", stderr="")
+            return _FakeCompleted(returncode=0, stdout="", stderr="")
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_run)
+        monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+
+    def test_env_fail_meta_includes_model_for_codex_cli(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """codex_cli + env_fail short-circuit → meta line carries `model`."""
+        repo_dir, venv_dir, results_dir = self._dirs(tmp_path)
+        self._patch_to_env_fail(monkeypatch)
+
+        runner = _FakeCodexRunner()  # surface == "codex_cli"
+
+        verdict = run_mod._run_arm(
+            problem=self._problem(),
+            arm="baseline",
+            run_idx=1,
+            repo_dir=repo_dir,
+            venv_dir=venv_dir,
+            results_dir=results_dir,
+            agent_binary="/usr/bin/codex",
+            mcp_config_path=str(tmp_path / "mcp.json"),
+            root=tmp_path,
+            runner=runner,
+            codex_model="gpt-5.4-mini",
+        )
+
+        assert verdict == "env_fail"
+        meta = self._read_meta(results_dir)
+        assert meta["type"] == "meta"
+        assert meta["agent_surface"] == "codex_cli"
+        assert meta["model"] == "gpt-5.4-mini", (
+            f"Expected `model` field in env_fail meta line for codex_cli, "
+            f"but got: {meta}"
+        )
+
+    def test_env_fail_meta_omits_model_for_claude_code(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """claude_code + env_fail → meta line MUST NOT include `model`.
+
+        Claude's USD cost comes from `total_cost_usd` in its own stream-json
+        output. A `model` field would be misleading and is therefore omitted.
+        """
+        repo_dir, venv_dir, results_dir = self._dirs(tmp_path)
+        self._patch_to_env_fail(monkeypatch)
+
+        # No runner override → defaults to ClaudeRunner inside _run_arm.
+        # But we exercise the env_fail short-circuit which uses the `runner`
+        # arg directly to read surface. Pass a Claude-shaped stub.
+        from swebench.runner import ClaudeRunner
+
+        verdict = run_mod._run_arm(
+            problem=self._problem(),
+            arm="baseline",
+            run_idx=1,
+            repo_dir=repo_dir,
+            venv_dir=venv_dir,
+            results_dir=results_dir,
+            agent_binary="/usr/bin/claude",
+            mcp_config_path=str(tmp_path / "mcp.json"),
+            root=tmp_path,
+            runner=ClaudeRunner(),
+            codex_model=None,
+        )
+
+        assert verdict == "env_fail"
+        meta = self._read_meta(results_dir)
+        assert meta["type"] == "meta"
+        assert meta["agent_surface"] == "claude_code"
+        assert "model" not in meta, (
+            f"`model` must not appear in meta for claude_code; got: {meta}"
+        )

--- a/tests/test_integration_codex_cost_estimate.py
+++ b/tests/test_integration_codex_cost_estimate.py
@@ -1,0 +1,471 @@
+"""Integration wiring tests for codex cost estimation — issue #253.
+
+Scenario: slice-run-codex-model-flag-wiring
+Scenario: slice-analyze-summary-codex-cli-tilde
+Tier: wiring
+
+These tests exercise the full CLI dispatch path through Click
+(swebench/cli.py → swebench/run.py / swebench/analyze/summary.py)
+without invoking a real codex binary or a real benchmark run.
+
+What they verify (wiring only — no exact output comparison):
+
+Scenario 1 — slice-run-codex-model-flag-wiring
+  1. ``swebench run --help`` lists ``--codex-model`` in the option table.
+  2. The ``--codex-model`` default is ``gpt-5.5`` (plan acceptance criterion).
+  3. ``--codex-model`` is described in the help text so users can discover it.
+  4. The flag is registered on the Click command object (structural wiring).
+
+Scenario 2 — slice-analyze-summary-codex-cli-tilde
+  5. ``swebench analyze summary --results-dir <dir>`` shows ``~$`` for codex_cli
+     rows (estimate marker) — routed through the full cli → analyze → summary
+     dispatch chain.
+  6. ``swebench analyze summary`` shows plain ``$`` for claude_code rows (no
+     tilde prefix — authoritative billing).
+  7. ``swebench analyze summary`` shows ``N/A`` for codex_cli rows whose JSONL
+     model field is unknown (graceful degradation).
+  8. The two surfaces coexist in the same results directory without collision.
+
+Integration boundary: swebench/cli.py → swebench/run.py (run_command, Click
+@option decorator) and swebench/cli.py → swebench/analyze/summary.py
+(summary_command via analyze_command).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from swebench.cli import cli
+from swebench.run import run_command as _run_command
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_codex_run_dir(
+    results_dir: Path,
+    *,
+    instance_id: str,
+    arm: str,
+    run_idx: int,
+    model: str | None,
+    verdict: str,
+    input_tokens: int = 10_000,
+    cached_input_tokens: int = 2_000,
+    output_tokens: int = 500,
+    agent_surface: str = "codex_cli",
+) -> None:
+    """Write synthetic codex result files into results_dir.
+
+    Creates a JSONL meta line (with optional model field) + one
+    turn.completed event + a test verdict file.  Mirrors the real file
+    layout written by run.py so _parse_results() picks them up.
+    """
+    results_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{instance_id}_{arm}_run{run_idx}"
+
+    meta: dict = {
+        "type": "meta",
+        "instance_id": instance_id,
+        "arm": arm,
+        "run": run_idx,
+        "agent_surface": agent_surface,
+        "agent_binary": "/usr/bin/codex",
+        "agent_version": "test-1.0",
+    }
+    if model is not None:
+        meta["model"] = model
+
+    usage_line = {
+        "type": "turn.completed",
+        "usage": {
+            "input_tokens": input_tokens,
+            "cached_input_tokens": cached_input_tokens,
+            "output_tokens": output_tokens,
+        },
+    }
+
+    jsonl_path = results_dir / f"{stem}.jsonl"
+    jsonl_path.write_text(
+        json.dumps(meta) + "\n" + json.dumps(usage_line) + "\n"
+    )
+
+    test_path = results_dir / f"{stem}_test.txt"
+    test_path.write_text(f"{verdict}\n")
+
+
+def _make_claude_run_dir(
+    results_dir: Path,
+    *,
+    instance_id: str,
+    arm: str,
+    run_idx: int,
+    verdict: str,
+    cost_usd: float,
+    num_turns: int = 5,
+) -> None:
+    """Write synthetic claude_code result files into results_dir.
+
+    Mirrors what ClaudeRunner.invoke writes (stream-json including the
+    assistant-level result record) so _parse_results() can pick up the
+    ``total_cost_usd`` field.
+    """
+    results_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{instance_id}_{arm}_run{run_idx}"
+
+    meta: dict = {
+        "type": "meta",
+        "instance_id": instance_id,
+        "arm": arm,
+        "run": run_idx,
+        "agent_surface": "claude_code",
+        "agent_binary": "/usr/bin/claude",
+    }
+    result_line = {
+        "type": "result",
+        "total_cost_usd": cost_usd,
+        "num_turns": num_turns,
+    }
+
+    jsonl_path = results_dir / f"{stem}.jsonl"
+    jsonl_path.write_text(
+        json.dumps(meta) + "\n" + json.dumps(result_line) + "\n"
+    )
+
+    test_path = results_dir / f"{stem}_test.txt"
+    test_path.write_text(f"{verdict}\n")
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: slice-run-codex-model-flag-wiring
+#
+# swebench run --help must expose --codex-model with its default (gpt-5.5).
+# ---------------------------------------------------------------------------
+
+
+def test_run_help_lists_codex_model_option(runner):
+    """``swebench run --help`` must list ``--codex-model`` in the option table.
+
+    Wiring assertion: the flag must be registered on run_command and rendered
+    in the Click help output visible to users and operators.
+    """
+    result = runner.invoke(cli, ["run", "--help"])
+
+    assert result.exit_code == 0, (
+        f"``swebench run --help`` must exit 0; got {result.exit_code}.\n{result.output}"
+    )
+    assert "--codex-model" in result.output, (
+        f"``--codex-model`` not found in ``swebench run --help`` output:\n{result.output}"
+    )
+
+
+def test_run_codex_model_default_is_gpt55(runner):
+    """``--codex-model`` default must be ``gpt-5.5`` (plan acceptance criterion).
+
+    Schema assertion: Click renders the default in the help text.  The issue
+    acceptance criteria specify gpt-5.5 as the reproducible default.
+    """
+    result = runner.invoke(cli, ["run", "--help"])
+
+    assert result.exit_code == 0, (
+        f"Expected exit 0, got {result.exit_code}:\n{result.output}"
+    )
+    # The default must appear in the section near --codex-model.
+    codex_model_idx = result.output.find("--codex-model")
+    assert codex_model_idx != -1, "--codex-model not in help"
+
+    # Extract the block after --codex-model (up to next option or end).
+    block = result.output[codex_model_idx:codex_model_idx + 400]
+    assert "gpt-5.5" in block, (
+        f"Default 'gpt-5.5' not shown near --codex-model in help block:\n{block!r}"
+    )
+
+
+def test_run_codex_model_registered_on_click_command():
+    """``--codex-model`` must be a registered Click parameter on run_command.
+
+    Structural wiring: validates that the @click.option decorator is in place,
+    independently of the rendered help text.
+    """
+    param_names = [p.name for p in _run_command.params]
+    assert "codex_model" in param_names, (
+        f"codex_model parameter not registered on run_command; "
+        f"registered params: {param_names}"
+    )
+
+
+def test_run_codex_model_param_default():
+    """The Click Parameter for --codex-model must have default='gpt-5.5'."""
+    param = next(
+        (p for p in _run_command.params if p.name == "codex_model"), None
+    )
+    assert param is not None, "codex_model param not found on run_command"
+    assert param.default == "gpt-5.5", (
+        f"Expected default='gpt-5.5', got {param.default!r}"
+    )
+
+
+def test_run_codex_model_option_is_text_type():
+    """``--codex-model`` must accept free-form text (not a constrained Choice).
+
+    Schema assertion: users should be able to specify any model slug, including
+    future models not yet in the price table.  Unknown models degrade to
+    cost=None rather than being rejected at parse time.
+    """
+    import click as _click
+
+    param = next(
+        (p for p in _run_command.params if p.name == "codex_model"), None
+    )
+    assert param is not None, "codex_model param not found"
+    # STRING type means any text is accepted.
+    assert param.type in (
+        _click.STRING,
+        _click.types.StringParamType(),
+        str,
+    ) or str(param.type) in ("STRING", "TEXT", "<class 'str'>"), (
+        f"Expected STRING type for --codex-model; got {param.type!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: slice-analyze-summary-codex-cli-tilde
+#
+# swebench analyze summary must show ~$ for codex_cli rows and plain $ for
+# claude_code rows, routed through the full cli → analyze → summary chain.
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_summary_shows_tilde_prefix_for_codex_cli(tmp_path, monkeypatch):
+    """``swebench analyze summary`` must show ``~$`` for codex_cli runs.
+
+    Integration wiring assertion: the cost formatter (_format_cost) must be
+    connected to the summary_command output path through the full CLI dispatch
+    chain (cli → analyze_command → summary_command → _parse_results →
+    _format_cost → click.echo).
+
+    The ``~`` marker signals that the figure is a price-table estimate, not a
+    billed amount.  Verifying this through the CLI (not just the unit
+    _format_cost function) ensures the wiring from parse → format → output is
+    intact.
+    """
+    monkeypatch.setattr("swebench.analyze.summary.repo_root", lambda: tmp_path)
+    results_dir = tmp_path / "runs" / "swebench"
+
+    _make_codex_run_dir(
+        results_dir,
+        instance_id="myrepo__issue-1",
+        arm="baseline",
+        run_idx=1,
+        model="gpt-5.5",
+        verdict="PASS",
+        input_tokens=10_000,
+        cached_input_tokens=2_000,
+        output_tokens=500,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["analyze", "summary", "--results-dir", str(results_dir)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, (
+        f"analyze summary must exit 0; got {result.exit_code}.\n{result.output}"
+    )
+    assert "~$" in result.output, (
+        f"Expected '~$' cost prefix for codex_cli row in summary output.\n"
+        f"Output:\n{result.output}"
+    )
+
+
+def test_analyze_summary_plain_dollar_for_claude_code(tmp_path, monkeypatch):
+    """``swebench analyze summary`` must show plain ``$`` for claude_code runs.
+
+    Complementary schema assertion: authoritative USD billed by Claude must NOT
+    get the ``~`` estimate marker.  The two surfaces must be visually
+    distinguishable.
+    """
+    monkeypatch.setattr("swebench.analyze.summary.repo_root", lambda: tmp_path)
+    results_dir = tmp_path / "runs" / "swebench"
+
+    _make_claude_run_dir(
+        results_dir,
+        instance_id="myrepo__claude-1",
+        arm="baseline",
+        run_idx=1,
+        verdict="PASS",
+        cost_usd=0.4567,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["analyze", "summary", "--results-dir", str(results_dir)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, (
+        f"analyze summary must exit 0; got {result.exit_code}.\n{result.output}"
+    )
+    # Plain $ must appear (the cost is not zero).
+    assert "$" in result.output, (
+        f"Expected '$' in summary output for claude_code row.\n{result.output}"
+    )
+    # The tilde prefix must NOT appear for claude rows.
+    assert "~$" not in result.output, (
+        f"claude_code rows must NOT use '~$' prefix; got:\n{result.output}"
+    )
+
+
+def test_analyze_summary_na_for_unknown_codex_model(tmp_path, monkeypatch):
+    """Unknown codex model → cost=None → ``N/A`` in summary (no ``~$``).
+
+    Graceful degradation: if the model slug is not in codex_prices.toml,
+    the CLI must emit N/A rather than crashing or showing a wrong value.
+    The route from extract_metadata → _parse_results → _format_cost must
+    handle this cleanly through the full CLI dispatch chain.
+    """
+    monkeypatch.setattr("swebench.analyze.summary.repo_root", lambda: tmp_path)
+    results_dir = tmp_path / "runs" / "swebench"
+
+    _make_codex_run_dir(
+        results_dir,
+        instance_id="myrepo__issue-2",
+        arm="onlycode",
+        run_idx=1,
+        model="totally-unknown-model-99",
+        verdict="FAIL",
+        input_tokens=5_000,
+        output_tokens=300,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["analyze", "summary", "--results-dir", str(results_dir)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, (
+        f"analyze summary must exit 0; got {result.exit_code}.\n{result.output}"
+    )
+    assert "N/A" in result.output, (
+        f"Expected 'N/A' for unknown model cost.\n{result.output}"
+    )
+    assert "~$" not in result.output, (
+        f"'~$' must not appear when cost is N/A.\n{result.output}"
+    )
+
+
+def test_analyze_summary_mixed_surfaces_in_same_dir(tmp_path, monkeypatch):
+    """codex_cli and claude_code results coexist correctly in one results dir.
+
+    Integration contract: ``_parse_results`` uses the ``agent_surface`` meta
+    field to route each row to the right cost parser.  Both surfaces must
+    appear correctly in the same table — ``~$`` for codex, ``$`` for claude —
+    without either row interfering with the other.
+    """
+    monkeypatch.setattr("swebench.analyze.summary.repo_root", lambda: tmp_path)
+    results_dir = tmp_path / "runs" / "swebench"
+
+    # codex_cli row — should show ~$
+    _make_codex_run_dir(
+        results_dir,
+        instance_id="myrepo__codex-1",
+        arm="baseline",
+        run_idx=1,
+        model="gpt-5.4",
+        verdict="PASS",
+        input_tokens=8_000,
+        cached_input_tokens=1_000,
+        output_tokens=400,
+    )
+
+    # claude_code row — should show plain $
+    _make_claude_run_dir(
+        results_dir,
+        instance_id="myrepo__claude-1",
+        arm="baseline",
+        run_idx=1,
+        verdict="PASS",
+        cost_usd=0.3456,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["analyze", "summary", "--results-dir", str(results_dir)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, (
+        f"analyze summary must exit 0; got {result.exit_code}.\n{result.output}"
+    )
+    # Both rows must appear.
+    assert "myrepo__codex-1" in result.output, (
+        f"codex row not found in output:\n{result.output}"
+    )
+    assert "myrepo__claude-1" in result.output, (
+        f"claude row not found in output:\n{result.output}"
+    )
+    # Estimate marker must be present (for the codex row).
+    assert "~$" in result.output, (
+        f"Expected '~$' for codex_cli row in mixed-surface summary.\n{result.output}"
+    )
+    # Plain dollar must be present (for the claude row).
+    assert "$" in result.output, (
+        f"Expected '$' for claude_code row in mixed-surface summary.\n{result.output}"
+    )
+
+
+def test_analyze_summary_codex_na_when_meta_has_no_model(tmp_path, monkeypatch):
+    """codex_cli row with no ``model`` field in meta → ``N/A`` (not a crash).
+
+    Defensive degradation: old result files written before issue #253 may not
+    have the model field.  ``swebench analyze summary`` must still render the
+    row as N/A without raising an exception or emitting invalid output.
+    """
+    monkeypatch.setattr("swebench.analyze.summary.repo_root", lambda: tmp_path)
+    results_dir = tmp_path / "runs" / "swebench"
+
+    _make_codex_run_dir(
+        results_dir,
+        instance_id="myrepo__issue-3",
+        arm="baseline",
+        run_idx=1,
+        model=None,   # no model key in meta line
+        verdict="FAIL",
+        input_tokens=1_000,
+        output_tokens=100,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["analyze", "summary", "--results-dir", str(results_dir)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, (
+        f"analyze summary must exit 0 even without model field; "
+        f"got {result.exit_code}.\n{result.output}"
+    )
+    assert "N/A" in result.output, (
+        f"Expected 'N/A' when model field is absent.\n{result.output}"
+    )
+    assert "~$" not in result.output, (
+        f"'~$' must not appear when model is absent (cost is N/A).\n{result.output}"
+    )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -198,6 +198,238 @@ def test_write_codex_config_persistent_kernel_flag(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# CodexRunner — model pinning (Issue #253)
+# ---------------------------------------------------------------------------
+
+def test_write_codex_config_writes_default_model_line(tmp_path):
+    """Acceptance: ``_write_codex_config`` always writes a ``model = "..."`` line."""
+    _write_codex_config(str(tmp_path), "/bundle.mjs", "/scratch", "0")
+    content = (tmp_path / "config.toml").read_text()
+    assert 'model = "gpt-5.5"' in content
+
+
+def test_write_codex_config_writes_custom_model_line(tmp_path):
+    """Acceptance: ``--codex-model <name>`` overrides the default."""
+    _write_codex_config(
+        str(tmp_path), "/bundle.mjs", "/scratch", "0", model="gpt-5.4-mini"
+    )
+    content = (tmp_path / "config.toml").read_text()
+    assert 'model = "gpt-5.4-mini"' in content
+    # Must be at top level, not inside any [section]
+    first_section = content.split("[", 1)[0]
+    assert 'model = "gpt-5.4-mini"' in first_section
+
+
+def test_codex_runner_constructor_passes_model(tmp_path):
+    """The model arg threads through to ``_write_codex_config``."""
+    runner = CodexRunner(model="gpt-5.4")
+    assert runner.model == "gpt-5.4"
+
+
+def test_codex_runner_default_model_is_gpt_5_5():
+    """Default constructor arg is gpt-5.5."""
+    assert CodexRunner().model == "gpt-5.5"
+
+
+def test_make_runner_codex_threads_codex_model():
+    """make_runner forwards codex_model to CodexRunner."""
+    r = make_runner("codex_cli", codex_model="gpt-5.4")
+    assert isinstance(r, CodexRunner)
+    assert r.model == "gpt-5.4"
+
+
+def test_make_runner_codex_default_model():
+    """make_runner uses gpt-5.5 as the default codex_model."""
+    r = make_runner("codex_cli")
+    assert isinstance(r, CodexRunner)
+    assert r.model == "gpt-5.5"
+
+
+# ---------------------------------------------------------------------------
+# CodexRunner — cost estimation from token usage (Issue #253)
+# ---------------------------------------------------------------------------
+
+def _make_codex_jsonl(
+    tmp_path: Path,
+    *,
+    model: str | None,
+    usages: list[dict] | None,
+) -> Path:
+    """Build a minimal Codex JSONL with optional meta+model and usage entries."""
+    f = tmp_path / "agent.jsonl"
+    lines: list[str] = []
+    if model is not None:
+        lines.append(json.dumps({"type": "meta", "model": model}))
+    else:
+        lines.append(json.dumps({"type": "meta"}))  # meta but no model field
+    if usages is None:
+        # Default: just one turn with no usage block
+        lines += [
+            json.dumps({"type": "turn.started"}),
+            json.dumps({"type": "turn.completed"}),
+        ]
+    else:
+        for usage in usages:
+            lines += [
+                json.dumps({"type": "turn.started"}),
+                json.dumps({"type": "turn.completed", "usage": usage}),
+            ]
+    f.write_text("\n".join(lines) + "\n")
+    return f
+
+
+def test_codex_extract_metadata_known_model_estimates_cost(tmp_path):
+    """Acceptance: known model + turn.completed usage → estimated cost."""
+    f = _make_codex_jsonl(
+        tmp_path,
+        model="gpt-5.5",
+        usages=[{
+            "input_tokens": 421838,
+            "cached_input_tokens": 353280,
+            "output_tokens": 4673,
+            "reasoning_output_tokens": 1881,  # already inside output_tokens
+        }],
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert turns == 1
+    # gpt-5.5: input=$5/M, cached=$0.50/M, output=$30/M
+    # non_cached = 421838 - 353280 = 68558
+    # cost = (68558 * 5 + 353280 * 0.50 + 4673 * 30) / 1_000_000
+    #      = (342790 + 176640 + 140190) / 1_000_000 = 659620 / 1_000_000 = 0.65962
+    expected = (68558 * 5.0 + 353280 * 0.50 + 4673 * 30.0) / 1_000_000.0
+    assert cost == pytest.approx(expected, rel=1e-9)
+
+
+def test_codex_extract_metadata_sums_multiple_turns(tmp_path):
+    """Multiple turn.completed events are summed."""
+    f = _make_codex_jsonl(
+        tmp_path,
+        model="gpt-5.4-mini",
+        usages=[
+            {"input_tokens": 1000, "cached_input_tokens": 0, "output_tokens": 100},
+            {"input_tokens": 2000, "cached_input_tokens": 500, "output_tokens": 200},
+        ],
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert turns == 2
+    # Totals: input=3000, cached=500, output=300
+    # gpt-5.4-mini: input=$0.75, cached=$0.075, output=$4.50
+    # non_cached = 3000 - 500 = 2500
+    # cost = (2500 * 0.75 + 500 * 0.075 + 300 * 4.50) / 1_000_000
+    expected = (2500 * 0.75 + 500 * 0.075 + 300 * 4.50) / 1_000_000.0
+    assert cost == pytest.approx(expected, rel=1e-9)
+
+
+def test_codex_extract_metadata_unknown_model_returns_none(tmp_path):
+    """Acceptance: unknown model → cost=None (turns still extracted)."""
+    f = _make_codex_jsonl(
+        tmp_path,
+        model="claude-sonnet-99",  # not in price table
+        usages=[{"input_tokens": 100, "cached_input_tokens": 0, "output_tokens": 10}],
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert cost is None
+    assert turns == 1
+
+
+def test_codex_extract_metadata_missing_meta_returns_none(tmp_path):
+    """No meta line at all → cost=None."""
+    f = tmp_path / "agent.jsonl"
+    f.write_text(
+        json.dumps({"type": "turn.started"}) + "\n"
+        + json.dumps({"type": "turn.completed", "usage": {
+            "input_tokens": 100, "output_tokens": 5
+        }}) + "\n"
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert cost is None
+    assert turns == 1
+
+
+def test_codex_extract_metadata_meta_without_model_returns_none(tmp_path):
+    """Meta line present but no model field → cost=None."""
+    f = _make_codex_jsonl(
+        tmp_path,
+        model=None,  # meta with no model field
+        usages=[{"input_tokens": 100, "cached_input_tokens": 0, "output_tokens": 5}],
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert cost is None
+    assert turns == 1
+
+
+def test_codex_extract_metadata_no_usage_returns_none(tmp_path):
+    """Known model but no turn.completed has a ``usage`` block → cost=None."""
+    f = _make_codex_jsonl(
+        tmp_path,
+        model="gpt-5.5",
+        usages=None,  # turn.completed with no usage key
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert cost is None
+    assert turns == 1
+
+
+def test_codex_extract_metadata_handles_missing_cached_input(tmp_path):
+    """``cached_input_tokens`` absent → treated as 0 (still produces a cost)."""
+    f = _make_codex_jsonl(
+        tmp_path,
+        model="gpt-5.4",
+        usages=[{"input_tokens": 1000, "output_tokens": 100}],
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert turns == 1
+    # gpt-5.4: input=$2.50, cached=$0.25, output=$15
+    # cost = (1000 * 2.5 + 0 * 0.25 + 100 * 15) / 1_000_000
+    expected = (1000 * 2.5 + 100 * 15) / 1_000_000.0
+    assert cost == pytest.approx(expected, rel=1e-9)
+
+
+def test_codex_extract_metadata_malformed_jsonl_lines_ignored(tmp_path):
+    """Non-JSON / malformed lines are skipped, not raised."""
+    f = tmp_path / "agent.jsonl"
+    f.write_text(
+        json.dumps({"type": "meta", "model": "gpt-5.5"}) + "\n"
+        + "WARNING: some stderr line leaked in\n"
+        + json.dumps({"type": "turn.started"}) + "\n"
+        + json.dumps({"type": "turn.completed", "usage": {
+            "input_tokens": 100, "output_tokens": 5
+        }}) + "\n"
+    )
+    cost, turns = CodexRunner().extract_metadata(f)
+    assert turns == 1
+    assert cost == pytest.approx(
+        (100 * 5.0 + 5 * 30.0) / 1_000_000.0, rel=1e-9
+    )
+
+
+# ---------------------------------------------------------------------------
+# codex_prices.toml — schema sanity
+# ---------------------------------------------------------------------------
+
+def test_codex_prices_toml_contains_three_models():
+    """Acceptance: price table covers gpt-5.5, gpt-5.4, gpt-5.4-mini."""
+    from swebench.runner import _load_codex_prices
+    prices = _load_codex_prices()
+    for slug in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"):
+        assert slug in prices, f"missing {slug} in price table"
+        assert prices[slug]["input"] > 0
+        assert prices[slug]["cached_input"] >= 0
+        assert prices[slug]["output"] > 0
+
+
+def test_codex_prices_toml_has_dated_header():
+    """Acceptance: TOML header records the date and source URL."""
+    from pathlib import Path as _P
+    import swebench.runner as _r
+    path = _P(_r.__file__).parent / "codex_prices.toml"
+    content = path.read_text()
+    # Must mention a 2026 date and openai.com source so a reviewer can audit it.
+    assert "2026" in content
+    assert "openai" in content.lower()
+
+
+# ---------------------------------------------------------------------------
 # CodexRunner — build_tools_flags always empty
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #232

## Summary

- **`scikit-learn__scikit-learn-3840`** (`_INSTANCE_PRE_INSTALL` new entry): nose-style yield parametrize tests; pytest removed its nose plugin in 7.2, so collection errors on pytest 8.x. `pytest<7` keeps the nose compatibility layer active.
- **`scikit-learn__scikit-learn-11596`** (`_INSTANCE_PYTHON` new entry + `_INSTANCE_PRE_INSTALL` new entry): `test_print_versions.py` imports `distutils.version.LooseVersion`, deprecated in Python 3.10+ and promoted to an error by pytest's `filterwarnings = error`. Fixed by (a) adding `python3.9` (same as all adjacent 0.21.dev instances, also needed for the Cython ABI) and (b) pinning `pytest<7` with `scipy<1.6` matching adjacent entries.
- **`scikit-learn__scikit-learn-13864`** (`_INSTANCE_PRE_INSTALL` updated): `pytest.warns(None)` was changed in pytest 7.0 to raise `TypeError` when used as a no-op context manager; pytest 6.x accepts the legacy usage that this sklearn 0.22.dev test suite relies on.

All three instances get `pytest<7` in their pre-install pins so a compatible pytest is installed before the editable `pip install -e .` runs.

## Test plan

- [x] `pytest tests/ -m "not integration"` — 669 passed, 0 failures
- [ ] Re-run batch D seed_1 baseline for the three affected instances to confirm collection succeeds (requires full harness setup with network access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)