### PR TITLE
fix(#273): downgrade returncode=0 with no-test-ran to FAIL

### DIFF
--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -1356,6 +1357,70 @@ def run_preflight_collect(
     return False, proc.stdout + (("\n" + proc.stderr) if proc.stderr else "")
 
 
+# ---------------------------------------------------------------------------
+# Effective-pass classifier (Issue #273)
+# ---------------------------------------------------------------------------
+
+# Django runtests.py / stdlib unittest emit one terminal "Ran N test[s] in T.Ts".
+_UNITTEST_RAN_RE = re.compile(r"^Ran (\d+) tests? in [\d.]+s\s*$", re.MULTILINE)
+# Followed (when rc=0) by either "OK" or "OK (skipped=N[, expected_failures=K, ...])".
+_UNITTEST_OK_RE = re.compile(r"^OK(?:\s+\(([^)]*)\))?\s*$", re.MULTILINE)
+# pytest terminal summary: "===== <body> in <time> ====" or "===== no tests ran in <time> =====".
+_PYTEST_SUMMARY_RE = re.compile(
+    r"={2,}\s+(?P<body>.+?)\s+in\s+[\d.]+\s*\w*\s+={2,}\s*$",
+    re.MULTILINE,
+)
+
+
+def _classify_test_result(output: str) -> tuple[bool, str | None]:
+    """Decide whether *output* reflects at least one actually-executed, non-skipped test.
+
+    Returns ``(effective_pass, reason_if_not)``.
+
+    Recognises unittest and pytest terminal output.  Unknown formats fall through
+    to ``(True, None)`` so the caller continues to trust ``returncode == 0`` —
+    this keeps non-pytest/-unittest invocations and stubbed unit tests unchanged.
+    """
+    # Pick the LAST matching summary in the output: a Django runtests.py invocation
+    # can print "Ran 0 tests" once before the real suite runs (e.g. when warnings
+    # configuration is probed), so the trailing summary is the authoritative one.
+    unittest_matches = list(_UNITTEST_RAN_RE.finditer(output))
+    if unittest_matches:
+        last = unittest_matches[-1]
+        ran = int(last.group(1))
+        if ran == 0:
+            return False, "unittest reported 0 tests run"
+        # Look for the OK line that follows the last "Ran ..." marker.
+        tail = output[last.end():]
+        ok = _UNITTEST_OK_RE.search(tail)
+        if ok:
+            attrs_str = ok.group(1) or ""
+            # parse "skipped=3, expected_failures=1" → {skipped:3, ...}
+            attrs = {
+                k: int(v)
+                for k, v in re.findall(r"(\w+)=(\d+)", attrs_str)
+            }
+            skipped = attrs.get("skipped", 0)
+            if skipped >= ran:
+                return False, f"unittest skipped all {ran} tests"
+        return True, None
+
+    pytest_matches = list(_PYTEST_SUMMARY_RE.finditer(output))
+    if pytest_matches:
+        body = pytest_matches[-1].group("body").strip()
+        if "no tests ran" in body:
+            return False, "pytest reported no tests ran"
+        # Treat any of these as "a real test executed and did not fail":
+        # passed, xpassed (unexpected pass — still an executed test signalling a fix).
+        # Failures/errors would have set returncode != 0 already; we only reach here on rc=0.
+        has_passed = re.search(r"\b(\d+)\s+(passed|xpassed)\b", body)
+        if not has_passed:
+            return False, f"pytest summary has no passed tests ({body!r})"
+        return True, None
+
+    return True, None
+
+
 def run_tests(
     *,
     repo_dir: str,
@@ -1419,9 +1484,27 @@ def run_tests(
             env=env,
         )
 
-    verdict = "PASS" if proc.returncode == 0 else "FAIL"
+    if proc.returncode != 0:
+        verdict = "FAIL"
+        downgrade_note: str | None = None
+    else:
+        try:
+            captured = Path(result_file).read_text(errors="replace")
+        except OSError:
+            captured = ""
+        effective, reason = _classify_test_result(captured)
+        if effective:
+            verdict = "PASS"
+            downgrade_note = None
+        else:
+            verdict = "FAIL"
+            downgrade_note = (
+                f"[harness] returncode=0 but {reason}; scoring FAIL (Issue #273)"
+            )
 
     with open(result_file, "a") as out:
+        if downgrade_note:
+            out.write(f"\n{downgrade_note}\n")
         out.write(f"\n{verdict}\n")
 
     return verdict

--- a/tests/test_harness_effective_pass.py
+++ b/tests/test_harness_effective_pass.py
@@ -1,0 +1,253 @@
+"""Tests for the effective-pass test classifier (Issue #273).
+
+Before #273, ``harness.run_tests`` returned PASS purely on ``returncode == 0``.
+Both pytest and unittest exit 0 when every collected test is skipped or when
+zero tests run, so all-skipped runs were silently scored PASS even though no
+test actually exercised the agent's fix.
+
+These tests pin the parser behaviour and the ``run_tests`` downgrade path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import swebench.harness as _harness_mod
+from swebench.harness import _classify_test_result, run_tests
+
+
+# ---------------------------------------------------------------------------
+# _classify_test_result — pytest output shapes
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyPytest:
+    def test_pytest_one_passed(self):
+        out = (
+            "tests/test_x.py .                              [100%]\n"
+            "============================== 1 passed in 0.10s ==============================\n"
+        )
+        ok, reason = _classify_test_result(out)
+        assert ok is True
+        assert reason is None
+
+    def test_pytest_passed_and_skipped(self):
+        out = "===== 3 passed, 2 skipped in 0.42s =====\n"
+        ok, reason = _classify_test_result(out)
+        assert ok is True
+
+    def test_pytest_only_skipped_is_fail(self):
+        out = "============================== 3 skipped in 0.01s ==============================\n"
+        ok, reason = _classify_test_result(out)
+        assert ok is False
+        assert reason is not None and "no passed tests" in reason
+
+    def test_pytest_no_tests_ran_is_fail(self):
+        out = "============================== no tests ran in 0.01s ==============================\n"
+        ok, reason = _classify_test_result(out)
+        assert ok is False
+        assert reason is not None and "no tests ran" in reason
+
+    def test_pytest_xpassed_counts_as_executed(self):
+        # xpassed = unexpected pass; the test ran and a fix likely made it pass.
+        out = "===== 1 xpassed in 0.05s =====\n"
+        ok, reason = _classify_test_result(out)
+        assert ok is True
+
+    def test_pytest_summary_with_warnings_block_only(self):
+        # "5 passed, 1 warning in 0.10s" — warnings are noise; passed counts.
+        out = "===== 5 passed, 1 warning in 0.10s =====\n"
+        ok, _ = _classify_test_result(out)
+        assert ok is True
+
+    def test_pytest_last_summary_wins(self):
+        # Pytest invoked twice in one log; trailing summary is authoritative.
+        out = (
+            "===== 0 passed, 3 skipped in 0.10s =====\n"
+            "===== 5 passed in 0.20s =====\n"
+        )
+        ok, _ = _classify_test_result(out)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# _classify_test_result — unittest / Django runtests.py output shapes
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyUnittest:
+    def test_unittest_ok(self):
+        out = (
+            "....\n"
+            "----------------------------------------------------------------------\n"
+            "Ran 4 tests in 0.012s\n"
+            "\n"
+            "OK\n"
+        )
+        ok, _ = _classify_test_result(out)
+        assert ok is True
+
+    def test_unittest_ok_with_partial_skip(self):
+        # 4 ran, 1 skipped — still PASS because 3 actually executed.
+        out = (
+            "Ran 4 tests in 0.012s\n"
+            "\n"
+            "OK (skipped=1)\n"
+        )
+        ok, _ = _classify_test_result(out)
+        assert ok is True
+
+    def test_unittest_all_skipped_is_fail(self):
+        # The django__django-12155 case: 1 ran, 1 skipped → no real test executed.
+        out = (
+            "s\n"
+            "----------------------------------------------------------------------\n"
+            "Ran 1 test in 0.000s\n"
+            "\n"
+            "OK (skipped=1)\n"
+        )
+        ok, reason = _classify_test_result(out)
+        assert ok is False
+        assert reason is not None and "skipped all 1" in reason
+
+    def test_unittest_zero_tests_is_fail(self):
+        out = (
+            "----------------------------------------------------------------------\n"
+            "Ran 0 tests in 0.000s\n"
+            "\n"
+            "OK\n"
+        )
+        ok, reason = _classify_test_result(out)
+        assert ok is False
+        assert reason is not None and "0 tests run" in reason
+
+    def test_unittest_ok_with_expected_failures_and_partial_skip(self):
+        # skipped<ran → PASS even with expected_failures mixed in.
+        out = (
+            "Ran 7 tests in 0.05s\n"
+            "\n"
+            "OK (skipped=2, expected_failures=1)\n"
+        )
+        ok, _ = _classify_test_result(out)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# _classify_test_result — unknown / non-test output
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyUnknownFormat:
+    def test_empty_output(self):
+        # Trust returncode=0 when nothing to parse.
+        ok, _ = _classify_test_result("")
+        assert ok is True
+
+    def test_arbitrary_output_no_unittest_or_pytest_markers(self):
+        ok, _ = _classify_test_result("just some script output\nhello world\n")
+        assert ok is True
+
+    def test_dummy_pass_stub_used_in_other_tests(self):
+        # The pre-existing tests in test_harness_instance_env.py write "PASS\n"
+        # to the result file as a stub.  That must keep working unchanged.
+        ok, _ = _classify_test_result("PASS\n")
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# run_tests downgrade integration
+# ---------------------------------------------------------------------------
+
+
+class TestRunTestsDowngradesAllSkipped:
+    """run_tests writes FAIL when subprocess exits 0 but no test actually ran."""
+
+    def _patch_python(self, tmp_path: Path) -> str:
+        venv_dir = str(tmp_path / "venv")
+        (tmp_path / "venv" / "bin").mkdir(parents=True)
+        (tmp_path / "venv" / "bin" / "python").write_text("#!/bin/sh\n")
+        return venv_dir
+
+    def test_all_skipped_unittest_downgrades_to_fail(self, monkeypatch, tmp_path: Path):
+        def _fake_run(cmd, **kw):
+            out = kw["stdout"]
+            out.write("s\n")
+            out.write("----------------------------------------------------------------------\n")
+            out.write("Ran 1 test in 0.000s\n\n")
+            out.write("OK (skipped=1)\n")
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_run)
+
+        result_file = str(tmp_path / "result.txt")
+        venv_dir = self._patch_python(tmp_path)
+
+        verdict = run_tests(
+            repo_dir=str(tmp_path),
+            test_cmd="python -m pytest tests/x.py",
+            venv_dir=venv_dir,
+            result_file=result_file,
+        )
+        assert verdict == "FAIL"
+        body = Path(result_file).read_text()
+        assert "skipped all 1 tests" in body
+        assert "Issue #273" in body
+        assert body.rstrip().endswith("FAIL")
+
+    def test_zero_tests_pytest_downgrades_to_fail(self, monkeypatch, tmp_path: Path):
+        def _fake_run(cmd, **kw):
+            kw["stdout"].write("===== no tests ran in 0.01s =====\n")
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_run)
+        result_file = str(tmp_path / "result.txt")
+        venv_dir = self._patch_python(tmp_path)
+
+        verdict = run_tests(
+            repo_dir=str(tmp_path),
+            test_cmd="python -m pytest tests/x.py",
+            venv_dir=venv_dir,
+            result_file=result_file,
+        )
+        assert verdict == "FAIL"
+
+    def test_real_pass_still_passes(self, monkeypatch, tmp_path: Path):
+        def _fake_run(cmd, **kw):
+            kw["stdout"].write("===== 5 passed in 0.10s =====\n")
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_run)
+        result_file = str(tmp_path / "result.txt")
+        venv_dir = self._patch_python(tmp_path)
+
+        verdict = run_tests(
+            repo_dir=str(tmp_path),
+            test_cmd="python -m pytest tests/x.py",
+            venv_dir=venv_dir,
+            result_file=result_file,
+        )
+        assert verdict == "PASS"
+        # No downgrade note for legitimate passes.
+        assert "Issue #273" not in Path(result_file).read_text()
+
+    def test_nonzero_returncode_skips_classifier(self, monkeypatch, tmp_path: Path):
+        # rc != 0 → FAIL regardless of stdout shape; no downgrade note appended.
+        def _fake_run(cmd, **kw):
+            kw["stdout"].write("===== 5 passed in 0.10s =====\n")  # liar
+            return SimpleNamespace(returncode=1)
+
+        monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_run)
+        result_file = str(tmp_path / "result.txt")
+        venv_dir = self._patch_python(tmp_path)
+
+        verdict = run_tests(
+            repo_dir=str(tmp_path),
+            test_cmd="python -m pytest tests/x.py",
+            venv_dir=venv_dir,
+            result_file=result_file,
+        )
+        assert verdict == "FAIL"
+        assert "Issue #273" not in Path(result_file).read_text()


### PR DESCRIPTION
Closes #273.

## Summary

- Adds `harness._classify_test_result` that parses unittest and pytest terminal summaries and reports whether at least one non-skipped test actually executed.
- `run_tests` now downgrades `returncode == 0` to `FAIL` (with a `[harness] returncode=0 but <reason>; scoring FAIL (Issue #273)` note appended to the result file) when the classifier says no real test ran.
- Unknown output formats fall through to the existing `returncode == 0 → PASS` behaviour so non-pytest/-unittest invocations and stub-based unit tests (e.g. `tests/test_harness_instance_env.py` writing `"PASS\n"` to result files) keep working unchanged.

## Why

`runs/swebench/codex_gpt55_seed_1` batch V1 baseline reported 1/13 PASS. The sole PASS was `django__django-12155`, whose result file ends with `OK (skipped=1)` because the cached venv has no `docutils`. The agent's own transcript flagged it: *"all seven tests are skipped in this environment because docutils isn't available."* The harness gate at `harness.py:1422` only checked `returncode == 0`, so all-skipped was scored PASS. Same risk applies to the claude_code surface whenever a test patch silently degrades to all-skipped.

## Test plan

- [x] `pytest tests/test_harness_effective_pass.py -q` — 19 new tests pass (pytest passed/skipped-only/no-tests-ran/xpassed/last-summary-wins, unittest OK/partial-skip/all-skip/zero-tests/expected-failures, unknown-format fallback, plus four `run_tests` integration cases covering downgrade + non-downgrade paths).
- [x] `pytest tests/ -m "not integration" -q` — full non-integration suite passes: 721 passed, 18 deselected.
- [x] Re-ran codex baseline on `django__django-12155` against post-db0629a cache. Result file ends with:
  ```
  s
  ----------------------------------------------------------------------
  Ran 1 test in 0.000s

  OK (skipped=1)
  Testing against Django installed in '/tmp/django__django-12155-eval/merged/django'
  System check identified no issues (0 silenced).

  [harness] returncode=0 but unittest skipped all 1 tests; scoring FAIL (Issue #273)

  FAIL
  ```
  The May-19 false PASS is now correctly scored FAIL, downgrade note is present, and the trailing `FAIL` line preserves the parse contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)