### PR TITLE
fix(#264-#270): batch datasci-mini env fixes (7 issues)

### DIFF
--- a/patches/scikit-learn__scikit-learn-11596_source_seed.patch
+++ b/patches/scikit-learn__scikit-learn-11596_source_seed.patch
@@ -1,0 +1,23 @@
+diff --git a/sklearn/utils/_show_versions.py b/sklearn/utils/_show_versions.py
+new file mode 100644
+index 0000000000..f27d6d1424
+--- /dev/null
++++ b/sklearn/utils/_show_versions.py
+@@ -0,0 +1,17 @@
++"""Stub _show_versions module — exists only so pre-flight ``pytest --collect-only``
++succeeds on the new tests that import this module. The agent is expected to
++replace these no-op bodies with a real implementation that reports system
++info, dependency versions, and BLAS configuration.
++"""
++
++
++def _get_sys_info():
++    return {}
++
++
++def _get_deps_info():
++    return {}
++
++
++def show_versions():
++    pass

--- a/problems/swe/swebench-datasci-mini/matplotlib__matplotlib-23088.yaml
+++ b/problems/swe/swebench-datasci-mini/matplotlib__matplotlib-23088.yaml
@@ -1,49 +1,8 @@
 instance_id: matplotlib__matplotlib-23088
 repo: matplotlib/matplotlib
 base_commit: b5fc36e9ac52aa130f852effb2fa08094ac5712b
-test_cmd: python -m pytest lib/matplotlib/tests/test_axes.py::test_plot_format_errors[None-f-'f'
-  lib/matplotlib/tests/test_axes.py::test_plot_format_errors[None-o+-'o\\+' lib/matplotlib/tests/test_axes.py::test_plot_format_errors[None-:--':-'
-  lib/matplotlib/tests/test_axes.py::test_plot_format_errors[None-rk-'rk' lib/matplotlib/tests/test_axes.py::test_plot_format_errors[None-:o-r-':o-r'
-  lib/matplotlib/tests/test_axes.py::test_plot_format_errors[data1-f-'f' lib/matplotlib/tests/test_axes.py::test_plot_format_errors[data1-o+-'o\\+'
-  lib/matplotlib/tests/test_axes.py::test_plot_format_errors[data1-:--':-' lib/matplotlib/tests/test_axes.py::test_plot_format_errors[data1-rk-'rk'
-  lib/matplotlib/tests/test_axes.py::test_plot_format_errors[data1-:o-r-':o-r'
+test_cmd: python -m pytest lib/matplotlib/tests/test_axes.py::test_plot_format_errors
 patch_file: patches/matplotlib__matplotlib-23088_tests.patch
-problem_statement: "[Bug]: Confusing error messages\n### Bug summary\n\nBasically,\
-  \ plotting from a dataframe failed because of a keyerror but the message I received\
-  \ was regarding formatting using a string. The failure happened silently, causing\
-  \ me to spend over an hour tracking down a type because I had no clue where to start.\n\
-  \n### Code for reproduction\n\n```python\n>>> import pandas as pd\r\n>>> import\
-  \ matplotlib.pyplot as plt\r\n>>> data  = [ [1,1], [2,2], [3,3] ]\r\n>>> df = pd.DataFrame(data,\
-  \ columns = ['header','mispelledHeader'])\r\n>>> figure, axes = plt.subplots()\r\
-  \n>>> line = axes.plot('header','correctlySpelledHeader',data = df)\n```\n\n\n###\
-  \ Actual outcome\n\nTraceback (most recent call last):\r\n  File \"<stdin>\", line\
-  \ 1, in <module>\r\n  File \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_axes.py\"\
-  , line 1605, in plot\r\n    lines = [*self._get_lines(*args, data=data, **kwargs)]\r\
-  \n  File \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_base.py\"\
-  , line 315, in __call__\r\n    yield from self._plot_args(this, kwargs)\r\n  File\
-  \ \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_base.py\"\
-  , line 452, in _plot_args\r\n    linestyle, marker, color = _process_plot_format(fmt)\r\
-  \n  File \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_base.py\"\
-  , line 188, in _process_plot_format\r\n    raise ValueError(\r\nValueError: Illegal\
-  \ format string \"correctlySpelledHeader\"; two color symbols\r\n\n\n### Expected\
-  \ outcome\n\nThe actual failure is happening when the df and key are passed into\
-  \ this as data and value respectively.\r\n\r\nmpl._replacer(data,value):\r\n----try:\r\
-  \n--------# if key isn't a string don't bother\r\n--------if isinstance(value, str):\r\
-  \n--------# try to use __getitem__\r\n--------value = data[value]            <-----------------------Key\
-  \ Error because of typo\r\n----except Exception:\r\n--------# key does not exist,\
-  \ silently fall back to key\r\n--------pass\r\n----return sanitize_sequence(value)\r\
-  \n\r\n\r\nAs you can see from the comment, this happens silently. And as you can\
-  \ see from the Traceback provided the error you finally receive is regarding a formatting\
-  \ string. So this caused quite a bit of confusion, because I was looking everywhere\
-  \ except my header spellings. I feel like this shouldn't happen 'silently', it at\
-  \ least deseves a warning, perhaps:\r\n\r\n----except Exception:\r\n--------warnings.warn('KeyError\
-  \ generated when attempting to access data using provided str')\r\n\r\n\r\nside\
-  \ note: the docstring says it returns data[value] or data back. in reality it passes\
-  \ back data[value] or value back. Not sure what the purpose is for allowing this\
-  \ to slide through, but either the behavior is wrong or the docstring is.\n\n###\
-  \ Additional information\n\n_No response_\n\n### Operating system\n\nUbuntu 20.04\n\
-  \n### Matplotlib Version\n\n3.4.2\n\n### Matplotlib Backend\n\nQt5Agg\n\n### Python\
-  \ version\n\n3.9.1\n\n### Jupyter version\n\n_No response_\n\n### Installation\n\
-  \n_No response_\n"
-added_at: '2026-04-17'
+problem_statement: "[Bug]: Confusing error messages\n### Bug summary\n\nBasically, plotting from a dataframe failed because of a keyerror but the message I received was regarding formatting using a string. The failure happened silently, causing me to spend over an hour tracking down a type because I had no clue where to start.\n\n### Code for reproduction\n\n```python\n>>> import pandas as pd\r\n>>> import matplotlib.pyplot as plt\r\n>>> data  = [ [1,1], [2,2], [3,3] ]\r\n>>> df = pd.DataFrame(data, columns = ['header','mispelledHeader'])\r\n>>> figure, axes = plt.subplots()\r\n>>> line = axes.plot('header','correctlySpelledHeader',data = df)\n```\n\n\n### Actual outcome\n\nTraceback (most recent call last):\r\n  File \"<stdin>\", line 1, in <module>\r\n  File \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_axes.py\", line 1605, in plot\r\n    lines = [*self._get_lines(*args, data=data, **kwargs)]\r\n  File \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_base.py\", line 315, in __call__\r\n    yield from self._plot_args(this, kwargs)\r\n  File \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_base.py\", line 452, in _plot_args\r\n    linestyle, marker, color = _process_plot_format(fmt)\r\n  File \"/home/b_briscoe/thirdparty/phel-1.2.0/linux_x86_64_9.4.0/miniconda3-4.9.2/lib/python3.9/site-packages/matplotlib/axes/_base.py\", line 188, in _process_plot_format\r\n    raise ValueError(\r\nValueError: Illegal format string \"correctlySpelledHeader\"; two color symbols\r\n\n\n### Expected outcome\n\nThe actual failure is happening when the df and key are passed into this as data and value respectively.\r\n\r\nmpl._replacer(data,value):\r\n----try:\r\n--------# if key isn't a string don't bother\r\n--------if isinstance(value, str):\r\n--------# try to use __getitem__\r\n--------value = data[value]            <-----------------------Key Error because of typo\r\n----except Exception:\r\n--------# key does not exist, silently fall back to key\r\n--------pass\r\n----return sanitize_sequence(value)\r\n\r\n\r\nAs you can see from the comment, this happens silently. And as you can see from the Traceback provided the error you finally receive is regarding a formatting string. So this caused quite a bit of confusion, because I was looking everywhere except my header spellings. I feel like this shouldn't happen 'silently', it at least deseves a warning, perhaps:\r\n\r\n----except Exception:\r\n--------warnings.warn('KeyError generated when attempting to access data using provided str')\r\n\r\n\r\nside note: the docstring says it returns data[value] or data back. in reality it passes back data[value] or value back. Not sure what the purpose is for allowing this to slide through, but either the behavior is wrong or the docstring is.\n\n### Additional information\n\n_No response_\n\n### Operating system\n\nUbuntu 20.04\n\n### Matplotlib Version\n\n3.4.2\n\n### Matplotlib Backend\n\nQt5Agg\n\n### Python version\n\n3.9.1\n\n### Jupyter version\n\n_No response_\n\n### Installation\n\n_No response_\n"
+added_at: '2026-05-17'
 hf_split: test

--- a/swebench/cache.py
+++ b/swebench/cache.py
@@ -226,13 +226,20 @@ def reinstall_editable(venv_dir: str, repo_dir: str) -> None:
     ``import package_name`` keeps working. This writes to the upperdir, not
     the cached lowerdir.
 
+    ``--no-build-isolation`` mirrors the same flag used by the initial editable
+    install in ``swebench/harness.py`` (setup_venv): the cached venv already has
+    every build dep at the pinned version (setuptools, cython, numpy, etc.).
+    Without this flag, PEP 517 creates a fresh build-env that pulls the LATEST
+    setuptools, which has removed APIs older instances depend on (e.g.,
+    ``setuptools.dep_util`` used by astropy ``setup_package.py``). (Issue #270.)
+
     Raises ``OverlayError`` on non-zero pip exit — a silent failure here would
     leave the venv's egg-link pointing at a path with no egg-info, causing
     confusing ImportErrors at test time.
     """
     pip = os.path.join(venv_dir, "bin", "pip")
     result = subprocess.run(
-        [pip, "install", "--quiet", "--no-deps", "-e", repo_dir],
+        [pip, "install", "--quiet", "--no-deps", "--no-build-isolation", "-e", repo_dir],
         capture_output=True,
         text=True,
     )

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -116,9 +116,11 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # "AttributeError: `np.unicode_` was removed in the NumPy 2.0 release".
     # pytz is required at test-module import time (xarray/tests/test_variable.py).
     "pydata__xarray-2905": ["numpy<2", "pytz"],
+    "pydata__xarray-3520": ["numpy<2"],
     "pydata__xarray-4075": ["numpy<2"],
     "pydata__xarray-4629": ["numpy<2"],
     "pydata__xarray-4911": ["numpy<2"],
+    "pydata__xarray-5455": ["numpy<2"],
     "pydata__xarray-6601": ["numpy<2", "setuptools_scm[toml]>=3.4", "setuptools_scm_git_archive"],
     "pydata__xarray-7003": ["numpy<2", "setuptools_scm[toml]>=3.4", "setuptools_scm_git_archive"],
     # scikit-learn 0.18 era (2017): tests use nose-style yield parametrize which
@@ -151,8 +153,10 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # the legacy usage that sklearn 0.22.dev tests rely on.
     "scikit-learn__scikit-learn-13864": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6", "pytest<7"],
     "scikit-learn__scikit-learn-14125": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
-    "scikit-learn__scikit-learn-14710": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
-    "scikit-learn__scikit-learn-15094": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6"],
+    # sklearn 0.22.dev: test modules transitively import `six` (Python 2/3 compat
+    # shim) which isn't a runtime dep of modern sklearn. (Issue #265)
+    "scikit-learn__scikit-learn-14710": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6", "six"],
+    "scikit-learn__scikit-learn-15094": ["setuptools<60", "numpy<1.24", "cython<3", "scipy<1.6", "six"],
     # scikit-learn 1.2–1.3 era: setup.py's check_package_status() imports scipy
     # at metadata-generation time, before any editable install. Without scipy
     # pre-installed, build fails with "scikit-learn requires scipy >= 1.3.2".
@@ -265,6 +269,12 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # seaborn 0.12 era (2022): numpy 2.x removed np.str_ etc. used in cm.py;
     # flit_core is required at build time for this instance's pyproject.toml.
     "mwaskom__seaborn-2946": ["matplotlib<3.7", "numpy<2", "flit_core>=3.2,<4"],
+    # seaborn 0.12 era (3069, 3202): same flit_core build-backend gap as 2946.
+    # 3202 also adds pandas<2.2 — the seaborn fixture calls
+    # ``pandas.set_option('mode.use_inf_as_na', ...)`` which pandas 2.2+ removed.
+    # (Issues #268, #269.)
+    "mwaskom__seaborn-3069": ["matplotlib<3.7", "numpy<2", "flit_core>=3.2,<4"],
+    "mwaskom__seaborn-3202": ["matplotlib<3.7", "numpy<2", "pandas<2.2", "flit_core>=3.2,<4"],
 }
 
 # ---------------------------------------------------------------------------
@@ -292,6 +302,12 @@ _INSTANCE_SOURCE_SEEDS: dict[str, str] = {
     # 1.0.3 which has the import; 2.0+ needs Sphinx≥5.0). The seed is a no-op
     # shim class so the imports succeed. (Issue #261, redesigned round 2.)
     "sphinx-doc__sphinx-9698": "patches/sphinx-doc__sphinx-9698_deprecation_seed.patch",
+    # sklearn 0.21.dev: the test patch imports `_get_sys_info`,
+    # `_get_deps_info`, `show_versions` from `sklearn.utils._show_versions`,
+    # a module the agent is expected to create. The stub has no-op bodies
+    # so the new tests collect but still FAIL until the agent does real
+    # work. (Issue #266.)
+    "scikit-learn__scikit-learn-11596": "patches/scikit-learn__scikit-learn-11596_source_seed.patch",
 }
 
 # ---------------------------------------------------------------------------

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -96,8 +96,14 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
     # astropy 5.x era (2022): same issue. setuptools_scm is required at test-import
     # time because astropy/version.py calls scm_version.get_version() during
     # `import astropy`. Without it, every test errors with "No module named 'setuptools_scm'".
-    "astropy__astropy-12962": ["setuptools<69", "numpy<2", "cython<3", "extension-helpers", "setuptools_scm"],
-    "astropy__astropy-13842": ["setuptools<69", "numpy<2", "cython<3", "extension-helpers", "setuptools_scm"],
+    # astropy 5.x: conftest + test_cmd need the full pytest-astropy plugin
+    # bundle (hypothesis, pytest-doctestplus, pytest-remotedata,
+    # pytest-openfiles, pytest-arraydiff, pytest-astropy-header). Each was
+    # surfaced one-by-one in rounds 2/3/4 of #270 after --no-build-isolation
+    # unblocked the reinstall_editable failure; `pytest-astropy` pulls them
+    # all in transitively.
+    "astropy__astropy-12962": ["setuptools<69", "numpy<2", "cython<3", "extension-helpers", "setuptools_scm", "pytest-astropy"],
+    "astropy__astropy-13842": ["setuptools<69", "numpy<2", "cython<3", "extension-helpers", "setuptools_scm", "pytest-astropy"],
     # matplotlib 3.5–3.6 era (2022): setuptools_scm 7.x deprecated get_version()
     # and emits DeprecationWarning when mpl.__version__ is accessed.  Pytest's
     # `filterwarnings = error` promotes this to an error, breaking SVG backend

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -243,6 +243,35 @@ def test_reinstall_editable_raises_on_pip_failure(tmp_path):
         cache.reinstall_editable(str(venv_dir), str(not_a_package))
 
 
+def test_reinstall_editable_uses_no_build_isolation(tmp_path, monkeypatch):
+    """``--no-build-isolation`` must be passed so the cached venv's pinned
+    build deps (e.g. setuptools<69 for astropy) are used — not a fresh
+    isolated build env that pulls the latest setuptools (which removed APIs
+    that older instances depend on like ``setuptools.dep_util``).
+    (Issue #270.)
+    """
+    captured = {}
+
+    class _FakeCompleted:
+        def __init__(self):
+            self.returncode = 0
+            self.stdout = ""
+            self.stderr = ""
+
+    def _fake_run(cmd, **kw):
+        captured["cmd"] = list(cmd)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(cache.subprocess, "run", _fake_run)
+    cache.reinstall_editable("/tmp/some_venv", "/tmp/some_repo")
+    cmd = captured["cmd"]
+    assert "--no-build-isolation" in cmd, (
+        f"reinstall_editable must pass --no-build-isolation; got cmd={cmd!r}"
+    )
+    # Sanity: --no-deps must still be there (we don't want to re-resolve deps).
+    assert "--no-deps" in cmd
+
+
 # --- run.py cached-setup fallback and teardown ------------------------------
 
 

--- a/tests/test_harness_venv.py
+++ b/tests/test_harness_venv.py
@@ -529,6 +529,80 @@ def test_astropy_5x_pre_install_pins() -> None:
         assert any("extension-helpers" in p for p in pins), f"Missing extension-helpers in {instance_id}"
 
 
+def test_xarray_pre_2_numpy_pins() -> None:
+    """xarray < 0.20 (and friends): the source tree references ``np.unicode_``,
+    removed in NumPy 2.0. Each affected instance must pin ``numpy<2`` in
+    pre-install. The set was extended in #264 after a datasci-mini sweep found
+    3520 and 5455 also affected (had been overlooked).
+    """
+    for instance_id in (
+        "pydata__xarray-2905",
+        "pydata__xarray-3520",
+        "pydata__xarray-4075",
+        "pydata__xarray-4629",
+        "pydata__xarray-4911",
+        "pydata__xarray-5455",
+        "pydata__xarray-6601",
+        "pydata__xarray-7003",
+    ):
+        pins = _INSTANCE_PRE_INSTALL.get(instance_id)
+        assert pins is not None, f"No pre-install pins for {instance_id}"
+        assert any("numpy<2" in p for p in pins), (
+            f"{instance_id} must pin numpy<2; got {pins!r}"
+        )
+
+
+def test_sklearn_022_six_pin() -> None:
+    """sklearn 0.22.dev: test modules transitively import ``six`` which isn't
+    a runtime dep of modern sklearn. Both 14710 and 15094 hit the same
+    ``ModuleNotFoundError: six`` at preflight. (Issue #265.)
+    """
+    for instance_id in (
+        "scikit-learn__scikit-learn-14710",
+        "scikit-learn__scikit-learn-15094",
+    ):
+        pins = _INSTANCE_PRE_INSTALL.get(instance_id)
+        assert pins is not None, f"No pre-install pins for {instance_id}"
+        assert "six" in pins, f"{instance_id} must pin `six`; got {pins!r}"
+
+
+def test_seaborn_3069_3202_flit_pins() -> None:
+    """seaborn 0.12 (3069, 3202): pyproject declares flit_core as the build
+    backend; without the pre-install pin, ``pip install -e . --no-build-isolation``
+    fails at cache setup. Mirrors the existing 2946 entry. (Issue #269.)
+    3202 additionally pins ``pandas<2.2`` because the seaborn fixture calls
+    ``pandas.set_option('mode.use_inf_as_na', ...)`` removed in pandas 2.2.
+    (Issue #268.)
+    """
+    pins_3069 = _INSTANCE_PRE_INSTALL.get("mwaskom__seaborn-3069")
+    pins_3202 = _INSTANCE_PRE_INSTALL.get("mwaskom__seaborn-3202")
+    assert pins_3069 is not None and pins_3202 is not None
+    for p in (pins_3069, pins_3202):
+        assert any("flit_core" in x for x in p), (
+            f"seaborn entry missing flit_core pin; got {p!r}"
+        )
+    assert any("pandas<2.2" in x for x in pins_3202), (
+        f"seaborn-3202 must pin pandas<2.2; got {pins_3202!r}"
+    )
+
+
+def test_sklearn_11596_has_source_seed() -> None:
+    """sklearn-11596 needs a source-seed patch creating a stub for
+    ``sklearn.utils._show_versions``. The test patch imports symbols from
+    that module which the agent is expected to create. (Issue #266.)
+    """
+    from swebench.harness import _INSTANCE_SOURCE_SEEDS
+    from swebench import repo_root
+    seed_rel = _INSTANCE_SOURCE_SEEDS.get("scikit-learn__scikit-learn-11596")
+    assert seed_rel is not None, "11596 must have a source-seed registered"
+    seed_path = repo_root() / seed_rel
+    assert seed_path.is_file(), f"source seed not found at {seed_path}"
+    text = seed_path.read_text()
+    # Must define the three symbols imported by the test patch.
+    for symbol in ("_get_sys_info", "_get_deps_info", "show_versions"):
+        assert symbol in text, f"source seed missing symbol {symbol}"
+
+
 def test_matplotlib_26160_instance_pins() -> None:
     """Test 18: matplotlib-26160 uses instance-level pins that drop setuptools<65."""
     pins = _INSTANCE_PRE_INSTALL.get("matplotlib__matplotlib-26160")

--- a/tests/test_harness_venv.py
+++ b/tests/test_harness_venv.py
@@ -519,7 +519,12 @@ def test_sphinx_9698_uses_low_pins_with_source_seed() -> None:
 
 
 def test_astropy_5x_pre_install_pins() -> None:
-    """Test 15: astropy 5.x instances have the required pre-install pins."""
+    """Test 15: astropy 5.x instances have the required pre-install pins.
+    `pytest-astropy` pulls in the full test plugin bundle (hypothesis,
+    pytest-doctestplus, pytest-remotedata, pytest-openfiles, pytest-arraydiff,
+    pytest-astropy-header) that the conftest + test_cmd need.
+    (Issue #270 rounds 2-4.)
+    """
     for instance_id in ("astropy__astropy-12962", "astropy__astropy-13842"):
         pins = _INSTANCE_PRE_INSTALL.get(instance_id)
         assert pins is not None, f"No instance pins for {instance_id}"
@@ -527,6 +532,11 @@ def test_astropy_5x_pre_install_pins() -> None:
         assert any("numpy<2" in p for p in pins), f"Missing numpy<2 in {instance_id}"
         assert any("cython<3" in p for p in pins), f"Missing cython<3 in {instance_id}"
         assert any("extension-helpers" in p for p in pins), f"Missing extension-helpers in {instance_id}"
+        assert "pytest-astropy" in pins, (
+            f"{instance_id} must pin pytest-astropy (meta-package pulls in the "
+            f"test plugins that conftest + --doctest-rst + remote_data need); "
+            f"got {pins!r}"
+        )
 
 
 def test_xarray_pre_2_numpy_pins() -> None:


### PR DESCRIPTION
## Summary

Batch env fix for `swebench-datasci-mini` (50 instances), closing 7 issues (#264–#270) found by the 2026-05-17 baseline validation sweep. Follows the playbook in [`docs/ENV_FIX_LOOP.md`](docs/ENV_FIX_LOOP.md) and the same shape as PR #263 (which did `swebench-verified-mini`).

| Issue | Bucket | Instances | Fix shape |
|---|---|---|---|
| #264 | `np.unicode_` removed (NumPy 2.0) | xarray-3520, 5455 | Extend existing `numpy<2` pre-install pattern. |
| #265 | `ModuleNotFoundError: six` | sklearn-14710, 15094 | Append `six` to pre-install. |
| #266 | `_show_versions` module missing at base_commit | sklearn-11596 | New source-seed patch (stub with no-op bodies — tests still FAIL until agent does real work). |
| #267 | Bad parametrize node IDs in YAML test_cmd (YAML-folding bug, pre-#262 writer) | matplotlib-23088 | Re-fetched and simplified test_cmd to target the function (pytest collects all variants). |
| #268 | `pandas.OptionError: mode.use_inf_as_na` (pandas 2.2 removal) | seaborn-3202 (hidden as FAIL) | Add `pandas<2.2`. |
| #269 | `flit_core` build backend missing under `--no-build-isolation` | seaborn-3069, 3202 (cache-stage failure) | Add `flit_core>=3.2,<4` (mirrors seaborn-2946). |
| #270 | `reinstall_editable` creates fresh PEP 517 build env → pulls latest setuptools → astropy `setup_package.py` imports removed `setuptools.dep_util` | astropy-12962, 13842 (hard ERROR, no test.txt) | One-line fix in `swebench/cache.py`: pass `--no-build-isolation` (same flag the initial install uses). |

## Tests

- `pytest tests/ -m "not integration"` → **700 passed** (5 new tests covering the new pins, source seed, and the `--no-build-isolation` flag).
- 6 caches `--force` rebuilt successfully after pin changes.

## Pre-PR sweep results

Round-1 baseline sweep on the 50 datasci-mini instances (`runs/swebench/datasci_validation_2026-05-17/`):

| Verdict | Count | Notes |
|---|---:|---|
| PASS | 32 | |
| FAIL | 10 | 9 look like legit agent misses (assertions, NotFittedError); **1 hidden env** (seaborn-3202 fixed in #268). |
| env_fail | 6 | Buckets #264 (×2), #265 (×2), #266 (×1), #267 (×1). |
| hard ERROR (no test.txt) | 2 | astropy-12962 + 13842 — both fixed by #270. |

Post-PR verification sweep on the 10 affected instances is running in `runs/swebench/datasci_validation_postfix1/`. **Will post the per-instance verdict table as a comment when it completes.**

## Risk notes

- **`--no-build-isolation` for `reinstall_editable`** (#270) is global — affects every cached instance, not just astropy. Per the subagent diagnosis: the cached venv always has all build deps installed via pre-install, so honoring those pins is strictly better than letting pip re-resolve. Same flag is already used by the initial editable install in `harness.py`. No realistic regressions expected, but worth a spot-check on the verify sweep.
- **`matplotlib-23088` test_cmd simplification** (#267) means pytest will run all 10 parametrize variants instead of the 5 specifically requested by the upstream FAIL_TO_PASS field. All 10 should pass with a correct fix and the extra variants don't add scoring risk.
- **`sklearn-11596` source seed** (#266) uses no-op bodies (returning `{}` / `pass`), so the test patch's assertions still FAIL until the agent implements real behavior — preserves the benchmark's integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
