### PR TITLE
fix(#287): defer apply_test_patch to post-agent

### DIFF
--- a/docs/RESULTS_SWE_MINI.md
+++ b/docs/RESULTS_SWE_MINI.md
@@ -1,5 +1,19 @@
 # SWE-bench Mini — Batched Run Results (verified-mini, partial)
 
+> **⚠️ LEGACY — pre-#287 protocol.**
+> The runs reported below were produced under the pre-Issue #287 evaluation
+> protocol, where `apply_test_patch` ran *before* the agent and the hidden
+> test files sat on disk during the agent's execution.  Under that protocol
+> a baseline / bash_only / onlycode agent could read the held-out assertions
+> directly via `cat tests/test_added.py`, `ls tests/`, or `grep -r`, even
+> after #226 closed the `git diff` vector.  Numbers here therefore conflate
+> "agent fixed the bug" with "agent read the leaked tests" and must NOT be
+> compared against post-#287 runs.  The legacy run directories have been
+> moved to `runs/swebench/_legacy_pre_287/` for archival.
+>
+> Post-#287 numbers will be reported in a separate document once the
+> corrected protocol is re-run end-to-end.
+
 Status as of 2026-05-10. Companion to [BATCHED_RUN_SWE.md](BATCHED_RUN_SWE.md).
 
 ## Scope

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -293,19 +293,28 @@ _INSTANCE_PRE_INSTALL: dict[str, list[str]] = {
 # Per-instance source seed patches
 # ---------------------------------------------------------------------------
 # Paths are relative to the problems root (same convention as patch_file in
-# YAML). Applied to the repo BEFORE the test patch so that test-patch imports
-# of agent-created modules succeed at pre-flight collection time.
+# YAML). Applied to the repo BEFORE the agent runs.
+#
+# Scope (Issue #287 audit): only *environment* fixes — patches that make the
+# base repository's own pytest collection succeed regardless of the test_patch.
+# Seeds that stubbed modules the agent is expected to author have been removed
+# because, under the post-agent test-patch protocol, the agent is the one that
+# creates those modules; pre-stubbing them would either short-circuit the work
+# or read as the agent reusing a leaked hint.
+#
+# Removed (legacy under the pre-#287 protocol):
+#   - ``scikit-learn__scikit-learn-10427``: stubbed ``sklearn.externals._pilutil``
+#     so the pre-agent --collect-only would succeed.  Module is agent-authored.
+#   - ``scikit-learn__scikit-learn-11596``: stubbed ``sklearn.utils._show_versions``
+#     for the same reason.  Module is agent-authored.
 _INSTANCE_SOURCE_SEEDS: dict[str, str] = {
-    # sklearn 0.20-era: the test patch imports sklearn.externals._pilutil which
-    # the agent is expected to create as its fix. Without a stub the pre-flight
-    # --collect-only fails before the agent ever runs.
-    "scikit-learn__scikit-learn-10427": "patches/scikit-learn__scikit-learn-10427_source_seed.patch",
     # astropy 3.x / Python 3.9: conftest.py calls enable_deprecations_as_exceptions()
     # which turns all DeprecationWarnings into errors. On Python 3.9, the
     # collections ABCs (e.g. collections.MutableSequence) and pkg_resources both
     # issue DeprecationWarnings not covered by the 3.5/3.6 ignore lists in
     # astropy/tests/helper.py, causing collection to ERROR before any test runs.
-    # This patch adds Python 3.9 to the ignore list.  (Issue #246)
+    # This patch adds Python 3.9 to the ignore list.  (Issue #246)  Kept under
+    # #287 because it is an environment fix independent of the test patch.
     "astropy__astropy-6938": "patches/astropy__astropy-6938_py39_compat.patch",
     # sphinx 4.3 (9698): re-add ``RemovedInSphinx40Warning`` to
     # ``sphinx/deprecation.py``. The base_commit deleted the symbol but every
@@ -313,13 +322,9 @@ _INSTANCE_SOURCE_SEEDS: dict[str, str] = {
     # imports it; no PyPI version is in the safe zone (htmlhelp 1.x maxes at
     # 1.0.3 which has the import; 2.0+ needs Sphinx≥5.0). The seed is a no-op
     # shim class so the imports succeed. (Issue #261, redesigned round 2.)
+    # Kept under #287: it patches sphinx itself so any pytest run — including
+    # the agent's own test invocations — can import the package at all.
     "sphinx-doc__sphinx-9698": "patches/sphinx-doc__sphinx-9698_deprecation_seed.patch",
-    # sklearn 0.21.dev: the test patch imports `_get_sys_info`,
-    # `_get_deps_info`, `show_versions` from `sklearn.utils._show_versions`,
-    # a module the agent is expected to create. The stub has no-op bodies
-    # so the new tests collect but still FAIL until the agent does real
-    # work. (Issue #266.)
-    "scikit-learn__scikit-learn-11596": "patches/scikit-learn__scikit-learn-11596_source_seed.patch",
 }
 
 # ---------------------------------------------------------------------------

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -1060,14 +1060,90 @@ def setup_venv(
     Path(_venv_sentinel(venv_dir)).write_text(python_bin + "\n")
 
 
+def _parse_patch_targets(patch_path: str) -> tuple[list[str], list[str]]:
+    """Return ``(modified_paths, created_paths)`` for a unified-diff patch.
+
+    *modified_paths*: existing files the patch touches; the agent may have
+    edited these during its run, so we must reset them to HEAD before
+    ``git apply`` can succeed.
+
+    *created_paths*: new files the patch introduces (``--- /dev/null``);
+    if the agent created a file at the same path for unrelated reasons
+    ``git apply`` will fail with "already exists" — we ``rm -f`` those
+    before applying.
+
+    The state machine only treats ``--- ``/``+++ `` as file headers when
+    they appear between a ``diff --git`` line and the first ``@@`` hunk
+    marker, so a removed source line that happens to start with ``---``
+    inside a hunk body won't be misread as a header.
+    """
+    modified: list[str] = []
+    created: list[str] = []
+    in_header = False
+    last_source: str | None = None
+    with open(patch_path) as f:
+        for line in f:
+            if line.startswith("diff --git "):
+                in_header = True
+                last_source = None
+            elif line.startswith("@@"):
+                in_header = False
+            elif in_header and line.startswith("--- "):
+                last_source = line[4:].rstrip("\n").rstrip("\r")
+            elif in_header and line.startswith("+++ "):
+                target = line[4:].rstrip("\n").rstrip("\r")
+                if target == "/dev/null":
+                    # Patch deletes a file; treat as modify so we restore it
+                    # to HEAD before apply (apply will then re-delete it).
+                    if last_source and last_source.startswith("a/"):
+                        modified.append(last_source[2:])
+                else:
+                    path = target[2:] if target.startswith("b/") else target
+                    if last_source == "/dev/null":
+                        created.append(path)
+                    else:
+                        modified.append(path)
+                last_source = None
+    return modified, created
+
+
 def apply_test_patch(repo_dir: str, patch_path: str) -> bool:
     """Apply a test patch to the repo and commit it. Returns True if successful.
 
     Committing the patch (rather than leaving it as an unstaged diff) prevents
     agents from reading the test assertions via ``git diff`` — Issue #226.
+
+    Under the Issue #287 post-agent ordering the agent may have edited the
+    test files during its run, which would make ``git apply`` fail with a
+    conflict.  To keep the held-out tests authoritative we force-reset the
+    patch's modified files to HEAD and ``rm`` any agent-created files at the
+    patch's "new file" paths *before* applying.  A patch that still fails
+    after this — e.g. the agent edited a file the patch creates from
+    ``--- /dev/null`` and ``rm`` could not clear it — returns ``False`` and
+    the caller scores the run as FAIL rather than trusting ``run_tests``
+    against a contaminated tree.
     """
     if not os.path.isfile(patch_path):
         return False
+
+    # 1. Force the agent's edits out of the patch's blast radius.
+    modified, created = _parse_patch_targets(patch_path)
+    if modified:
+        subprocess.run(
+            ["git", "-C", repo_dir, "checkout", "HEAD", "--", *modified],
+            capture_output=True,
+        )
+    for rel in created:
+        full = os.path.join(repo_dir, rel)
+        try:
+            if os.path.isfile(full) or os.path.islink(full):
+                os.remove(full)
+        except OSError:
+            # Best-effort: if removal fails, the apply step below will fail
+            # cleanly and the caller treats that as FAIL.
+            pass
+
+    # 2. Apply the patch.
     result = subprocess.run(
         ["git", "-C", repo_dir, "apply", patch_path],
         capture_output=True,

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -340,12 +340,59 @@ def _run_arm(
     # until this point keeps tests/test_*.py invisible to ``cat`` / ``ls`` /
     # ``grep -r`` during the agent's run, closing the leak vector that the
     # #226 fix did not cover.
+    #
+    # ``apply_test_patch`` force-resets the patch's modified files to HEAD
+    # and removes any agent-created file at the patch's "new file" paths
+    # before invoking ``git apply``, so the typical contamination case (an
+    # agent that also edited a test file) lands cleanly.  If apply still
+    # fails — e.g. the agent created a colliding file we couldn't remove —
+    # we score the run as FAIL right here rather than trusting ``run_tests``
+    # against a tree that does not contain the held-out assertions.
     if problem.patch_file:
         patch_path = str(root / problem.patch_file)
         if apply_test_patch(repo_dir, patch_path):
             _echo(f"  [{arm} run {run_idx}] Applied test patch (post-agent).")
         else:
-            _echo(f"  [{arm} run {run_idx}] WARNING: test patch failed to apply.")
+            _echo(
+                f"  [{arm} run {run_idx}] Test patch FAILED to apply post-agent — "
+                "recording FAIL (the tree does not contain the held-out tests; "
+                "run_tests would be measuring the agent's own assertions)."
+            )
+            # Update the meta record's verdict + reason in place, mirroring
+            # the env_fail handler. Agent transcript on subsequent lines is
+            # preserved.
+            try:
+                with open(result_file) as _rf:
+                    _lines = _rf.readlines()
+            except OSError:
+                _lines = []
+            if _lines:
+                try:
+                    _meta_loaded = json.loads(_lines[0])
+                except json.JSONDecodeError:
+                    _meta_loaded = dict(_meta_record)
+            else:
+                _meta_loaded = dict(_meta_record)
+            _meta_loaded["verdict"] = "FAIL"
+            _meta_loaded["reason"] = (
+                "post-agent git apply failed; agent edits conflicted with the "
+                "held-out test patch"
+            )
+            _lines[:1] = [json.dumps(_meta_loaded) + "\n"]
+            with open(result_file, "w") as _wf:
+                _wf.writelines(_lines)
+            with open(test_result_file, "w") as out:
+                out.write(
+                    "# Test patch failed to apply post-agent (Issue #287).\n"
+                    "# The agent's edits conflicted with the held-out hunks even\n"
+                    "# after force-resetting the patch's modified files to HEAD.\n"
+                    "# We do NOT run pytest against this tree because it does not\n"
+                    "# contain the held-out assertions — any PASS would be\n"
+                    "# measuring the agent's own tests, not the upstream contract.\n"
+                    "\nFAIL\n"
+                )
+            _echo(f"  [{arm} run {run_idx}] Verdict: FAIL ({wall_secs}s wall)")
+            return "FAIL"
 
     # ------------------------------------------------------------------
     # POST-AGENT: pre-flight pytest --collect-only (Issue #238 / #287)

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -205,8 +205,11 @@ def _run_arm(
     if needs_editable_reinstall:
         reinstall_editable(venv_dir, repo_dir)
 
-    # Apply source seed patch (if any) before the test patch so that
-    # test-patch imports of agent-created modules succeed at pre-flight time.
+    # Apply source seed patch (if any) before the agent runs. These patches
+    # are reserved for pre-agent *environment* fixes (e.g. Python 3.9 compat
+    # for astropy, missing deprecation shims for sphinxcontrib-* imports) —
+    # they do NOT seed modules the agent is expected to author. See
+    # ``_INSTANCE_SOURCE_SEEDS`` in harness.py for the per-instance rationale.
     seed_rel = _INSTANCE_SOURCE_SEEDS.get(problem.instance_id)
     if seed_rel:
         seed_path = str(root / seed_rel)
@@ -215,77 +218,14 @@ def _run_arm(
         else:
             _echo(f"  [{arm} run {run_idx}] WARNING: source seed patch failed to apply.")
 
-    # Apply test patch
-    if problem.patch_file:
-        patch_path = str(root / problem.patch_file)
-        if apply_test_patch(repo_dir, patch_path):
-            _echo(f"  [{arm} run {run_idx}] Applied test patch.")
-        else:
-            _echo(f"  [{arm} run {run_idx}] WARNING: test patch failed to apply.")
-
-    # ------------------------------------------------------------------
-    # Pre-flight: pytest --collect-only (Issue #238 / #234)
-    # ------------------------------------------------------------------
-    # Resolve the test command first (sympy bare-name → file::test node IDs)
-    # so the collection check sees the same final command the test run will
-    # use.  If zero items collect, record env_fail and skip the agent
-    # entirely — there is nothing for the agent to fix, and counting this
-    # as FAIL silently corrupts pass-rate aggregates.
-    resolved_test_cmd = resolve_test_node_ids(
-        problem.test_cmd,
-        repo_dir=repo_dir,
-        venv_dir=venv_dir,
-        repo_slug=problem.repo_slug,
-    )
-    collected_ok, preflight_output = run_preflight_collect(
-        repo_dir=repo_dir,
-        test_cmd=resolved_test_cmd,
-        venv_dir=venv_dir,
-        extra_env=_INSTANCE_ENV.get(problem.instance_id),
-        extra_pytest_args=_INSTANCE_EXTRA_PYTEST_ARGS.get(problem.instance_id),
-    )
-    if not collected_ok:
-        _echo(
-            f"  [{arm} run {run_idx}] Pre-flight collect FAILED — recording env_fail "
-            f"(0 items collected; skipping agent)."
-        )
-        result_file = os.path.join(
-            results_dir, f"{problem.instance_id}_{arm}_run{run_idx}.jsonl"
-        )
-        # Write a minimal meta record so downstream tools (analyze, summary,
-        # _is_triple_complete) see a properly-shaped jsonl file.
-        _meta_surface = runner.surface if runner is not None else "claude_code"
-        _meta_record: dict[str, object] = {
-            "type": "meta",
-            "instance_id": problem.instance_id,
-            "arm": arm,
-            "run": run_idx,
-            "agent_surface": _meta_surface,
-            "agent_binary": agent_binary,
-            "verdict": "env_fail",
-            "reason": "pytest --collect-only returned 0 items",
-        }
-        # Pin the model for codex_cli runs so extract_metadata can price the
-        # (empty) usage record and so the result file is self-describing.
-        if _meta_surface == "codex_cli" and codex_model is not None:
-            _meta_record["model"] = codex_model
-        with open(result_file, "w") as _meta_f:
-            _meta_f.write(json.dumps(_meta_record) + "\n")
-        test_result_file = os.path.join(
-            results_dir, f"{problem.instance_id}_{arm}_run{run_idx}_test.txt"
-        )
-        with open(test_result_file, "w") as out:
-            out.write(
-                "# pre-flight pytest --collect-only (Issue #238) — "
-                "0 items collected; agent was not invoked.\n"
-            )
-            if preflight_output:
-                out.write("\n--- pytest --collect-only output ---\n")
-                out.write(preflight_output)
-                out.write("\n--- end ---\n")
-            out.write("\nenv_fail\n")
-        _echo(f"  [{arm} run {run_idx}] Verdict: env_fail")
-        return "env_fail"
+    # NOTE: ``apply_test_patch`` and the pre-flight ``pytest --collect-only``
+    # check are deliberately deferred until *after* the agent finishes (Issue
+    # #287).  Applying the test patch pre-agent left the hidden test files
+    # readable on disk via ``cat tests/test_added.py`` / ``ls tests/`` /
+    # ``grep -r``, defeating the #226 integrity invariant. Under the new
+    # protocol the agent never sees the test patch — it operates on the same
+    # tree the upstream developer faced — and the harness applies + collects
+    # post-agent so PASS/FAIL still reflects the held-out tests.
 
     # Build prompt from problem_statement — eliminates hardcoded text bug
     venv_python = os.path.join(venv_dir, "bin", "python")
@@ -392,6 +332,78 @@ def _run_arm(
     test_result_file = os.path.join(
         results_dir, f"{problem.instance_id}_{arm}_run{run_idx}_test.txt"
     )
+
+    # ------------------------------------------------------------------
+    # POST-AGENT: apply test patch (Issue #287)
+    # ------------------------------------------------------------------
+    # Applied only now, after the agent has terminated. Holding the patch
+    # until this point keeps tests/test_*.py invisible to ``cat`` / ``ls`` /
+    # ``grep -r`` during the agent's run, closing the leak vector that the
+    # #226 fix did not cover.
+    if problem.patch_file:
+        patch_path = str(root / problem.patch_file)
+        if apply_test_patch(repo_dir, patch_path):
+            _echo(f"  [{arm} run {run_idx}] Applied test patch (post-agent).")
+        else:
+            _echo(f"  [{arm} run {run_idx}] WARNING: test patch failed to apply.")
+
+    # ------------------------------------------------------------------
+    # POST-AGENT: pre-flight pytest --collect-only (Issue #238 / #287)
+    # ------------------------------------------------------------------
+    # Moved alongside ``apply_test_patch`` because the pre-flight must see
+    # the test-patched tree. If zero items collect, record ``env_fail`` and
+    # skip ``run_tests``; the agent's transcript is preserved in the .jsonl.
+    resolved_test_cmd = resolve_test_node_ids(
+        problem.test_cmd,
+        repo_dir=repo_dir,
+        venv_dir=venv_dir,
+        repo_slug=problem.repo_slug,
+    )
+    collected_ok, preflight_output = run_preflight_collect(
+        repo_dir=repo_dir,
+        test_cmd=resolved_test_cmd,
+        venv_dir=venv_dir,
+        extra_env=_INSTANCE_ENV.get(problem.instance_id),
+        extra_pytest_args=_INSTANCE_EXTRA_PYTEST_ARGS.get(problem.instance_id),
+    )
+    if not collected_ok:
+        _echo(
+            f"  [{arm} run {run_idx}] Pre-flight collect FAILED (post-agent) — "
+            "recording env_fail (0 items collected; skipping run_tests)."
+        )
+        # Update the meta record on line 1 of the .jsonl to carry the
+        # env_fail verdict + reason, preserving the agent transcript that
+        # follows it. Downstream tools (analyze, summary) keep reading the
+        # first meta line and now see verdict=env_fail there.
+        try:
+            with open(result_file) as _rf:
+                _lines = _rf.readlines()
+        except OSError:
+            _lines = []
+        if _lines:
+            try:
+                _meta_loaded = json.loads(_lines[0])
+            except json.JSONDecodeError:
+                _meta_loaded = dict(_meta_record)
+        else:
+            _meta_loaded = dict(_meta_record)
+        _meta_loaded["verdict"] = "env_fail"
+        _meta_loaded["reason"] = "pytest --collect-only returned 0 items (post-agent)"
+        _lines[:1] = [json.dumps(_meta_loaded) + "\n"]
+        with open(result_file, "w") as _wf:
+            _wf.writelines(_lines)
+        with open(test_result_file, "w") as out:
+            out.write(
+                "# post-agent pytest --collect-only (Issue #287 / #238) — "
+                "0 items collected after applying test patch.\n"
+            )
+            if preflight_output:
+                out.write("\n--- pytest --collect-only output ---\n")
+                out.write(preflight_output)
+                out.write("\n--- end ---\n")
+            out.write("\nenv_fail\n")
+        _echo(f"  [{arm} run {run_idx}] Verdict: env_fail ({wall_secs}s wall)")
+        return "env_fail"
 
     _echo(f"  [{arm} run {run_idx}] Running test suite...")
 

--- a/tests/test_component_codex_onlycode_arm.py
+++ b/tests/test_component_codex_onlycode_arm.py
@@ -320,6 +320,26 @@ class _FakeCompleted:
         self.stderr = stderr
 
 
+class _NoopRunner:
+    """Stub AgentRunner — see Issue #287. Needed because the post-agent
+    pre-flight ordering means tests must run past ``runner.invoke()`` before
+    they can observe the pre-flight subprocess calls."""
+
+    surface = "claude_code"
+
+    def build_tools_flags(self, arm, mcp_config_path):
+        return []
+
+    def get_version(self, binary):
+        return "stub"
+
+    def invoke(self, **kw):
+        pass
+
+    def extract_metadata(self, path):
+        return (None, None)
+
+
 @pytest.mark.component
 class TestRunArmExtraPytestArgsForwardedToPreflight:
     """_run_arm must pass _INSTANCE_EXTRA_PYTEST_ARGS[instance_id] as extra_pytest_args
@@ -392,13 +412,7 @@ class TestRunArmExtraPytestArgsForwardedToPreflight:
 
         # Double run.py I/O seams that are not part of this boundary.
         monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
-        monkeypatch.setattr(
-            run_mod,
-            "run_claude",
-            lambda **kw: (_ for _ in ()).throw(
-                AssertionError("run_claude must not be called when preflight fails")
-            ),
-        )
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = self._make_problem()
         verdict = run_mod._run_arm(
@@ -411,6 +425,7 @@ class TestRunArmExtraPytestArgsForwardedToPreflight:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         # _run_arm must have taken the env_fail path (0 collected → env_fail).
@@ -451,7 +466,7 @@ class TestRunArmExtraPytestArgsForwardedToPreflight:
 
         monkeypatch.setattr(_harness_mod.subprocess, "run", _recording_subprocess_run)
         monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
-        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = self._make_problem()
         run_mod._run_arm(
@@ -464,6 +479,7 @@ class TestRunArmExtraPytestArgsForwardedToPreflight:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         assert len(preflight_calls) >= 1, "No --collect-only subprocess call observed"
@@ -503,7 +519,7 @@ class TestRunArmExtraPytestArgsForwardedToPreflight:
 
         monkeypatch.setattr(_harness_mod.subprocess, "run", _recording_subprocess_run)
         monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
-        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         # Use an instance NOT in _INSTANCE_EXTRA_PYTEST_ARGS.
         problem = Problem(
@@ -532,6 +548,7 @@ class TestRunArmExtraPytestArgsForwardedToPreflight:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         assert len(preflight_calls) >= 1
@@ -637,14 +654,14 @@ class TestRunArmWritesCodexModelToMeta:
 
         Claude's USD cost comes from `total_cost_usd` in its own stream-json
         output. A `model` field would be misleading and is therefore omitted.
+
+        Under Issue #287 the agent runs before pre-flight, so we install a
+        claude_code-flavoured ``_NoopRunner`` rather than the real
+        ``ClaudeRunner`` (which would try to spawn ``/usr/bin/claude``).
         """
         repo_dir, venv_dir, results_dir = self._dirs(tmp_path)
         self._patch_to_env_fail(monkeypatch)
-
-        # No runner override → defaults to ClaudeRunner inside _run_arm.
-        # But we exercise the env_fail short-circuit which uses the `runner`
-        # arg directly to read surface. Pass a Claude-shaped stub.
-        from swebench.runner import ClaudeRunner
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         verdict = run_mod._run_arm(
             problem=self._problem(),
@@ -656,7 +673,7 @@ class TestRunArmWritesCodexModelToMeta:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
-            runner=ClaudeRunner(),
+            runner=_NoopRunner(),  # surface == "claude_code"
             codex_model=None,
         )
 

--- a/tests/test_component_run_harness_preflight.py
+++ b/tests/test_component_run_harness_preflight.py
@@ -8,14 +8,19 @@ Boundary: ``swebench/run.py._run_arm`` calls two real functions from
 
 Both functions are exercised as their *real* harness implementations — no
 harness-level doubles.  The only seam doubled is ``subprocess.run`` inside
-the harness module (an I/O boundary), and the git/Claude/test-runner I/O
-boundaries in ``run.py`` (``git_reset``, ``run_claude``, ``run_tests``).
+the harness module (an I/O boundary), and the git/runner/test-runner I/O
+boundaries in ``run.py`` (``git_reset``, the stub ``AgentRunner``, ``run_tests``).
 
 These tests assert the cross-module contract that:
   - when preflight returns False via the real harness path, ``_run_arm``
     writes ``env_fail`` to both output files and returns ``"env_fail"``.
   - when preflight returns True via the real harness path, ``_run_arm``
-    continues past the pre-flight gate and invokes the agent.
+    continues past the pre-flight gate and finishes ``run_tests``.
+
+Under the Issue #287 protocol, ``apply_test_patch`` and the pre-flight
+collect run *after* the agent terminates, so each test installs a stub
+``AgentRunner`` whose ``invoke()`` is a no-op — without one, ``_run_arm``
+would try to spawn ``/usr/bin/claude`` before pre-flight is reached.
 
 The critical difference from the unit tests in ``test_run_preflight.py``
 (which double ``run_mod.run_preflight_collect`` entirely) is that *here*
@@ -81,6 +86,30 @@ class _FakeCompleted:
         self.stderr = stderr
 
 
+class _NoopRunner:
+    """Stub AgentRunner for tests that don't care about the agent transcript.
+
+    Issue #287 moved ``apply_test_patch`` + the pre-flight collect to *after*
+    the agent runs, so tests reaching ``_run_arm`` need an invoke() seam that
+    finishes without spawning a real binary.
+    """
+
+    surface = "claude_code"
+
+    def build_tools_flags(self, arm, mcp_config_path):
+        return []
+
+    def get_version(self, binary):
+        return "stub"
+
+    def invoke(self, **kw):  # noqa: D401 — protocol stub
+        # No-op: don't append anything; tests assert verdict + file shape only.
+        pass
+
+    def extract_metadata(self, path):
+        return (None, None)
+
+
 # ---------------------------------------------------------------------------
 # Boundary 1: real harness.run_preflight_collect returns False → env_fail
 # ---------------------------------------------------------------------------
@@ -102,6 +131,10 @@ class TestRunArmPrefailViaRealHarness:
         We double subprocess.run inside the harness to return 'no tests ran'
         (exit 5).  Everything else — the harness preflight logic, the run.py
         env_fail write path — runs for real.
+
+        Under Issue #287 the pre-flight runs *after* ``runner.invoke()``,
+        so the test installs a ``_NoopRunner`` to keep ``_run_arm`` from
+        spawning a real Claude binary before reaching the pre-flight gate.
         """
         repo_dir, venv_dir, results_dir = _make_dirs(tmp_path)
 
@@ -123,11 +156,7 @@ class TestRunArmPrefailViaRealHarness:
 
         # Double the I/O seams in run.py that are not part of this boundary.
         monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
-
-        def _boom_run_claude(**kw):  # pragma: no cover
-            raise AssertionError("run_claude must not be called when preflight fails")
-
-        monkeypatch.setattr(run_mod, "run_claude", _boom_run_claude)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = _make_problem(tmp_path)
 
@@ -141,6 +170,7 @@ class TestRunArmPrefailViaRealHarness:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         # _run_arm must return "env_fail".
@@ -175,7 +205,7 @@ class TestRunArmPrefailViaRealHarness:
 
         monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_subprocess_run)
         monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
-        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = _make_problem(tmp_path)
         run_mod._run_arm(
@@ -188,6 +218,7 @@ class TestRunArmPrefailViaRealHarness:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         jsonl = Path(results_dir) / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
@@ -213,7 +244,7 @@ class TestRunArmPrefailViaRealHarness:
 
         monkeypatch.setattr(_harness_mod.subprocess, "run", _fake_subprocess_run)
         monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
-        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = _make_problem(tmp_path)
         run_mod._run_arm(
@@ -226,6 +257,7 @@ class TestRunArmPrefailViaRealHarness:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         test_txt = Path(results_dir) / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
@@ -261,11 +293,7 @@ class TestRunArmEnvFailAgentBinaryPropagation:
         monkeypatch.setattr(
             run_mod, "run_preflight_collect", lambda **kw: (False, "0 items collected")
         )
-
-        def _boom_run_claude(**kw):  # pragma: no cover
-            raise AssertionError("run_claude must not be called when preflight fails")
-
-        monkeypatch.setattr(run_mod, "run_claude", _boom_run_claude)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = _make_problem(tmp_path)
         verdict = run_mod._run_arm(
@@ -278,6 +306,7 @@ class TestRunArmEnvFailAgentBinaryPropagation:
             agent_binary="/fake/binary",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         assert verdict == "env_fail"
@@ -299,7 +328,7 @@ class TestRunArmEnvFailAgentBinaryPropagation:
         monkeypatch.setattr(
             run_mod, "run_preflight_collect", lambda **kw: (False, "no tests ran\n")
         )
-        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = _make_problem(tmp_path)
         run_mod._run_arm(
@@ -312,6 +341,7 @@ class TestRunArmEnvFailAgentBinaryPropagation:
             agent_binary="/fake/binary",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         test_txt = Path(results_dir) / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
@@ -354,7 +384,7 @@ class TestRunArmResolverFeedsIntoPreflightViaRealHarness:
 
         monkeypatch.setattr(_harness_mod.subprocess, "run", _recording_subprocess_run)
         monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
-        monkeypatch.setattr(run_mod, "run_claude", lambda **kw: None)
+        monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "FAIL")
 
         problem = Problem(
             instance_id="django__django-16379",
@@ -377,6 +407,7 @@ class TestRunArmResolverFeedsIntoPreflightViaRealHarness:
             agent_binary="/usr/bin/claude",
             mcp_config_path=str(tmp_path / "mcp.json"),
             root=tmp_path,
+            runner=_NoopRunner(),
         )
 
         # The resolver must not have triggered a subprocess.run --collect-only call

--- a/tests/test_harness_strip.py
+++ b/tests/test_harness_strip.py
@@ -285,3 +285,124 @@ def test_apply_test_patch_leaves_empty_git_diff(tmp_path: Path) -> None:
     # History should now have exactly 2 commits (orphan base + test patch commit).
     count = _git(repo, "rev-list", "--all", "--count").stdout.strip()
     assert count == "2"
+
+
+def test_apply_test_patch_resets_agent_edits_to_modified_file(tmp_path: Path) -> None:
+    """Issue #287 contamination guard.
+
+    Under the post-agent ordering, the agent might edit the same test file
+    the held-out patch modifies.  ``apply_test_patch`` must force-reset
+    those files to HEAD before ``git apply`` so the patch lands cleanly —
+    otherwise the run would either silently fail-to-apply or, worse, score
+    PASS against a tree that doesn't contain the held-out assertions.
+    """
+    repo = _make_repo(tmp_path)
+    # Commit a file with a known body, then orphan-strip so HEAD is the only commit.
+    (Path(repo) / "test_target.py").write_text(
+        "def test_existing():\n    assert True\n"
+    )
+    _git(repo, "add", "test_target.py")
+    _git(repo, "commit", "-q", "-m", "add target")
+    strip_git_history(repo)
+
+    # The held-out patch ADDS an assertion to test_existing.
+    patch_path = tmp_path / "tests.patch"
+    patch_path.write_text(
+        "diff --git a/test_target.py b/test_target.py\n"
+        "--- a/test_target.py\n"
+        "+++ b/test_target.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " def test_existing():\n"
+        "     assert True\n"
+        "+    assert 42 == 42  # held-out assertion\n"
+    )
+
+    # Simulate the agent editing the same file with its own (conflicting) version.
+    (Path(repo) / "test_target.py").write_text(
+        "def test_existing():\n    pass  # I am the agent, I rewrote this\n"
+    )
+    # Important: don't commit the agent's edit; in the real harness the
+    # agent's edits are unstaged at the point apply_test_patch runs.
+
+    assert apply_test_patch(repo, str(patch_path)) is True, (
+        "apply_test_patch must reset the agent's conflicting edit before "
+        "git apply and land the patch successfully."
+    )
+
+    # The committed tree must reflect the held-out patch, not the agent's edit.
+    final = (Path(repo) / "test_target.py").read_text()
+    assert "held-out assertion" in final, (
+        f"Patch did not land — file contents: {final!r}"
+    )
+    assert "I am the agent" not in final, (
+        f"Agent's contamination survived — file contents: {final!r}"
+    )
+    # Working tree must be clean (patch was committed, not left as a diff).
+    assert _git(repo, "diff").stdout == ""
+    assert _git(repo, "diff", "HEAD").stdout == ""
+
+
+def test_apply_test_patch_removes_agent_created_file_collision(tmp_path: Path) -> None:
+    """If the patch creates a new file (``--- /dev/null``) and the agent
+    happened to write a file at the same path, ``git apply`` would normally
+    fail with "already exists in working directory".  ``apply_test_patch``
+    must rm the colliding file so the patch can land.
+    """
+    repo = _make_repo(tmp_path)
+    strip_git_history(repo)
+
+    # Patch creates tests/new_test.py from scratch.
+    patch_path = tmp_path / "tests.patch"
+    patch_path.write_text(
+        "diff --git a/tests/new_test.py b/tests/new_test.py\n"
+        "new file mode 100644\n"
+        "index 0000000..aaaaaaa\n"
+        "--- /dev/null\n"
+        "+++ b/tests/new_test.py\n"
+        "@@ -0,0 +1,2 @@\n"
+        "+def test_new():\n"
+        "+    assert True\n"
+    )
+
+    # Agent created a file at the same path with different content.
+    (Path(repo) / "tests").mkdir(exist_ok=True)
+    (Path(repo) / "tests" / "new_test.py").write_text("# agent's file\n")
+
+    assert apply_test_patch(repo, str(patch_path)) is True
+    final = (Path(repo) / "tests" / "new_test.py").read_text()
+    assert "test_new" in final
+    assert "agent's file" not in final
+
+
+def test_apply_test_patch_returns_false_when_unrecoverable(tmp_path: Path) -> None:
+    """If the patch references context the agent obliterated and reset can't
+    save us, ``apply_test_patch`` must return False so the caller can score
+    the run as FAIL rather than trust a contaminated tree.
+
+    Construct an unrecoverable case: the patch creates ``tests/`` as a file,
+    but the agent already created ``tests/`` as a directory containing other
+    files — ``os.remove`` will refuse a non-empty directory.
+    """
+    repo = _make_repo(tmp_path)
+    strip_git_history(repo)
+
+    # Patch creates a file at path "tests".
+    patch_path = tmp_path / "tests.patch"
+    patch_path.write_text(
+        "diff --git a/tests b/tests\n"
+        "new file mode 100644\n"
+        "index 0000000..aaaaaaa\n"
+        "--- /dev/null\n"
+        "+++ b/tests\n"
+        "@@ -0,0 +1 @@\n"
+        "+held-out content\n"
+    )
+    # Agent created "tests" as a directory with an unrelated file inside,
+    # so os.remove cannot clear the collision.
+    (Path(repo) / "tests").mkdir()
+    (Path(repo) / "tests" / "junk.py").write_text("# unrelated\n")
+
+    assert apply_test_patch(repo, str(patch_path)) is False, (
+        "apply_test_patch must return False when collision cannot be cleared, "
+        "so the caller knows to score the run as FAIL."
+    )

--- a/tests/test_harness_venv.py
+++ b/tests/test_harness_venv.py
@@ -596,21 +596,26 @@ def test_seaborn_3069_3202_flit_pins() -> None:
     )
 
 
-def test_sklearn_11596_has_source_seed() -> None:
-    """sklearn-11596 needs a source-seed patch creating a stub for
-    ``sklearn.utils._show_versions``. The test patch imports symbols from
-    that module which the agent is expected to create. (Issue #266.)
+def test_sklearn_agent_authored_modules_have_no_source_seed() -> None:
+    """Under Issue #287, modules the agent is expected to author must NOT be
+    pre-seeded.  The test patch is held back until after the agent runs, so
+    pre-stubbing the agent's deliverable would defeat the evaluation:
+
+    - sklearn-10427: ``sklearn.externals._pilutil`` (Issue #266).
+    - sklearn-11596: ``sklearn.utils._show_versions`` (Issue #266).
+
+    Both legacy seed entries were removed during the #287 audit.  This test
+    is the canary that catches anyone re-adding them.
     """
     from swebench.harness import _INSTANCE_SOURCE_SEEDS
-    from swebench import repo_root
-    seed_rel = _INSTANCE_SOURCE_SEEDS.get("scikit-learn__scikit-learn-11596")
-    assert seed_rel is not None, "11596 must have a source-seed registered"
-    seed_path = repo_root() / seed_rel
-    assert seed_path.is_file(), f"source seed not found at {seed_path}"
-    text = seed_path.read_text()
-    # Must define the three symbols imported by the test patch.
-    for symbol in ("_get_sys_info", "_get_deps_info", "show_versions"):
-        assert symbol in text, f"source seed missing symbol {symbol}"
+    for instance_id in (
+        "scikit-learn__scikit-learn-10427",
+        "scikit-learn__scikit-learn-11596",
+    ):
+        assert _INSTANCE_SOURCE_SEEDS.get(instance_id) is None, (
+            f"{instance_id} must NOT have a source seed under Issue #287 — "
+            "the agent is expected to author the missing module."
+        )
 
 
 def test_matplotlib_26160_instance_pins() -> None:

--- a/tests/test_run_arm_integrity_287.py
+++ b/tests/test_run_arm_integrity_287.py
@@ -253,3 +253,216 @@ def test_test_patch_applied_after_agent_terminates(integrity_setup):
     # Working tree must be clean (patch was committed, not left as a diff).
     assert _git(repo_dir, "diff").stdout == ""
     assert _git(repo_dir, "diff", "HEAD").stdout == ""
+
+
+# ---------------------------------------------------------------------------
+# Contamination guard — agent edits the test file the patch touches
+# ---------------------------------------------------------------------------
+
+
+class _ContaminatingRunner:
+    """Stub runner that *edits* a file inside the patch's blast radius
+    during ``invoke()`` — simulating a real agent that changed test files
+    as part of its work.  Used to verify that ``apply_test_patch`` resets
+    the agent's edits before applying the held-out patch.
+    """
+
+    surface = "claude_code"
+
+    def __init__(self, target_rel: str, contamination: str) -> None:
+        self._target_rel = target_rel
+        self._contamination = contamination
+
+    def build_tools_flags(self, arm, mcp_config_path):
+        return []
+
+    def get_version(self, binary):
+        return "contaminating-runner"
+
+    def extract_metadata(self, path):
+        return (None, None)
+
+    def invoke(self, **kw):
+        cwd = kw["cwd"]
+        target = Path(cwd) / self._target_rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(self._contamination)
+
+
+def _modify_patch(root: Path) -> Path:
+    """A patch that MODIFIES an existing file (the typical case — ~95% of
+    SWE-bench test_patches modify rather than add)."""
+    patches_dir = root / "patches"
+    patches_dir.mkdir(exist_ok=True)
+    patch = patches_dir / "modify_existing.patch"
+    patch.write_text(
+        "diff --git a/tests/test_existing.py b/tests/test_existing.py\n"
+        "--- a/tests/test_existing.py\n"
+        "+++ b/tests/test_existing.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " def test_existing():\n"
+        "     assert True\n"
+        "+    assert HELDOUT_SENTINEL_287 == 42\n"
+    )
+    return patch
+
+
+def test_agent_edits_to_patched_test_file_are_overwritten(monkeypatch, tmp_path):
+    """End-to-end: an agent that rewrites the held-out test file gets its
+    edits force-reset by ``apply_test_patch``; the run lands cleanly with
+    the held-out assertion present in the committed tree."""
+    # Build repo with a tests/test_existing.py at HEAD.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(str(repo), "init", "-q", "-b", "main")
+    _git(str(repo), "config", "user.email", "test@test")
+    _git(str(repo), "config", "user.name", "test")
+    tests_dir = repo / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_existing.py").write_text("def test_existing():\n    assert True\n")
+    _git(str(repo), "add", "tests/test_existing.py")
+    _git(str(repo), "commit", "-q", "-m", "base")
+    strip_git_history(str(repo))
+
+    patch = _modify_patch(tmp_path)
+
+    venv_dir = tmp_path / "venv"
+    (venv_dir / "bin").mkdir(parents=True)
+    (venv_dir / "bin" / "python").write_text("#!/bin/sh\nexec python3 \"$@\"\n")
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    monkeypatch.setattr(run_mod, "resolve_test_node_ids", lambda cmd, **kw: cmd)
+    monkeypatch.setattr(run_mod, "run_preflight_collect", lambda **kw: (True, ""))
+    monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "PASS")
+    monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+    monkeypatch.setattr(run_mod, "_patch_vendored_cloudpickle", lambda *a, **kw: False)
+
+    runner = _ContaminatingRunner(
+        target_rel="tests/test_existing.py",
+        contamination="def test_existing():\n    pass  # CONTAMINATION\n",
+    )
+
+    problem = Problem(
+        instance_id="probe__instance-contamination",
+        repo_slug="probe/instance",
+        base_commit="HEAD",
+        test_cmd="python -m pytest tests/test_existing.py",
+        problem_statement="dummy",
+        patch_file=os.path.relpath(patch, tmp_path),
+        added_at="2026-05-22",
+        hf_split="test",
+    )
+
+    verdict = run_mod._run_arm(
+        problem=problem,
+        arm="baseline",
+        run_idx=1,
+        repo_dir=str(repo),
+        venv_dir=str(venv_dir),
+        results_dir=str(results_dir),
+        agent_binary="/usr/bin/claude",
+        mcp_config_path=str(tmp_path / "mcp.json"),
+        root=tmp_path,
+        runner=runner,
+    )
+
+    assert verdict == "PASS", (
+        f"_run_arm must land cleanly after the contaminating runner runs; "
+        f"got {verdict!r}"
+    )
+    final = (repo / "tests" / "test_existing.py").read_text()
+    assert "HELDOUT_SENTINEL_287" in final, (
+        f"Held-out patch did not land — file contents: {final!r}"
+    )
+    assert "CONTAMINATION" not in final, (
+        f"Agent's contamination survived the patch — file contents: {final!r}"
+    )
+
+
+def test_unrecoverable_patch_apply_failure_scores_fail(monkeypatch, tmp_path):
+    """If apply_test_patch ultimately returns False, ``_run_arm`` must score
+    the run as ``FAIL`` immediately and skip ``run_tests`` — otherwise we'd
+    measure the agent's own assertions, not the upstream contract."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(str(repo), "init", "-q", "-b", "main")
+    _git(str(repo), "config", "user.email", "test@test")
+    _git(str(repo), "config", "user.name", "test")
+    (repo / "marker").write_text("x\n")
+    _git(str(repo), "add", "marker")
+    _git(str(repo), "commit", "-q", "-m", "base")
+    strip_git_history(str(repo))
+
+    venv_dir = tmp_path / "venv"
+    (venv_dir / "bin").mkdir(parents=True)
+    (venv_dir / "bin" / "python").write_text("#!/bin/sh\nexec python3 \"$@\"\n")
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    monkeypatch.setattr(run_mod, "resolve_test_node_ids", lambda cmd, **kw: cmd)
+    monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+    monkeypatch.setattr(run_mod, "_patch_vendored_cloudpickle", lambda *a, **kw: False)
+
+    # apply_test_patch returns False unconditionally — simulates an
+    # unrecoverable conflict that the reset+rm logic could not clear.
+    monkeypatch.setattr(run_mod, "apply_test_patch", lambda *a, **kw: False)
+
+    # If _run_arm reaches run_tests or run_preflight_collect after the
+    # patch-apply failure, the test must fail loudly.
+    def _boom(**kw):  # pragma: no cover
+        raise AssertionError(
+            "must not run pre-flight or run_tests against the contaminated tree"
+        )
+
+    monkeypatch.setattr(run_mod, "run_preflight_collect", _boom)
+    monkeypatch.setattr(run_mod, "run_tests", _boom)
+
+    # A patch_file path that exists is needed to enter the apply block at all.
+    patch = tmp_path / "tests.patch"
+    patch.write_text("not even a real patch\n")
+
+    class _NoopRunner:
+        surface = "claude_code"
+        def build_tools_flags(self, arm, cfg): return []
+        def get_version(self, b): return "stub"
+        def extract_metadata(self, p): return (None, None)
+        def invoke(self, **kw): pass
+
+    problem = Problem(
+        instance_id="probe__unrecoverable",
+        repo_slug="probe/instance",
+        base_commit="HEAD",
+        test_cmd="python -m pytest x",
+        problem_statement="dummy",
+        patch_file=os.path.relpath(patch, tmp_path),
+        added_at="2026-05-22",
+        hf_split="test",
+    )
+
+    verdict = run_mod._run_arm(
+        problem=problem,
+        arm="baseline",
+        run_idx=1,
+        repo_dir=str(repo),
+        venv_dir=str(venv_dir),
+        results_dir=str(results_dir),
+        agent_binary="/usr/bin/claude",
+        mcp_config_path=str(tmp_path / "mcp.json"),
+        root=tmp_path,
+        runner=_NoopRunner(),
+    )
+
+    assert verdict == "FAIL", (
+        f"Patch-apply failure must produce FAIL; got {verdict!r}"
+    )
+    # _test.txt's last non-empty line must be FAIL.
+    test_txt = results_dir / "probe__unrecoverable_baseline_run1_test.txt"
+    last = [ln for ln in test_txt.read_text().splitlines() if ln.strip()][-1]
+    assert last.strip() == "FAIL"
+    # Meta record must carry the verdict + a reason mentioning the apply failure.
+    import json as _json
+    jsonl = results_dir / "probe__unrecoverable_baseline_run1.jsonl"
+    meta = _json.loads(jsonl.read_text().splitlines()[0])
+    assert meta["verdict"] == "FAIL"
+    assert "apply" in meta.get("reason", "").lower()

--- a/tests/test_run_arm_integrity_287.py
+++ b/tests/test_run_arm_integrity_287.py
@@ -1,0 +1,255 @@
+"""Regression tests for Issue #287: test patch is invisible to the agent.
+
+Issue #226 closed the ``git diff`` vector by committing the test patch
+pre-agent.  Issue #287 closes the remaining vector — the test files on
+disk — by deferring ``apply_test_patch`` to *after* the agent terminates.
+
+These tests assert two invariants, both captured at the moment ``invoke()``
+runs:
+
+1. The test patch file's contents are NOT present in the repo working tree
+   (no leak via ``cat tests/test_added.py`` / ``ls tests/`` / ``grep -r``).
+2. ``git diff`` and ``git diff HEAD`` are both empty (the #226 invariant
+   continues to hold under the new ordering).
+
+The trick: install a stub ``AgentRunner`` whose ``invoke()`` *snapshots*
+the repo state at exactly the moment the agent would have been running.
+After ``_run_arm`` returns, inspect those snapshots.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from swebench import run as run_mod
+from swebench.harness import strip_git_history
+from swebench.models import Problem
+
+
+# Unique sentinel that the agent would see if the test_patch leaked. Picked
+# to be obviously not a coincidence in any source file.
+SECRET_ASSERTION = "ASSERT_HIDDEN_287_FINGERPRINT == 42"
+
+
+def _git(repo: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", repo, *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _make_repo_with_history(root: Path) -> str:
+    """Create a small repo with a base commit; matches what ``_setup_problem``
+    leaves behind once ``strip_git_history`` has run."""
+    repo = root / "repo"
+    repo.mkdir()
+    _git(str(repo), "init", "-q", "-b", "main")
+    _git(str(repo), "config", "user.email", "test@test")
+    _git(str(repo), "config", "user.name", "test")
+    (repo / "src.py").write_text("def f():\n    return 1\n")
+    _git(str(repo), "add", "src.py")
+    _git(str(repo), "commit", "-q", "-m", "base commit")
+    # The harness always runs strip_git_history before handing the repo to
+    # the agent — mirror that here so the test reflects real conditions.
+    strip_git_history(str(repo))
+    return str(repo)
+
+
+def _write_test_patch(root: Path) -> Path:
+    """Write a test_patch that introduces a new tests/ file containing the
+    secret sentinel.  Patch is shaped like real SWE-bench test_patches."""
+    patches_dir = root / "patches"
+    patches_dir.mkdir()
+    patch = patches_dir / "leak_probe_tests.patch"
+    patch.write_text(
+        "diff --git a/tests/test_added.py b/tests/test_added.py\n"
+        "new file mode 100644\n"
+        "index 0000000..1111111\n"
+        "--- /dev/null\n"
+        "+++ b/tests/test_added.py\n"
+        "@@ -0,0 +1,3 @@\n"
+        "+def test_leaks():\n"
+        f"+    {SECRET_ASSERTION}\n"
+        "+\n"
+    )
+    return patch
+
+
+def _make_problem(root: Path, patch_rel: str) -> Problem:
+    return Problem(
+        instance_id="probe__instance-287",
+        repo_slug="probe/instance",
+        base_commit="HEAD",
+        test_cmd="python -m pytest tests/test_added.py",
+        problem_statement="Fix the leak probe.",
+        patch_file=patch_rel,
+        added_at="2026-05-22",
+        hf_split="test",
+    )
+
+
+class _SnapshottingRunner:
+    """At ``invoke()`` time, snapshot exactly what an agent on this machine
+    would observe: the file listing under tests/, the contents of any test
+    file the patch would add, and the output of ``git diff`` / ``git diff HEAD``.
+    """
+
+    surface = "claude_code"
+
+    def __init__(self) -> None:
+        self.snapshot: dict[str, object] = {}
+
+    def build_tools_flags(self, arm, mcp_config_path):
+        return []
+
+    def get_version(self, binary):
+        return "snapshot-runner"
+
+    def extract_metadata(self, path):
+        return (None, None)
+
+    def invoke(self, **kw):
+        cwd = kw["cwd"]
+        tests_dir = os.path.join(cwd, "tests")
+        if os.path.isdir(tests_dir):
+            self.snapshot["tests_dir_listing"] = sorted(os.listdir(tests_dir))
+        else:
+            self.snapshot["tests_dir_listing"] = None
+
+        added_path = os.path.join(cwd, "tests", "test_added.py")
+        if os.path.isfile(added_path):
+            self.snapshot["test_added_contents"] = Path(added_path).read_text()
+        else:
+            self.snapshot["test_added_contents"] = None
+
+        # grep -r equivalent across the working tree.
+        any_leak = False
+        for base, dirs, files in os.walk(cwd):
+            # don't descend into .git
+            if ".git" in dirs:
+                dirs.remove(".git")
+            for name in files:
+                p = os.path.join(base, name)
+                try:
+                    if SECRET_ASSERTION in Path(p).read_text(errors="ignore"):
+                        any_leak = True
+                        break
+                except OSError:
+                    continue
+            if any_leak:
+                break
+        self.snapshot["secret_found_on_disk"] = any_leak
+
+        self.snapshot["git_diff"] = _git(cwd, "diff").stdout
+        self.snapshot["git_diff_head"] = _git(cwd, "diff", "HEAD").stdout
+
+
+@pytest.fixture
+def integrity_setup(tmp_path, monkeypatch):
+    """Build a real git repo + test patch, then run ``_run_arm`` with the
+    snapshotting runner.  Returns the populated snapshot dict."""
+    repo_dir = _make_repo_with_history(tmp_path)
+    patch = _write_test_patch(tmp_path)
+
+    # venv dir — _run_arm only checks that bin/python exists; doesn't run it
+    # because we stub out resolve_test_node_ids / run_preflight_collect.
+    venv_dir = tmp_path / "venv"
+    (venv_dir / "bin").mkdir(parents=True)
+    (venv_dir / "bin" / "python").write_text("#!/bin/sh\nexec python3 \"$@\"\n")
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    # Skip the resolver and preflight subprocess calls — they aren't part of
+    # what we're asserting and would require a real venv.
+    monkeypatch.setattr(run_mod, "resolve_test_node_ids", lambda cmd, **kw: cmd)
+    monkeypatch.setattr(run_mod, "run_preflight_collect", lambda **kw: (True, ""))
+    monkeypatch.setattr(run_mod, "run_tests", lambda **kw: "PASS")
+    # Keep the real git operations intact (apply_test_patch + git_reset).
+    monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
+    # Skip the cloudpickle patch — only relevant for sklearn instances.
+    monkeypatch.setattr(run_mod, "_patch_vendored_cloudpickle", lambda *a, **kw: False)
+
+    snapshotter = _SnapshottingRunner()
+
+    patch_rel = os.path.relpath(patch, tmp_path)
+    problem = _make_problem(tmp_path, patch_rel)
+
+    run_mod._run_arm(
+        problem=problem,
+        arm="baseline",
+        run_idx=1,
+        repo_dir=repo_dir,
+        venv_dir=str(venv_dir),
+        results_dir=str(results_dir),
+        agent_binary="/usr/bin/claude",
+        mcp_config_path=str(tmp_path / "mcp.json"),
+        root=tmp_path,
+        runner=snapshotter,
+    )
+
+    return snapshotter.snapshot, repo_dir
+
+
+def test_test_patch_file_absent_during_agent_run(integrity_setup):
+    """The test_added.py file from the patch must NOT exist on disk while
+    the agent is running (closes the ``cat tests/test_added.py`` vector)."""
+    snapshot, _ = integrity_setup
+    assert snapshot["test_added_contents"] is None, (
+        "tests/test_added.py was readable during agent execution — Issue #287 "
+        "integrity invariant violated.\n"
+        f"Contents: {snapshot['test_added_contents']!r}"
+    )
+
+
+def test_tests_directory_does_not_show_added_file_during_agent_run(integrity_setup):
+    """``ls tests/`` must not list the patch's new file during agent execution."""
+    snapshot, _ = integrity_setup
+    listing = snapshot["tests_dir_listing"]
+    if listing is not None:
+        assert "test_added.py" not in listing, (
+            "tests/test_added.py was visible to ``ls tests/`` during agent run; "
+            f"directory listing: {listing}"
+        )
+
+
+def test_secret_assertion_not_grep_able_during_agent_run(integrity_setup):
+    """A ``grep -r ASSERT_HIDDEN_287_FINGERPRINT`` over the working tree during
+    agent execution must find zero matches."""
+    snapshot, _ = integrity_setup
+    assert snapshot["secret_found_on_disk"] is False, (
+        "The hidden assertion fingerprint was discoverable via grep during "
+        "agent execution — the test patch contents leaked onto disk."
+    )
+
+
+def test_git_diff_remains_empty_during_agent_run(integrity_setup):
+    """Re-assert the Issue #226 invariant under the #287 ordering: both
+    ``git diff`` and ``git diff HEAD`` must be empty from the agent's POV."""
+    snapshot, _ = integrity_setup
+    assert snapshot["git_diff"] == "", (
+        f"git diff was non-empty during agent run: {snapshot['git_diff']!r}"
+    )
+    assert snapshot["git_diff_head"] == "", (
+        f"git diff HEAD was non-empty during agent run: {snapshot['git_diff_head']!r}"
+    )
+
+
+def test_test_patch_applied_after_agent_terminates(integrity_setup):
+    """Post-agent, the test patch must be applied and committed — otherwise
+    ``run_tests`` would never see the held-out assertions."""
+    _, repo_dir = integrity_setup
+    added = Path(repo_dir) / "tests" / "test_added.py"
+    assert added.exists(), (
+        "tests/test_added.py must exist after _run_arm completes (post-agent "
+        "apply_test_patch). File is missing — Issue #287 ordering is broken."
+    )
+    assert SECRET_ASSERTION in added.read_text()
+    # Working tree must be clean (patch was committed, not left as a diff).
+    assert _git(repo_dir, "diff").stdout == ""
+    assert _git(repo_dir, "diff", "HEAD").stdout == ""

--- a/tests/test_run_preflight.py
+++ b/tests/test_run_preflight.py
@@ -1,9 +1,12 @@
 """Tests for the pre-flight ``pytest --collect-only`` integration in run.py.
 
-Issue #238 / #234.  The pre-flight check must:
-  - Run after ``apply_test_patch`` and before ``run_claude``.
-  - Record ``env_fail`` and skip the agent when zero items collect.
+Issue #238 / #234 (and Issue #287).  The pre-flight check must:
+  - Run after ``apply_test_patch`` — both now happen *post*-agent (#287).
+  - Record ``env_fail`` and skip ``run_tests`` when zero items collect.
   - Mark the run as a "complete" triple for ``--resume`` purposes.
+  - Preserve the agent transcript already appended to the .jsonl on env_fail
+    (#287 ordering change): only the meta record on line 1 gets its
+    ``verdict`` field updated to ``env_fail``.
 """
 
 from __future__ import annotations
@@ -84,11 +87,16 @@ def _make_problem(tmp_path: Path) -> Problem:
 
 
 def test_run_arm_writes_env_fail_when_preflight_fails(monkeypatch, tmp_path: Path):
-    """When pre-flight reports 0 items, _run_arm must skip the agent and
-    write ``env_fail`` to both the jsonl and the test file."""
+    """When pre-flight reports 0 items, _run_arm must skip ``run_tests`` and
+    write ``env_fail`` to both the jsonl and the test file.
+
+    Under Issue #287 the agent runs *before* pre-flight, so the agent
+    transcript must be preserved in the .jsonl; only the meta record on
+    line 1 gets its ``verdict`` field flipped to ``env_fail``.
+    """
     from swebench import run as run_mod
 
-    # Pre-flight returns False (0 items collected).
+    # Pre-flight returns False (0 items collected) post-agent.
     monkeypatch.setattr(
         run_mod,
         "run_preflight_collect",
@@ -100,15 +108,37 @@ def test_run_arm_writes_env_fail_when_preflight_fails(monkeypatch, tmp_path: Pat
         "resolve_test_node_ids",
         lambda cmd, **kw: cmd,
     )
-    # If git_reset or run_claude is called we want the test to fail.
     monkeypatch.setattr(run_mod, "git_reset", lambda *a, **kw: None)
 
-    def _boom(*a, **kw):  # pragma: no cover
+    # ``run_tests`` must not be invoked when post-agent preflight fails.
+    def _boom_run_tests(**kw):  # pragma: no cover
         raise AssertionError(
-            "run_claude must not be invoked when pre-flight fails"
+            "run_tests must not be invoked when post-agent pre-flight fails"
         )
 
-    monkeypatch.setattr(run_mod, "run_claude", _boom)
+    monkeypatch.setattr(run_mod, "run_tests", _boom_run_tests)
+
+    # Stub runner that appends a fake transcript line, simulating a real agent.
+    class _TranscriptRunner:
+        surface = "claude_code"
+
+        def build_tools_flags(self, arm, cfg):
+            return []
+
+        def get_version(self, binary):
+            return "test"
+
+        def extract_metadata(self, path):
+            return (None, None)
+
+        def invoke(self, **kw):
+            # Append a fake transcript record after the meta line, so the
+            # test can verify it survives the env_fail rewrite.
+            with open(kw["result_file"], "a") as out:
+                out.write(
+                    '{"type":"assistant","content":"thinking"}\n'
+                    '{"type":"result","total_cost_usd":0.0,"num_turns":1}\n'
+                )
 
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
@@ -129,6 +159,7 @@ def test_run_arm_writes_env_fail_when_preflight_fails(monkeypatch, tmp_path: Pat
         agent_binary="/usr/bin/claude",
         mcp_config_path=str(tmp_path / "mcp.json"),
         root=tmp_path,
+        runner=_TranscriptRunner(),
     )
 
     assert verdict == "env_fail"
@@ -141,11 +172,16 @@ def test_run_arm_writes_env_fail_when_preflight_fails(monkeypatch, tmp_path: Pat
 
     jsonl = results_dir / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
     assert jsonl.exists()
-    # Meta record present and well-formed JSON.
+    # Meta record present and carries env_fail verdict (line 1).
     import json
-    first = json.loads(jsonl.read_text().splitlines()[0])
+    lines = jsonl.read_text().splitlines()
+    first = json.loads(lines[0])
     assert first["verdict"] == "env_fail"
     assert first["instance_id"] == INSTANCE
+    # Agent transcript still present after the meta line (#287 invariant).
+    assert any("assistant" in ln or "result" in ln for ln in lines[1:]), (
+        f"Agent transcript was wiped on env_fail; lines: {lines}"
+    )
 
 
 def test_run_arm_proceeds_when_preflight_passes(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes #287.

The #226 fix committed the test patch pre-agent to close the `git diff` vector, but the held-out test files still sat on disk during the agent run — any `cat tests/test_added.py`, `ls tests/`, or `grep -r` would surface the assertions the harness is supposed to hide.  This PR moves `apply_test_patch` and the pre-flight `pytest --collect-only` check to **after** `runner.invoke()` returns, so the agent operates on exactly the same tree the upstream developer faced.

- Defer test-patch application + pre-flight collect to post-agent in `_run_arm` ([swebench/run.py](onlycodes/swebench/run.py)).
- On post-agent env_fail, rewrite the meta line in-place to attach `verdict=env_fail` while preserving the agent transcript on subsequent lines.
- Audit `_INSTANCE_SOURCE_SEEDS`: drop `sklearn-10427` and `sklearn-11596` (modules the agent authors); keep `astropy-6938` and `sphinx-9698` (environment fixes independent of the test patch).
- Add `tests/test_run_arm_integrity_287.py`: a snapshotting `AgentRunner` proves `tests/test_added.py` is absent, `git diff` / `git diff HEAD` are empty, and a sentinel string is not grep-able during agent execution.
- Update preflight component tests (`test_component_run_harness_preflight.py`, `test_component_codex_onlycode_arm.py`, `test_run_preflight.py`) to inject stub runners — the old tests relied on early-return-before-invoke, which no longer applies.
- Mark `docs/RESULTS_SWE_MINI.md` as legacy (pre-#287 protocol).

Legacy run directories under `runs/swebench/` were moved to `runs/swebench/_legacy_pre_287/` separately.

## Test plan

- [x] `pytest tests/ -m "not integration"` → 725 passed
- [x] New integrity tests (`tests/test_run_arm_integrity_287.py`) cover all #287 acceptance criteria
- [ ] Smoke run on V1 batch (1 instance) under both `--agent-surface claude_code` and `--agent-surface codex_cli` to confirm end-to-end with the new ordering
- [ ] Re-run a known instance and verify the agent's logged tool calls contain no occurrence of the test_patch sentinel strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)