### PR TITLE
WS-A.2.1(#311): conda-env-native Verified build [PR 2]

### DIFF
--- a/scripts/extract_swebench_specs.py
+++ b/scripts/extract_swebench_specs.py
@@ -11,10 +11,17 @@ Run this with the **upstream** package installed in an ISOLATED venv (never our
 repo venv), then commit the regenerated JSON:
 
     python3.11 -m venv /tmp/swe-official
-    /tmp/swe-official/bin/pip install 'swebench==<pinned>'
+    /tmp/swe-official/bin/pip install 'swebench==4.1.0'
     /tmp/swe-official/bin/python scripts/extract_swebench_specs.py \
         --repos-from sets/verified-spine.txt \
         --out swebench/data/official_specs.json
+
+The pin matters: a different upstream `swebench` may ship a different
+`MAP_REPO_VERSION_TO_SPECS`, silently changing the vendored specs (and thus how
+every Verified instance builds). **`swebench==4.1.0` reproduces the committed
+`swebench/data/official_specs.json` byte-for-byte (verified 2026-06-03, #311).**
+After regenerating, `git diff swebench/data/official_specs.json` should be empty
+unless you intentionally bumped the pin.
 
 `--repos-from` reads instance ids (e.g. the frozen spine pool) and extracts only
 the repos they reference, keeping the vendored file small. Omit it to dump every
@@ -27,6 +34,9 @@ import argparse
 import json
 import sys
 from pathlib import Path
+
+# Upstream package version this extractor is pinned to (see module docstring).
+PINNED_SWEBENCH_VERSION = "4.1.0"
 
 
 def _repos_from_ids(path: Path) -> set[str]:
@@ -66,10 +76,26 @@ def main() -> int:
             "ERROR: could not import the upstream swebench package "
             f"({exc}).\nInstall it in an ISOLATED venv (not the repo venv — names "
             "collide):\n  python3.11 -m venv /tmp/swe-official && "
-            "/tmp/swe-official/bin/pip install swebench",
+            f"/tmp/swe-official/bin/pip install 'swebench=={PINNED_SWEBENCH_VERSION}'",
             file=sys.stderr,
         )
         return 1
+
+    # Warn loudly if the installed version isn't the pin — the map can drift
+    # between releases and silently change the vendored specs (#311).
+    try:
+        import importlib.metadata as _md
+        installed = _md.version("swebench")
+        if installed != PINNED_SWEBENCH_VERSION:
+            print(
+                f"WARNING: swebench=={installed} installed, but this extractor is "
+                f"pinned to {PINNED_SWEBENCH_VERSION}. The vendored JSON was generated "
+                f"from {PINNED_SWEBENCH_VERSION}; regenerating from a different version "
+                "may change specs. Re-pin (and re-validate) deliberately.",
+                file=sys.stderr,
+            )
+    except Exception:  # noqa: BLE001 — metadata lookup is best-effort
+        pass
 
     if args.repos_from:
         wanted = _repos_from_ids(args.repos_from)

--- a/scripts/extract_swebench_specs.py
+++ b/scripts/extract_swebench_specs.py
@@ -64,13 +64,25 @@ def main() -> int:
         help="Where to write the vendored JSON (default: swebench/data/official_specs.json).",
     )
     parser.add_argument(
+        "--reqs-out", type=Path, default=Path("swebench/data/official_reqs_paths.json"),
+        help="Where to write the vendored requirements/environment.yml path maps "
+             "(default: swebench/data/official_reqs_paths.json). Kept in a SEPARATE "
+             "file so --out stays byte-for-byte reproducible.",
+    )
+    parser.add_argument(
         "--repos-from", type=Path, default=None,
         help="Id file (e.g. sets/verified-spine.txt) — extract only the repos it references.",
     )
     args = parser.parse_args()
 
     try:
-        from swebench.harness.constants import MAP_REPO_VERSION_TO_SPECS
+        from swebench.harness.constants import (
+            MAP_REPO_VERSION_TO_SPECS,
+            MAP_REPO_TO_REQS_PATHS,
+            MAP_REPO_TO_ENV_YML_PATHS,
+        )
+        # REPLACE_REQ_PACKAGES lives in the test-spec builder, not constants.
+        from swebench.harness.test_spec.python import REPLACE_REQ_PACKAGES
     except ImportError as exc:
         print(
             "ERROR: could not import the upstream swebench package "
@@ -107,11 +119,33 @@ def main() -> int:
                   file=sys.stderr)
     else:
         out = dict(MAP_REPO_VERSION_TO_SPECS)
+        wanted = set(out)
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(out, indent=2, sort_keys=True) + "\n")
     n_specs = sum(len(v) for v in out.values())
     print(f"Wrote {len(out)} repos / {n_specs} specs to {args.out}", file=sys.stderr)
+
+    # Requirements / environment.yml path maps. A spec whose `packages` is the
+    # sentinel "requirements.txt" / "environment.yml" does NOT name a literal
+    # repo-root file — upstream resolves the real path(s) via these maps and reads
+    # the file at environment_setup_commit. Vendored so setup_conda_env resolves
+    # them the same way (e.g. flask → requirements/dev.txt, not ./requirements.txt).
+    # Filtered to the same repos as --out; REPLACE_REQ_PACKAGES kept whole (tiny).
+    reqs_out = {
+        "reqs_paths": {r: MAP_REPO_TO_REQS_PATHS[r] for r in sorted(wanted)
+                       if r in MAP_REPO_TO_REQS_PATHS},
+        "env_yml_paths": {r: MAP_REPO_TO_ENV_YML_PATHS[r] for r in sorted(wanted)
+                          if r in MAP_REPO_TO_ENV_YML_PATHS},
+        "replace_req_packages": [list(pair) for pair in REPLACE_REQ_PACKAGES],
+    }
+    args.reqs_out.parent.mkdir(parents=True, exist_ok=True)
+    args.reqs_out.write_text(json.dumps(reqs_out, indent=2, sort_keys=True) + "\n")
+    print(
+        f"Wrote {len(reqs_out['reqs_paths'])} reqs-path + "
+        f"{len(reqs_out['env_yml_paths'])} env-yml-path repos to {args.reqs_out}",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/scripts/validate_verified_setup.py
+++ b/scripts/validate_verified_setup.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import os
 import re
 import subprocess
 import sys
@@ -74,6 +75,13 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RUNS_DIR = REPO_ROOT / "runs" / "validation"
+
+
+def _conda_default() -> bool:
+    """Default for ``--conda`` when the flag is unset — mirrors
+    ``cache_cli.setup``'s ``ONLYCODES_CONDA_BUILD`` convention so the validator
+    builds the same way the spine's ``cache setup`` does."""
+    return os.environ.get("ONLYCODES_CONDA_BUILD", "").lower() in ("1", "true", "yes", "on")
 
 # Throwaway clones for the Gate-2 collect check. The bare repo is local after
 # Gate 1, so these clones are cheap; each is wiped before and after use.
@@ -200,6 +208,7 @@ WORKER_SCRIPT = r"""
 import json, os, sys, shutil, traceback
 sys.path.insert(0, {repo_root!r})
 from pathlib import Path
+from swebench import specs
 from swebench.models import Problem
 from swebench.cache import cache_paths, bare_repo_path
 from swebench.cache_cli import _setup_one
@@ -212,16 +221,19 @@ from swebench.run import _INSTANCE_ENV, _INSTANCE_EXTRA_PYTEST_ARGS
 yaml_path = Path({yaml_path!r})
 clone_base = {clone_base!r}
 force = {force!r}
+conda = {conda!r}
 repo_root = {repo_root!r}
 
 problem = Problem.from_yaml(yaml_path)
 iid = problem.instance_id
 result = {{"ok": False, "status": "build_fail", "reason": None,
-          "lockfile": False, "collect_skipped": False}}
+          "lockfile": False, "collect_skipped": False, "conda": conda}}
 
 try:
     # --- Gate 1: clone + venv-build (identical to `cache setup` for one id) ---
-    _id, built_ok, build_msg = _setup_one(problem, force=force)
+    # Under --conda, spec-bearing instances build conda-native (the faithful
+    # MAP_REPO_VERSION_TO_SPECS path); instances without a spec fall back to venv.
+    _id, built_ok, build_msg = _setup_one(problem, force=force, conda=conda)
     result["build_msg"] = build_msg
     paths = cache_paths(iid)
     if not built_ok:
@@ -249,13 +261,33 @@ try:
             problem.test_cmd, repo_dir=tmp_repo, venv_dir=venv_dir,
             repo_slug=problem.repo_slug,
         )
+        # Collect-time env. Under --conda we run the collect faithfully under the
+        # spec's `export`-style eval_commands (LANG/LC_ALL/... locale pins) — the
+        # test-fidelity half of the conda-native build — with the hand-curated
+        # _INSTANCE_ENV taking precedence (hand-tables > official-spec, per #311).
+        # System-level eval_commands (locale-gen) need root and are skipped+logged,
+        # exactly as setup_conda_env skips system-level pre_install.
+        extra_env = dict(_INSTANCE_ENV.get(iid) or {{}})
+        if conda:
+            spec = specs.spec_for(problem.repo_slug, getattr(problem, "version", None))
+            if spec:
+                spec_env = specs.eval_env(spec)
+                if spec_env:
+                    extra_env = {{**spec_env, **extra_env}}
+                    result["eval_env"] = spec_env
+                skipped = specs.eval_system_commands(spec)
+                if skipped:
+                    result["eval_system_skipped"] = skipped
+                    sys.stdout.write("\n--- spec eval_commands skipped (system-level, need root) ---\n")
+                    for c in skipped:
+                        sys.stdout.write(c + "\n")
         # run_preflight_collect returns (True, "") for non-pytest/-unittest
         # runners (e.g. Django runtests.py) — record that as collect_skipped so
         # the report is honest about which gate actually fired.
         is_pytest_like = (" -m pytest" in resolved) or (" -m unittest" in resolved)
         collected_ok, output = run_preflight_collect(
             repo_dir=tmp_repo, test_cmd=resolved, venv_dir=venv_dir,
-            extra_env=_INSTANCE_ENV.get(iid),
+            extra_env=extra_env or None,
             extra_pytest_args=_INSTANCE_EXTRA_PYTEST_ARGS.get(iid),
         )
         sys.stdout.write("\n--- pytest --collect-only (tail) ---\n")
@@ -284,7 +316,8 @@ print("__VALIDATOR_RESULT__" + json.dumps(result))
 """
 
 
-def run_one(yaml_path: Path, *, clone_base: str, timeout: int, force: bool, log_dir: Path) -> dict:
+def run_one(yaml_path: Path, *, clone_base: str, timeout: int, force: bool,
+            conda: bool, log_dir: Path) -> dict:
     """Validate one instance in a subprocess. Always returns; never raises."""
     instance_id = yaml_path.stem
     log_file = log_dir / f"{instance_id}.log"
@@ -294,6 +327,7 @@ def run_one(yaml_path: Path, *, clone_base: str, timeout: int, force: bool, log_
         yaml_path=str(yaml_path),
         clone_base=clone_base,
         force=force,
+        conda=conda,
     )
 
     started = dt.datetime.now(dt.timezone.utc).isoformat()
@@ -358,6 +392,9 @@ def run_one(yaml_path: Path, *, clone_base: str, timeout: int, force: bool, log_
         "build_msg": (worker_result or {}).get("build_msg"),
         "lockfile": (worker_result or {}).get("lockfile", False),
         "collect_skipped": (worker_result or {}).get("collect_skipped", False),
+        "conda": (worker_result or {}).get("conda", conda),
+        "eval_env": (worker_result or {}).get("eval_env"),
+        "eval_system_skipped": (worker_result or {}).get("eval_system_skipped"),
         "failure_class": klass,
         "fix_hint": hint,
         "log_file": str(log_file.relative_to(REPO_ROOT)),
@@ -379,7 +416,7 @@ def write_buildable(results: list[dict], paths: list[Path]) -> None:
 
 
 def write_summary(results: list[dict], out_path: Path, *, set_name: str,
-                  start: dt.datetime, pool_size: int) -> None:
+                  start: dt.datetime, pool_size: int, conda: bool = False) -> None:
     total = len(results)
     ok = sum(1 for r in results if r["status"] == "ok")
     shortfall = pool_size - ok
@@ -395,6 +432,12 @@ def write_summary(results: list[dict], out_path: Path, *, set_name: str,
     lines.append("")
     lines.append(f"- Started (UTC): `{start.isoformat()}`")
     lines.append(f"- Pool size (validated): **{pool_size}**")
+    lines.append(
+        "- Build path: **"
+        + ("conda-native (spec-faithful `MAP_REPO_VERSION_TO_SPECS`) + venv fallback "
+           "for spec-less instances" if conda else "venv (generic)")
+        + "**"
+    )
     lines.append(f"- Buildable (built + collected cleanly): **{ok}**")
     lines.append(f"- **Shortfall (pool − buildable): {shortfall}**")
     lines.append("")
@@ -420,6 +463,18 @@ def write_summary(results: list[dict], out_path: Path, *, set_name: str,
         Only `buildable.txt` ids feed #299's spine and #301's powered subset.
     """).strip())
     lines.append("")
+
+    if conda:
+        lines.append(textwrap.dedent("""
+            Under conda-native build, Gate 1 builds each spec-bearing instance from
+            `MAP_REPO_VERSION_TO_SPECS` verbatim (correct interpreter via micromamba,
+            file-ref deps, custom install flags), and Gate 2 runs the collect under
+            the spec's `export`-style `eval_commands` (locale pins). System-level
+            `eval_commands` (`locale-gen`) need root and are skipped + logged in the
+            per-instance log, the same way `setup_conda_env` skips system-level
+            `pre_install`. Instances with no official spec fall back to the venv path.
+        """).strip())
+        lines.append("")
 
     lines.append("## Per-instance result")
     lines.append("")
@@ -525,11 +580,39 @@ def main() -> int:
         help="Also write the buildable id list here (e.g. sets/verified-buildable.txt). "
              "Always written to the run dir's buildable.txt regardless.",
     )
+    parser.add_argument(
+        "--conda", action=argparse.BooleanOptionalAction, default=None,
+        help="Build spec-bearing instances conda-native (faithful "
+             "MAP_REPO_VERSION_TO_SPECS via micromamba) in Gate 1, and run the Gate-2 "
+             "collect under the spec's eval_commands env (locale pins). Instances "
+             "without an official spec fall back to the venv path. Defaults to the "
+             "ONLYCODES_CONDA_BUILD env var (falsey if unset). Requires micromamba in "
+             "the image (#311).",
+    )
     args = parser.parse_args()
 
     if args.concurrency < 1:
         print("ERROR: --concurrency must be >= 1.", file=sys.stderr)
         return 2
+
+    conda = _conda_default() if args.conda is None else args.conda
+    if conda:
+        # Fail loudly up front rather than letting every instance fall back or
+        # error mid-run: conda-native builds need micromamba, which is baked into
+        # the devcontainer image (#311). A pre-rebuild container won't have it.
+        # REPO_ROOT on the path so the import works when run as a bare script
+        # (the worker subprocess does the same before its own swebench imports).
+        sys.path.insert(0, str(REPO_ROOT))
+        from swebench.harness import _find_micromamba
+        if _find_micromamba() is None:
+            print(
+                "ERROR: --conda requested but micromamba was not found. The "
+                "conda-native build needs micromamba (baked at /usr/local/bin by the "
+                "devcontainer image — rebuild the container, or set ONLYCODES_MICROMAMBA "
+                "to its path). Re-run with --no-conda for the generic venv path. (#311)",
+                file=sys.stderr,
+            )
+            return 2
 
     problems_dir = REPO_ROOT / "problems" / args.set_name
     if not problems_dir.is_dir():
@@ -565,6 +648,7 @@ def main() -> int:
     print(f"Instances:   {pool_size}")
     print(f"Concurrency: {args.concurrency}")
     print(f"Timeout:     {args.timeout}s per instance")
+    print(f"Build path:  {'conda-native (spec-faithful) + venv fallback' if conda else 'venv (generic)'}")
     print(f"Output dir:  {out_dir.relative_to(REPO_ROOT)}")
     print(f"Started:     {start.isoformat()}")
     print(flush=True)
@@ -580,14 +664,15 @@ def main() -> int:
         ordered = sorted(results, key=lambda r: r["instance_id"])
         (out_dir / "results.json").write_text(json.dumps(ordered, indent=2))
         write_summary(ordered, out_dir / "summary.md", set_name=args.set_name,
-                      start=start, pool_size=pool_size)
+                      start=start, pool_size=pool_size, conda=conda)
         write_buildable(ordered, buildable_targets)
 
     done = 0
     with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
         futs = {
             pool.submit(run_one, yp, clone_base=args.clone_base,
-                        timeout=args.timeout, force=args.force, log_dir=log_dir): yp
+                        timeout=args.timeout, force=args.force, conda=conda,
+                        log_dir=log_dir): yp
             for yp in yamls
         }
         for fut in as_completed(futs):

--- a/swebench/cache_cli.py
+++ b/swebench/cache_cli.py
@@ -15,6 +15,7 @@ once ``run`` starts calling into the cache).
 
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 import threading
@@ -34,11 +35,13 @@ from swebench.cache import (
     scrub_cache_dir,
     write_lockfile,
 )
+from swebench import specs
 from swebench.harness import (
     _venv_kwargs,
     clone_bare_repo,
     clone_from_bare,
     git_reset,
+    setup_conda_env,
     setup_venv,
 )
 from swebench.models import Problem
@@ -78,7 +81,7 @@ def _load_problems(filter_ids: str | None) -> list[Problem]:
     return problems
 
 
-def _setup_one(problem: Problem, *, force: bool) -> tuple[str, bool, str]:
+def _setup_one(problem: Problem, *, force: bool, conda: bool = False) -> tuple[str, bool, str]:
     """Build the cache for one instance. Returns (id, ok, message).
 
     New cache entries use the isolated layout (``venv_lower/`` as the pristine
@@ -86,9 +89,22 @@ def _setup_one(problem: Problem, *, force: bool) -> tuple[str, bool, str]:
     overlays).  Existing legacy entries (``venv/`` present, no ``venv_lower/``)
     are left as-is here — lazy migration happens in ``_setup_problem_cached``
     when ``swebench run`` first uses them with ``--venv-isolation``.
+
+    When *conda* is True and the instance has an official spec
+    (``version`` present + in the vendored ``MAP_REPO_VERSION_TO_SPECS``), the
+    environment is built **conda-native** (``setup_conda_env``) following the
+    spec verbatim, instead of the generic venv path. The conda env occupies the
+    same ``venv/`` → ``venv_lower/`` slot (the overlay machinery is path-based;
+    P2-α verified it works unchanged). Instances without a spec fall back to the
+    venv path even under ``--conda``. (#311)
     """
     instance_id = problem.instance_id
     paths = cache_paths(instance_id)
+    spec = (
+        specs.spec_for(problem.repo_slug, getattr(problem, "version", None))
+        if conda else None
+    )
+    use_conda = spec is not None
 
     # Check isolated layout first (preferred), then fall back to legacy.
     if not force and (has_cached_instance(instance_id, venv_isolation=True)
@@ -113,13 +129,10 @@ def _setup_one(problem: Problem, *, force: bool) -> tuple[str, bool, str]:
             shutil.rmtree(repo_dir, ignore_errors=True)
         clone_from_bare(bare, repo_dir)
 
-        # 3. Checkout base commit
-        git_reset(repo_dir, problem.base_commit)
-
-        # 4. Venv + editable install — build into venv/ (the canonical creation path).
-        # Shebangs in console scripts are baked to the creation path; the overlay
-        # mounts back at venv/ so they keep working after migration. After building,
-        # we rename venv/ → venv_lower/ so the mountpoint (venv/) is free.
+        # 3+4. Build the environment into venv/ (the canonical creation path).
+        # Shebangs/prefix paths bake to the creation path; the overlay mounts
+        # back at venv/ so they keep working after migration. After building, we
+        # rename venv/ → venv_lower/ so the mountpoint (venv/) is free.
         venv_lower_dir = paths["venv_lower"]
         venv_canonical = paths["venv"]
         if force and Path(venv_lower_dir).exists():
@@ -127,8 +140,20 @@ def _setup_one(problem: Problem, *, force: bool) -> tuple[str, bool, str]:
         # On --force or fresh build, ensure venv/ is clear (not a live mount).
         if force and Path(venv_canonical).exists() and not Path(venv_canonical).is_mount():
             shutil.rmtree(venv_canonical, ignore_errors=True)
-        # Build into venv/ (canonical path — shebangs will point here).
-        setup_venv(venv_canonical, repo_dir, **_venv_kwargs(problem))
+
+        if use_conda:
+            # Conda-native: build at environment_setup_commit so file-ref deps
+            # (requirements.txt / environment.yml) resolve from the right tree —
+            # it differs from base_commit and is unreachable post-strip. Then
+            # reset the working tree to base_commit for the frozen repo.
+            setup_commit = getattr(problem, "environment_setup_commit", None) or problem.base_commit
+            git_reset(repo_dir, setup_commit)
+            setup_conda_env(venv_canonical, repo_dir, spec=spec, repo_slug=problem.repo_slug)
+            git_reset(repo_dir, problem.base_commit)
+        else:
+            # Generic venv + editable install at base_commit (legacy path).
+            git_reset(repo_dir, problem.base_commit)
+            setup_venv(venv_canonical, repo_dir, **_venv_kwargs(problem))
 
         # 5. Scrub transient artifacts
         scrub_cache_dir(repo_dir)
@@ -176,16 +201,27 @@ def cache_group() -> None:
     default=False,
     help="Rebuild even if a cache entry already exists.",
 )
-def setup(filter_ids: str | None, concurrency: int, force: bool) -> None:
+@click.option(
+    "--conda/--no-conda",
+    default=None,
+    help="Build spec-bearing instances conda-native (faithful MAP_REPO_VERSION_TO_SPECS) "
+         "instead of the generic venv path. Defaults to the ONLYCODES_CONDA_BUILD env var "
+         "(falsey if unset). Instances without an official spec always use the venv path. (#311)",
+)
+def setup(filter_ids: str | None, concurrency: int, force: bool, conda: bool | None) -> None:
     """Pre-build the instance cache.
 
     Produces ``/workspaces/.swebench-cache/instances/<id>/`` for each problem,
     each containing ``repo/`` (scrubbed working tree at base commit),
-    ``venv/`` (python3.11 + editable install), and ``lockfile.txt``.
+    ``venv/`` (the per-arm-overlay env: a venv, or a conda env under ``--conda``),
+    and ``lockfile.txt``.
     """
     if concurrency < 1:
         click.echo("ERROR: --concurrency must be >= 1.", err=True)
         sys.exit(1)
+
+    if conda is None:
+        conda = os.environ.get("ONLYCODES_CONDA_BUILD", "").lower() in ("1", "true", "yes", "on")
 
     problems = _load_problems(filter_ids)
 
@@ -195,7 +231,7 @@ def setup(filter_ids: str | None, concurrency: int, force: bool) -> None:
 
     _echo(
         f"cache setup: {len(problems)} instance(s), concurrency={concurrency}, "
-        f"force={force}"
+        f"force={force}, conda={conda}"
     )
 
     successes: list[str] = []
@@ -203,7 +239,8 @@ def setup(filter_ids: str | None, concurrency: int, force: bool) -> None:
 
     with ThreadPoolExecutor(max_workers=concurrency) as pool:
         futures = {
-            pool.submit(_setup_one, p, force=force): p.instance_id for p in problems
+            pool.submit(_setup_one, p, force=force, conda=conda): p.instance_id
+            for p in problems
         }
         for fut in as_completed(futures):
             iid, ok, msg = fut.result()

--- a/swebench/data/official_reqs_paths.json
+++ b/swebench/data/official_reqs_paths.json
@@ -1,0 +1,36 @@
+{
+  "env_yml_paths": {
+    "matplotlib/matplotlib": [
+      "environment.yml"
+    ],
+    "pydata/xarray": [
+      "ci/requirements/environment.yml",
+      "environment.yml"
+    ]
+  },
+  "replace_req_packages": [
+    [
+      "types-pkg_resources",
+      "types-setuptools"
+    ]
+  ],
+  "reqs_paths": {
+    "django/django": [
+      "tests/requirements/py3.txt"
+    ],
+    "matplotlib/matplotlib": [
+      "requirements/dev/dev-requirements.txt",
+      "requirements/testing/travis_all.txt"
+    ],
+    "pallets/flask": [
+      "requirements/dev.txt"
+    ],
+    "pylint-dev/pylint": [
+      "requirements_test.txt"
+    ],
+    "sympy/sympy": [
+      "requirements-dev.txt",
+      "requirements-test.txt"
+    ]
+  }
+}

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -1160,6 +1160,16 @@ def setup_venv(
     """
     pip = os.path.join(venv_dir, "bin", "pip")
     if os.path.isdir(venv_dir):
+        # Never treat a conda env (built by setup_conda_env) as a venv: the
+        # sentinel mismatch below would rmtree it and rebuild a plain venv,
+        # silently discarding the spec-faithful environment. Fail loudly so the
+        # caller routes the rebuild to setup_conda_env instead (#311).
+        _sentinel = _read_sentinel(venv_dir)
+        if _sentinel and _sentinel.startswith("conda:"):
+            raise CondaBuildError(
+                f"{venv_dir} holds a conda env (sentinel {_sentinel!r}); rebuild it "
+                "with setup_conda_env, not setup_venv (#311 conda-native path)."
+            )
         # F-19: Guard against a partially-built venv skeleton that has the
         # directory but not bin/pip (e.g. venv creation crashed mid-way).
         if not os.path.isfile(pip):
@@ -1292,6 +1302,197 @@ def setup_venv(
         _smoke_import(venv_dir, repo_slug)
     # Write the sentinel last — only after a fully successful install.
     Path(_venv_sentinel(venv_dir)).write_text(python_bin + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Conda-native env builder (P2-γ, #311)
+#
+# Builds a conda env per (repo, version) following SWE-bench's official
+# MAP_REPO_VERSION_TO_SPECS *verbatim*, rather than the generic venv + pinned
+# pip path above. Used for the Verified set so instances build exactly the way
+# SWE-bench specifies (correct interpreter incl. 3.5/3.6, file-ref deps, custom
+# install flags). The env drops into the same per-arm overlay slot as a venv —
+# the overlay machinery is path-based and works unchanged (verified, P2-α).
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONDA_CHANNEL = "conda-forge"
+
+# pre_install commands we must NOT run in our (non-container) flow: they mutate
+# the host system and need root. SWE-bench runs them inside a per-instance
+# container; our overlay isolates the repo + env but not the system. We skip and
+# log these (sed/echo source pins are safe and ARE run).
+_UNSAFE_PRE_INSTALL_RE = re.compile(
+    r"^\s*(sudo\s+)?(apt-get|apt|locale-gen|add-apt-repository|dpkg|yum)\b"
+)
+
+
+class CondaBuildError(RuntimeError):
+    """Raised when a conda-native env build step fails."""
+
+
+def _find_micromamba() -> str | None:
+    """Locate the micromamba binary.
+
+    Order: ``ONLYCODES_MICROMAMBA`` env override → ``micromamba`` on PATH →
+    common install paths. The devcontainer image bakes it at
+    ``/usr/local/bin/micromamba`` (#311); ``None`` if genuinely absent.
+    """
+    override = os.environ.get("ONLYCODES_MICROMAMBA")
+    if override and os.path.isfile(override):
+        return override
+    found = shutil.which("micromamba")
+    if found:
+        return found
+    for cand in (
+        "/usr/local/bin/micromamba",
+        "/tmp/mmroot/bin/micromamba",
+        os.path.expanduser("~/.local/bin/micromamba"),
+    ):
+        if os.path.isfile(cand):
+            return cand
+    return None
+
+
+def _mm_run(mm: str, args: list[str]) -> None:
+    """Run a micromamba subcommand; raise CondaBuildError with stderr on failure."""
+    result = subprocess.run([mm, *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        head = " ".join(args[:4])
+        raise CondaBuildError(
+            f"micromamba {head}… failed (rc={result.returncode}):\n"
+            f"{(result.stderr or result.stdout)[-2000:]}"
+        )
+
+
+def _conda_path_env(env_dir: str) -> dict:
+    """Environment for shell commands run against *env_dir* without activation.
+
+    Puts ``env_dir/bin`` first on PATH so bare ``python``/``pip`` in the spec's
+    ``install`` / ``pre_install`` lines resolve to the conda env, and clears
+    PYTHONHOME/VIRTUAL_ENV so an outer venv/conda activation can't leak in.
+    """
+    env = dict(os.environ)
+    env["PATH"] = os.path.join(env_dir, "bin") + os.pathsep + env.get("PATH", "")
+    env.pop("PYTHONHOME", None)
+    env.pop("VIRTUAL_ENV", None)
+    return env
+
+
+def _shell_run_checked(cmd: str, *, cwd: str, env: dict, what: str) -> None:
+    """Run a spec shell command (``shell=True``); raise CondaBuildError on failure."""
+    result = subprocess.run(
+        cmd, shell=True, cwd=cwd, env=env, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(
+            f"[harness] conda {what} failed (rc={result.returncode}): {cmd!r}\n"
+            f"{(result.stderr or result.stdout)[-2000:]}",
+            flush=True,
+        )
+        raise CondaBuildError(f"{what} failed (rc={result.returncode}): {cmd!r}")
+
+
+def setup_conda_env(
+    env_dir: str,
+    repo_dir: str,
+    *,
+    spec: dict,
+    repo_slug: str | None = None,
+    channel: str = _DEFAULT_CONDA_CHANNEL,
+    micromamba_bin: str | None = None,
+) -> None:
+    """Build a conda env at *env_dir* from the official SWE-bench spec, verbatim.
+
+    Mirrors ``MAP_REPO_VERSION_TO_SPECS`` build order:
+
+      1. ``micromamba create -p env_dir python=<spec.python> [inline conda pkgs]``
+      2. file-ref ``packages``: ``environment.yml`` → create from the file;
+         ``requirements.txt`` → ``pip install -r`` (read from the working tree)
+      3. ``pip install <pip_packages>``
+      4. ``pre_install`` shell commands — sed/echo source pins run; apt/locale/
+         system mutators are skipped + logged (see ``_UNSAFE_PRE_INSTALL_RE``)
+      5. the spec's ``install`` command, **verbatim** — so the build-isolation /
+         ``--no-use-pep517`` / extras policy is exactly what SWE-bench encoded
+         (this is what fixed the astropy ``-e .[test] --verbose`` case)
+
+    The repo at *repo_dir* MUST already be checked out at the commit whose
+    dependency files the spec references (``environment_setup_commit``, which
+    differs from ``base_commit`` and is unreachable post-strip). This function
+    never touches git state — the caller owns it, exactly like ``setup_venv``.
+
+    Steps 4–5 run with ``env_dir/bin`` first on PATH (no activation), which the
+    P2-α spike confirmed is sufficient for the scientific stack (conda rpath).
+    """
+    mm = micromamba_bin or _find_micromamba()
+    if not mm:
+        raise CondaBuildError(
+            "micromamba not found. Set ONLYCODES_MICROMAMBA or rebuild the "
+            "devcontainer image (it bakes micromamba at /usr/local/bin) — #311."
+        )
+    py = specs.conda_python(spec)
+    if not py:
+        raise CondaBuildError(f"official spec has no python version: {spec!r}")
+
+    kind = specs.packages_kind(spec)
+
+    # --- 1 (+ inline conda packages, or 2 for environment.yml): create the env ---
+    if kind == "environment_yml" and not specs.no_use_env(spec):
+        yml = os.path.join(repo_dir, specs.packages_file(spec))
+        if not os.path.isfile(yml):
+            raise CondaBuildError(
+                f"environment.yml not found at {yml!r} — wrong commit checked out? "
+                "(must be environment_setup_commit)."
+            )
+        _mm_run(mm, ["create", "-y", "-p", env_dir, "-c", channel, "-f", yml])
+        # Env files often omit/loosely pin python; enforce the spec's version.
+        _mm_run(mm, ["install", "-y", "-p", env_dir, "-c", channel, f"python={py}"])
+    else:
+        create_args = ["create", "-y", "-p", env_dir, "-c", channel, f"python={py}"]
+        create_args += specs.conda_packages(spec)  # inline conda specs, verbatim
+        _mm_run(mm, create_args)
+
+    pip = os.path.join(env_dir, "bin", "pip")
+    if not os.path.isfile(pip):  # minimal envs may lack pip
+        _mm_run(mm, ["install", "-y", "-p", env_dir, "-c", channel, "pip"])
+
+    # --- 2 (requirements.txt ref): read from the checked-out working tree ---
+    if kind == "requirements_txt":
+        req = os.path.join(repo_dir, specs.packages_file(spec))
+        if not os.path.isfile(req):
+            raise CondaBuildError(
+                f"requirements file not found at {req!r} — wrong commit checked out?"
+            )
+        _pip_run_checked(pip, ["install", "-r", req])
+
+    # --- 3: pip_packages ---
+    pip_pkgs = specs.pip_packages(spec)
+    if pip_pkgs:
+        _pip_run_checked(pip, ["install", *pip_pkgs])
+
+    # --- 4: pre_install shell commands (cwd=repo, env-on-PATH) ---
+    shell_env = _conda_path_env(env_dir)
+    for cmd in specs.pre_install_commands(spec):
+        if _UNSAFE_PRE_INSTALL_RE.match(cmd):
+            print(
+                f"[harness] SKIP system-level pre_install (needs root, not "
+                f"isolated in our flow): {cmd!r}",
+                flush=True,
+            )
+            continue
+        _shell_run_checked(cmd, cwd=repo_dir, env=shell_env, what="pre_install")
+
+    # --- 5: the spec's install command, verbatim ---
+    install = specs.install_command(spec)
+    if install:
+        _shell_run_checked(install, cwd=repo_dir, env=shell_env, what="install")
+
+    # Ensure pytest exists (tests need it; mirrors setup_venv's fallback). Best-effort.
+    subprocess.run([pip, "install", "--quiet", "pytest"], capture_output=True, text=True)
+
+    # Sentinel mirrors setup_venv's, tagged so the layout is self-describing. The
+    # run-time reuse path keys off lockfile drift, not this value, so a conda env
+    # in the slot is reused (not rebuilt) as long as its pip-freeze matches.
+    Path(_venv_sentinel(env_dir)).write_text(f"conda:python{py}\n")
 
 
 def _parse_patch_targets(patch_path: str) -> tuple[list[str], list[str]]:

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -1320,9 +1320,14 @@ _DEFAULT_CONDA_CHANNEL = "conda-forge"
 # pre_install commands we must NOT run in our (non-container) flow: they mutate
 # the host system and need root. SWE-bench runs them inside a per-instance
 # container; our overlay isolates the repo + env but not the system. We skip and
-# log these (sed/echo source pins are safe and ARE run).
+# log these (sed/echo source pins targeting the repo tree are safe and ARE run).
 _UNSAFE_PRE_INSTALL_RE = re.compile(
+    # a system package manager (optionally via sudo), e.g. `apt-get install …`
     r"^\s*(sudo\s+)?(apt-get|apt|locale-gen|add-apt-repository|dpkg|yum)\b"
+    # …or a redirect that writes into a root-owned system dir, e.g. django's
+    # `echo 'en_US UTF-8' > /etc/locale.gen` — fails (rc=2) without root in our
+    # flow, so skip it the same way (the matching locale-gen step is skipped too).
+    r"|.*[>]{1,2}\s*/(etc|usr|var|opt|boot|lib|lib64|sbin|bin|root)/"
 )
 
 

--- a/swebench/harness.py
+++ b/swebench/harness.py
@@ -1392,6 +1392,81 @@ def _shell_run_checked(cmd: str, *, cwd: str, env: dict, what: str) -> None:
         raise CondaBuildError(f"{what} failed (rc={result.returncode}): {cmd!r}")
 
 
+# Lines excluded from a resolved requirements file, mirroring upstream
+# get_requirements: editable self-installs (handled by the spec's `install`
+# command), comments, and `.[test]`-style extras refs.
+_REQ_EXCLUDE_PREFIXES = ("-e .", "#", ".[test")
+
+
+def _resolve_first_existing(repo_dir: str, candidates: list[str]) -> tuple[str, str] | None:
+    """First ``(relpath, abspath)`` in *candidates* that exists under *repo_dir*."""
+    for rel in candidates:
+        ap = os.path.join(repo_dir, rel)
+        if os.path.isfile(ap):
+            return rel, ap
+    return None
+
+
+def resolve_requirements_text(repo_dir: str, repo_slug: str | None) -> str | None:
+    """Build the combined requirements text for a ``requirements.txt``-sentinel spec.
+
+    Faithful local port of upstream SWE-bench ``get_requirements`` (which reads from
+    GitHub raw at ``environment_setup_commit``): the real path comes from the
+    vendored ``MAP_REPO_TO_REQS_PATHS`` (``specs.reqs_paths``), not the literal
+    ``"requirements.txt"`` token — e.g. flask resolves to ``requirements/dev.txt``.
+    We read from the working tree instead (the caller has it checked out at
+    ``environment_setup_commit``). One level of ``-r`` includes is inlined (relative
+    to the requirements file's dir); ``-e .`` / comment / ``.[test`` lines are
+    dropped; ``REPLACE_REQ_PACKAGES`` substitutions are applied.
+
+    Returns the requirements text, or ``None`` if no candidate path exists (or the
+    repo has no vendored reqs-path entry) so the caller can fall back.
+    """
+    candidates = specs.reqs_paths(repo_slug) if repo_slug else []
+    found = _resolve_first_existing(repo_dir, candidates)
+    if not found:
+        return None
+    rel, abspath = found
+    req_dir = os.path.dirname(rel)
+
+    def _excluded(line: str) -> bool:
+        s = line.strip()
+        return any(s.startswith(x) for x in _REQ_EXCLUDE_PREFIXES)
+
+    original: list[str] = []
+    additional: list[str] = []
+    for line in Path(abspath).read_text().split("\n"):
+        if line.strip().startswith("-r"):
+            inc = line[len("-r"):].strip()
+            inc_path = os.path.join(repo_dir, req_dir, inc)
+            if os.path.isfile(inc_path):
+                additional += [l for l in Path(inc_path).read_text().split("\n")
+                               if not _excluded(l)]
+        elif not _excluded(line):
+            original.append(line)
+
+    additional.append("\n".join(original))   # match upstream ordering
+    text = "\n".join(additional)
+    for old, new in specs.replace_req_packages():
+        text = re.sub(rf"^{re.escape(old)}([<>=!~]=?.*|$)", new, text, flags=re.MULTILINE)
+    return text
+
+
+def resolve_env_yml_path(repo_dir: str, repo_slug: str | None, spec: dict) -> str | None:
+    """Resolved ``environment.yml`` abspath for an ``environment.yml``-sentinel spec.
+
+    Tries the vendored ``MAP_REPO_TO_ENV_YML_PATHS`` (``specs.env_yml_paths``) in
+    order, then falls back to the literal ``packages`` filename at repo root (for a
+    repo not in the map). ``None`` if nothing resolves.
+    """
+    candidates = list(specs.env_yml_paths(repo_slug) if repo_slug else [])
+    literal = specs.packages_file(spec)
+    if literal and literal not in candidates:
+        candidates.append(literal)   # back-compat fallback
+    found = _resolve_first_existing(repo_dir, candidates)
+    return found[1] if found else None
+
+
 def setup_conda_env(
     env_dir: str,
     repo_dir: str,
@@ -1437,11 +1512,14 @@ def setup_conda_env(
 
     # --- 1 (+ inline conda packages, or 2 for environment.yml): create the env ---
     if kind == "environment_yml" and not specs.no_use_env(spec):
-        yml = os.path.join(repo_dir, specs.packages_file(spec))
-        if not os.path.isfile(yml):
+        # "environment.yml" is a sentinel — resolve the real path via the vendored
+        # env-yml-path map (e.g. xarray → ci/requirements/environment.yml).
+        yml = resolve_env_yml_path(repo_dir, repo_slug, spec)
+        if not yml:
             raise CondaBuildError(
-                f"environment.yml not found at {yml!r} — wrong commit checked out? "
-                "(must be environment_setup_commit)."
+                f"environment.yml not found for {repo_slug} at any of "
+                f"{specs.env_yml_paths(repo_slug) or [specs.packages_file(spec)]!r} — "
+                "wrong commit checked out? (must be environment_setup_commit)."
             )
         _mm_run(mm, ["create", "-y", "-p", env_dir, "-c", channel, "-f", yml])
         # Env files often omit/loosely pin python; enforce the spec's version.
@@ -1455,14 +1533,32 @@ def setup_conda_env(
     if not os.path.isfile(pip):  # minimal envs may lack pip
         _mm_run(mm, ["install", "-y", "-p", env_dir, "-c", channel, "pip"])
 
-    # --- 2 (requirements.txt ref): read from the checked-out working tree ---
+    # --- 2 (requirements.txt ref): resolve the real path (sentinel, not literal),
+    # following upstream get_requirements, and install from the working tree. ---
     if kind == "requirements_txt":
-        req = os.path.join(repo_dir, specs.packages_file(spec))
-        if not os.path.isfile(req):
-            raise CondaBuildError(
-                f"requirements file not found at {req!r} — wrong commit checked out?"
-            )
-        _pip_run_checked(pip, ["install", "-r", req])
+        reqs_text = resolve_requirements_text(repo_dir, repo_slug)
+        if reqs_text is None:
+            # Back-compat: a repo with no vendored reqs-path entry — try the literal
+            # packages filename at repo root, as the pre-resolution code did.
+            literal = os.path.join(repo_dir, specs.packages_file(spec) or "")
+            if not os.path.isfile(literal):
+                raise CondaBuildError(
+                    f"requirements file not found for {repo_slug} at any of "
+                    f"{specs.reqs_paths(repo_slug) or [specs.packages_file(spec)]!r} — "
+                    "wrong commit checked out? (must be environment_setup_commit)."
+                )
+            _pip_run_checked(pip, ["install", "-r", literal])
+        else:
+            # Write the combined, cleaned requirements to a temp file and install it.
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".txt", prefix="swebench_reqs_", delete=False
+            ) as fh:
+                fh.write(reqs_text)
+                reqs_file = fh.name
+            try:
+                _pip_run_checked(pip, ["install", "-r", reqs_file])
+            finally:
+                os.unlink(reqs_file)
 
     # --- 3: pip_packages ---
     pip_pkgs = specs.pip_packages(spec)

--- a/swebench/specs.py
+++ b/swebench/specs.py
@@ -11,11 +11,18 @@ SWE-bench Verified specifies — the correct Python and the exact pinned
 dependencies — instead of a generic `python3.11` + plain editable install. The
 hand-curated override tables in `harness.py` still take precedence (#311).
 
-PR-1 scope: this module surfaces the spec's `python` and the pip-installable
-dependency pins (`pip_packages` + the pip-translatable tokens of `packages`).
-It deliberately does NOT handle the spec's shell `pre_install` commands (sed,
-apt), custom `install` flags, or file-reference packages
-(`requirements.txt` / `environment.yml`) — those are deferred (#311 follow-up).
+Two consumers, two views of the same spec:
+
+* **Venv path (`harness._venv_kwargs`, all non-Verified sets):** `python_bin` +
+  `pip_requirements` — the spec's `python` and the pip-installable pins
+  (`pip_packages` + the pip-translatable tokens of `packages`). The shell
+  `pre_install`, custom `install` flags, and file-reference packages are NOT
+  applied on this path.
+* **Conda-native path (P2-γ, the Verified build, #311):** the full spec —
+  `conda_python`, `packages_kind` / `packages_file` / `conda_packages`,
+  `pip_packages`, `pre_install_commands`, `install_command`, `eval_commands`,
+  `no_use_env` — so the environment is built exactly the way SWE-bench's
+  `MAP_REPO_VERSION_TO_SPECS` specifies (commands run verbatim, not translated).
 """
 
 from __future__ import annotations
@@ -98,3 +105,112 @@ def pip_requirements(spec: dict) -> list[str]:
             seen.add(r)
             out.append(r)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Conda-native build accessors (P2-γ, #311)
+#
+# These expose the spec verbatim for the conda env builder, which runs SWE-bench's
+# own commands rather than translating them. Unlike `pip_requirements` above, they
+# do NOT pip-translate — `micromamba install` consumes conda syntax directly.
+# ---------------------------------------------------------------------------
+
+def conda_python(spec: dict) -> str | None:
+    """Bare CPython version for ``micromamba create python=<X>``, e.g. ``"3.6"``.
+
+    Distinct from :func:`python_bin` (``"python3.6"``), which names a PATH binary
+    for the venv path. Returns ``None`` if the spec has no ``python``.
+    """
+    py = spec.get("python")
+    return str(py) if py else None
+
+
+def install_command(spec: dict) -> str | None:
+    """The spec's ``install`` command, verbatim (e.g. ``"python -m pip install -e .[test] --verbose"``).
+
+    Run as-is by the conda builder, so the build-isolation / pep517 / extras
+    policy is whatever SWE-bench encoded — no second-guessing. ``None`` if absent.
+    """
+    cmd = (spec.get("install") or "").strip()
+    return cmd or None
+
+
+def pre_install_commands(spec: dict) -> list[str]:
+    """Shell commands the spec runs *before* ``install`` (e.g. ``sed`` setup.py pins).
+
+    Returned verbatim and in order. NOTE for the builder: some entries are
+    ``apt-get`` / ``locale-gen`` (system-level, root) — SWE-bench runs these in a
+    per-instance container; our overlay model does not isolate the system, so the
+    builder must decide which are safe to run (sed: yes; apt/locale: handle or log).
+    """
+    return [c for c in (spec.get("pre_install") or []) if (c or "").strip()]
+
+
+def pip_packages(spec: dict) -> list[str]:
+    """The spec's ``pip_packages`` (already pip-style), cleaned. Verbatim, no translation."""
+    return [p.strip() for p in (spec.get("pip_packages") or []) if (p or "").strip()]
+
+
+def eval_commands(spec: dict) -> list[str]:
+    """The spec's ``eval_commands`` (run during evaluation, before the test cmd). Verbatim."""
+    return [c for c in (spec.get("eval_commands") or []) if (c or "").strip()]
+
+
+def no_use_env(spec: dict) -> bool:
+    """The spec's ``no_use_env`` flag.
+
+    When true, an ``environment.yml`` ``packages`` ref must NOT be used to create
+    the conda env directly (``micromamba env create -f``); instead create a plain
+    ``python=<ver>`` env and install deps separately.
+    """
+    return bool(spec.get("no_use_env"))
+
+
+def packages_kind(spec: dict) -> str:
+    """Classify the spec's ``packages`` field for the conda builder.
+
+    One of: ``"none"`` (absent/empty), ``"requirements_txt"`` (a ``*.txt`` file
+    ref), ``"environment_yml"`` (a ``*.yml``/``*.yaml`` file ref), or ``"inline"``
+    (a conda package list). In the vendored data a file ref is always the sole
+    token, so a whole-string suffix test is sufficient.
+    """
+    p = (spec.get("packages") or "").strip()
+    if not p:
+        return "none"
+    low = p.lower()
+    if low.endswith(".txt"):
+        return "requirements_txt"
+    if low.endswith((".yml", ".yaml")):
+        return "environment_yml"
+    return "inline"
+
+
+def packages_file(spec: dict) -> str | None:
+    """For a ``requirements_txt`` / ``environment_yml`` spec, the referenced filename.
+
+    The builder reads this file from the repo checked out at
+    ``environment_setup_commit`` (which differs from ``base_commit`` and is
+    unreachable after history-stripping — read it before the strip). ``None`` for
+    inline / absent ``packages``.
+    """
+    if packages_kind(spec) in ("requirements_txt", "environment_yml"):
+        return (spec.get("packages") or "").strip()
+    return None
+
+
+def conda_packages(spec: dict) -> list[str]:
+    """For an ``"inline"`` ``packages`` spec, the conda package specs, verbatim.
+
+    Shell-quoted tokens are unquoted (``'numpy==1.19.2'`` → ``numpy==1.19.2``) but
+    NOT pip-translated — they are passed straight to ``micromamba install``, which
+    accepts conda match-specs (``numpy=1.19``, ``numpy==1.19.2``, ``pandas<2.0.0``).
+    ``[]`` unless ``packages_kind`` is ``"inline"``.
+    """
+    if packages_kind(spec) != "inline":
+        return []
+    raw = spec.get("packages") or ""
+    try:
+        tokens = shlex.split(raw)
+    except ValueError:
+        tokens = raw.split()
+    return [t for t in (tok.strip() for tok in tokens) if t]

--- a/swebench/specs.py
+++ b/swebench/specs.py
@@ -29,10 +29,14 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 import shlex
 from pathlib import Path
 
 _SPECS_PATH = Path(__file__).resolve().parent / "data" / "official_specs.json"
+
+# `export KEY=VALUE` form of an eval_command (see `eval_env` below).
+_EVAL_EXPORT_RE = re.compile(r"^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 
 # `packages` tokens we cannot pip-translate in PR-1 (file refs / conda env files).
 _FILE_PKG_SUFFIXES = (".txt", ".yml", ".yaml", ".cfg")
@@ -154,6 +158,42 @@ def pip_packages(spec: dict) -> list[str]:
 def eval_commands(spec: dict) -> list[str]:
     """The spec's ``eval_commands`` (run during evaluation, before the test cmd). Verbatim."""
     return [c for c in (spec.get("eval_commands") or []) if (c or "").strip()]
+
+
+def eval_env(spec: dict) -> dict[str, str]:
+    """Env-var overrides distilled from the spec's ``export``-style ``eval_commands``.
+
+    SWE-bench runs ``eval_commands`` in the eval shell *before* the test command.
+    In the vendored data they are overwhelmingly ``export KEY=VALUE`` locale pins
+    (``LANG`` / ``LC_ALL`` / ``LANGUAGE`` / ``PYTHONIOENCODING``, mostly Django), so
+    we surface them as a plain env dict the test/collect step can run *under* — the
+    test-fidelity counterpart to the conda-native build (#311 P2-δ). Surrounding
+    single/double quotes on the value are stripped; no shell ``$VAR`` expansion.
+
+    Non-``export`` eval_commands (e.g. ``sed … /etc/locale.gen && locale-gen``) are
+    system-level mutators that need root and are deliberately NOT represented here —
+    SWE-bench runs them inside its per-instance container, but our overlay model does
+    not isolate the system, exactly as :func:`harness.setup_conda_env` skips
+    system-level ``pre_install``. Use :func:`eval_system_commands` to see what was
+    left out.
+    """
+    env: dict[str, str] = {}
+    for cmd in eval_commands(spec):
+        m = _EVAL_EXPORT_RE.match(cmd)
+        if not m:
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        env[key] = val
+    return env
+
+
+def eval_system_commands(spec: dict) -> list[str]:
+    """The non-``export`` ``eval_commands`` — system-level mutators (``locale-gen``
+    etc.) that :func:`eval_env` deliberately omits. Surfaced so callers can log the
+    skip rather than silently dropping spec steps."""
+    return [c for c in eval_commands(spec) if not _EVAL_EXPORT_RE.match(c)]
 
 
 def no_use_env(spec: dict) -> bool:

--- a/swebench/specs.py
+++ b/swebench/specs.py
@@ -34,6 +34,7 @@ import shlex
 from pathlib import Path
 
 _SPECS_PATH = Path(__file__).resolve().parent / "data" / "official_specs.json"
+_REQS_PATHS_PATH = Path(__file__).resolve().parent / "data" / "official_reqs_paths.json"
 
 # `export KEY=VALUE` form of an eval_command (see `eval_env` below).
 _EVAL_EXPORT_RE = re.compile(r"^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
@@ -46,6 +47,17 @@ _FILE_PKG_SUFFIXES = (".txt", ".yml", ".yaml", ".cfg")
 def _load() -> dict:
     try:
         return json.loads(_SPECS_PATH.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+@functools.lru_cache(maxsize=1)
+def _load_reqs_paths() -> dict:
+    """The vendored requirements / environment.yml path maps (see
+    `scripts/extract_swebench_specs.py`). Separate file from the spec map so the
+    spec map stays byte-for-byte reproducible."""
+    try:
+        return json.loads(_REQS_PATHS_PATH.read_text())
     except (OSError, ValueError):
         return {}
 
@@ -228,14 +240,49 @@ def packages_kind(spec: dict) -> str:
 def packages_file(spec: dict) -> str | None:
     """For a ``requirements_txt`` / ``environment_yml`` spec, the referenced filename.
 
-    The builder reads this file from the repo checked out at
-    ``environment_setup_commit`` (which differs from ``base_commit`` and is
-    unreachable after history-stripping — read it before the strip). ``None`` for
-    inline / absent ``packages``.
+    NOTE: in the vendored data this is the *sentinel* string ``"requirements.txt"``
+    / ``"environment.yml"``, NOT a literal repo-root path — upstream resolves the
+    real path(s) via :func:`reqs_paths` / :func:`env_yml_paths` (e.g. flask's
+    ``"requirements.txt"`` → ``requirements/dev.txt``). The conda builder reads the
+    resolved file from the repo checked out at ``environment_setup_commit`` (which
+    differs from ``base_commit`` and is unreachable after history-stripping — read
+    it before the strip). ``None`` for inline / absent ``packages``.
     """
     if packages_kind(spec) in ("requirements_txt", "environment_yml"):
         return (spec.get("packages") or "").strip()
     return None
+
+
+# ---------------------------------------------------------------------------
+# Requirements / environment.yml path resolution (#311 P2-δ)
+#
+# A `packages` value of "requirements.txt" / "environment.yml" is an upstream
+# SWE-bench sentinel, not a literal file. The real path(s) come from these maps
+# (vendored in official_reqs_paths.json); the builder tries each in order and
+# reads the first that exists in the checked-out tree. See setup_conda_env.
+# ---------------------------------------------------------------------------
+
+def reqs_paths(repo_slug: str) -> list[str]:
+    """Candidate ``requirements.txt`` paths for *repo_slug*, in upstream order.
+
+    Empty if the repo isn't in the vendored ``MAP_REPO_TO_REQS_PATHS`` (then the
+    builder falls back to the literal ``packages`` filename for back-compat)."""
+    return list(_load_reqs_paths().get("reqs_paths", {}).get(repo_slug, []))
+
+
+def env_yml_paths(repo_slug: str) -> list[str]:
+    """Candidate ``environment.yml`` paths for *repo_slug*, in upstream order.
+
+    Empty if the repo isn't in the vendored ``MAP_REPO_TO_ENV_YML_PATHS`` (then the
+    builder falls back to the literal ``packages`` filename for back-compat)."""
+    return list(_load_reqs_paths().get("env_yml_paths", {}).get(repo_slug, []))
+
+
+def replace_req_packages() -> list[tuple[str, str]]:
+    """Upstream ``REPLACE_REQ_PACKAGES`` substitutions (yanked-package fixups,
+    e.g. ``types-pkg_resources`` → ``types-setuptools``) applied to resolved
+    requirements text. ``(old, new)`` pairs."""
+    return [(a, b) for a, b in _load_reqs_paths().get("replace_req_packages", [])]
 
 
 def conda_packages(spec: dict) -> list[str]:

--- a/tests/test_conda_build.py
+++ b/tests/test_conda_build.py
@@ -1,0 +1,96 @@
+"""Hermetic unit tests for the conda-native env builder (P2-γ, #311).
+
+Exercises the pure helpers, the guard logic, and the error paths of
+``harness.setup_conda_env`` without invoking micromamba or the network. The
+real end-to-end build is validated separately (manual P2-γ validation).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from swebench import harness
+from swebench.harness import (
+    CondaBuildError,
+    _conda_path_env,
+    _find_micromamba,
+    _UNSAFE_PRE_INSTALL_RE,
+    setup_conda_env,
+    setup_venv,
+)
+
+
+def test_find_micromamba_env_override(tmp_path: Path, monkeypatch) -> None:
+    fake = tmp_path / "micromamba"
+    fake.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("ONLYCODES_MICROMAMBA", str(fake))
+    assert _find_micromamba() == str(fake)
+
+
+def test_find_micromamba_override_ignored_if_missing(monkeypatch) -> None:
+    monkeypatch.setenv("ONLYCODES_MICROMAMBA", "/nonexistent/micromamba")
+    # Falls through to PATH / known locations (may be None in CI) — never the bad override.
+    assert _find_micromamba() != "/nonexistent/micromamba"
+
+
+def test_conda_path_env_prepends_bin_and_clears_activation(monkeypatch) -> None:
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setenv("PYTHONHOME", "/leak")
+    monkeypatch.setenv("VIRTUAL_ENV", "/leak/venv")
+    env = _conda_path_env("/opt/env")
+    assert env["PATH"].split(os.pathsep)[0] == "/opt/env/bin"
+    assert "PYTHONHOME" not in env
+    assert "VIRTUAL_ENV" not in env
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "apt-get update && apt-get install -y locales",
+        "sudo apt-get install -y imagemagick",
+        "locale-gen en_US.UTF-8",
+        "add-apt-repository ppa:foo/bar",
+        "  apt install build-essential",
+    ],
+)
+def test_unsafe_pre_install_matches_system_mutators(cmd: str) -> None:
+    assert _UNSAFE_PRE_INSTALL_RE.match(cmd)
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "sed -i 's/requires = \\[\"setuptools\",/requires = \\[\"setuptools==68.0.0\",/' pyproject.toml",
+        "echo 'en_US UTF-8' > /etc/locale.gen",
+        "python -m pip install -e .",
+    ],
+)
+def test_unsafe_pre_install_allows_safe_source_pins(cmd: str) -> None:
+    assert not _UNSAFE_PRE_INSTALL_RE.match(cmd)
+
+
+def test_setup_conda_env_raises_when_micromamba_absent(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(harness, "_find_micromamba", lambda: None)
+    with pytest.raises(CondaBuildError, match="micromamba not found"):
+        setup_conda_env(str(tmp_path / "env"), str(tmp_path), spec={"python": "3.9"})
+
+
+def test_setup_conda_env_raises_when_spec_has_no_python(tmp_path: Path) -> None:
+    # micromamba_bin is provided (exists) so we reach the python check.
+    with pytest.raises(CondaBuildError, match="no python"):
+        setup_conda_env(str(tmp_path / "env"), str(tmp_path), spec={}, micromamba_bin=sys.executable)
+
+
+def test_setup_venv_refuses_to_clobber_a_conda_env(tmp_path: Path) -> None:
+    # A dir carrying a conda sentinel must not be rebuilt as a venv (would rmtree it).
+    env = tmp_path / "venv"
+    env.mkdir()
+    (env / ".python_bin").write_text("conda:python3.9\n")
+    with pytest.raises(CondaBuildError, match="holds a conda env"):
+        setup_venv(str(env), str(tmp_path), python_bin="python3.11")
+    # The guard must fire BEFORE any deletion.
+    assert (env / ".python_bin").exists()

--- a/tests/test_conda_build.py
+++ b/tests/test_conda_build.py
@@ -58,6 +58,9 @@ def test_conda_path_env_prepends_bin_and_clears_activation(monkeypatch) -> None:
         "locale-gen en_US.UTF-8",
         "add-apt-repository ppa:foo/bar",
         "  apt install build-essential",
+        # redirects into root-owned system dirs need root (django py3.5 #311 P2-δ)
+        "echo 'en_US UTF-8' > /etc/locale.gen",
+        "echo 'deb ...' >> /etc/apt/sources.list",
     ],
 )
 def test_unsafe_pre_install_matches_system_mutators(cmd: str) -> None:
@@ -68,7 +71,8 @@ def test_unsafe_pre_install_matches_system_mutators(cmd: str) -> None:
     "cmd",
     [
         "sed -i 's/requires = \\[\"setuptools\",/requires = \\[\"setuptools==68.0.0\",/' pyproject.toml",
-        "echo 'en_US UTF-8' > /etc/locale.gen",
+        "echo 'x' > local_config.txt",          # redirect to a repo-relative file: safe
+        "python setup.py build > /dev/null",     # /dev is not a root-owned config dir
         "python -m pip install -e .",
     ],
 )

--- a/tests/test_conda_build.py
+++ b/tests/test_conda_build.py
@@ -18,7 +18,10 @@ from swebench.harness import (
     CondaBuildError,
     _conda_path_env,
     _find_micromamba,
+    _resolve_first_existing,
     _UNSAFE_PRE_INSTALL_RE,
+    resolve_env_yml_path,
+    resolve_requirements_text,
     setup_conda_env,
     setup_venv,
 )
@@ -94,3 +97,84 @@ def test_setup_venv_refuses_to_clobber_a_conda_env(tmp_path: Path) -> None:
         setup_venv(str(env), str(tmp_path), python_bin="python3.11")
     # The guard must fire BEFORE any deletion.
     assert (env / ".python_bin").exists()
+
+
+# ---------------------------------------------------------------------------
+# requirements.txt / environment.yml sentinel resolution (#311 P2-δ)
+# ---------------------------------------------------------------------------
+
+def test_resolve_first_existing(tmp_path: Path) -> None:
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "found.txt").write_text("x")
+    assert _resolve_first_existing(str(tmp_path), ["missing.txt", "a/found.txt"]) == (
+        "a/found.txt", str(tmp_path / "a" / "found.txt"),
+    )
+    assert _resolve_first_existing(str(tmp_path), ["nope.txt"]) is None
+
+
+def test_resolve_requirements_text_resolves_map_path_inlines_and_cleans(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # flask's real layout: the "requirements.txt" sentinel resolves to
+    # requirements/dev.txt, which `-r`-includes requirements/tests.txt.
+    monkeypatch.setattr(harness.specs, "reqs_paths",
+                        lambda repo: ["requirements/dev.txt"])
+    monkeypatch.setattr(harness.specs, "replace_req_packages",
+                        lambda: [("types-pkg_resources", "types-setuptools")])
+    reqdir = tmp_path / "requirements"
+    reqdir.mkdir()
+    (reqdir / "dev.txt").write_text(
+        "-r tests.txt\n"
+        "-e .\n"                       # editable self-install: excluded
+        "# a comment\n"                # comment: excluded
+        ".[test]\n"                    # extras ref: excluded
+        "flask==2.3.0\n"
+        "types-pkg_resources==0.1.3\n"  # yanked → replaced (version dropped)
+    )
+    (reqdir / "tests.txt").write_text("-e .\npytest==7.3.0\n")  # -e . excluded here too
+
+    text = resolve_requirements_text(str(tmp_path), "pallets/flask")
+    lines = [l for l in text.split("\n") if l.strip()]
+    assert "pytest==7.3.0" in lines           # inlined from the -r include
+    assert "flask==2.3.0" in lines
+    assert "types-setuptools" in lines        # replacement applied
+    assert not any(l.startswith("-e .") for l in lines)
+    assert not any(l.startswith("#") for l in lines)
+    assert not any("pkg_resources" in l for l in lines)
+    assert not any(l.startswith(".[test") for l in lines)
+
+
+def test_resolve_requirements_text_none_when_no_candidate(tmp_path: Path, monkeypatch) -> None:
+    # Repo not in the vendored map → no candidates → None (caller falls back).
+    monkeypatch.setattr(harness.specs, "reqs_paths", lambda repo: [])
+    assert resolve_requirements_text(str(tmp_path), "unknown/repo") is None
+    # In-map path but file absent → still None.
+    monkeypatch.setattr(harness.specs, "reqs_paths", lambda repo: ["requirements/dev.txt"])
+    assert resolve_requirements_text(str(tmp_path), "pallets/flask") is None
+
+
+def test_resolve_env_yml_path_prefers_map_order_then_literal(tmp_path: Path, monkeypatch) -> None:
+    # xarray-style: first map candidate is ci/requirements/environment.yml.
+    monkeypatch.setattr(harness.specs, "env_yml_paths",
+                        lambda repo: ["ci/requirements/environment.yml", "environment.yml"])
+    deep = tmp_path / "ci" / "requirements"
+    deep.mkdir(parents=True)
+    (deep / "environment.yml").write_text("name: x\n")
+    got = resolve_env_yml_path(str(tmp_path), "pydata/xarray", {"packages": "environment.yml"})
+    assert got == str(deep / "environment.yml")
+
+    # No map entry → fall back to the literal packages filename at repo root.
+    monkeypatch.setattr(harness.specs, "env_yml_paths", lambda repo: [])
+    (tmp_path / "environment.yml").write_text("name: y\n")
+    got2 = resolve_env_yml_path(str(tmp_path), "some/repo", {"packages": "environment.yml"})
+    assert got2 == str(tmp_path / "environment.yml")
+
+
+def test_vendored_reqs_paths_match_known_repos() -> None:
+    # Guard the vendored data against silent drift on regeneration.
+    from swebench import specs
+    assert specs.reqs_paths("pallets/flask") == ["requirements/dev.txt"]
+    assert specs.reqs_paths("django/django") == ["tests/requirements/py3.txt"]
+    assert specs.env_yml_paths("pydata/xarray")[0] == "ci/requirements/environment.yml"
+    assert specs.reqs_paths("psf/requests") == []   # inline repo, not in the map
+    assert ("types-pkg_resources", "types-setuptools") in specs.replace_req_packages()

--- a/tests/test_official_specs.py
+++ b/tests/test_official_specs.py
@@ -105,6 +105,50 @@ def test_eval_commands_and_no_use_env() -> None:
     assert specs.no_use_env({}) is False
 
 
+def test_eval_env_parses_exports_and_ignores_system_commands() -> None:
+    spec = {
+        "eval_commands": [
+            "export LANG=en_US.UTF-8",
+            "export PYTHONIOENCODING=utf8",
+            "  export LC_ALL=en_US.UTF-8  ",          # surrounding whitespace tolerated
+            "sed -i 's/x/y/' /etc/locale.gen && locale-gen",  # system-level: not env
+            "",                                        # blank dropped
+        ]
+    }
+    assert specs.eval_env(spec) == {
+        "LANG": "en_US.UTF-8",
+        "PYTHONIOENCODING": "utf8",
+        "LC_ALL": "en_US.UTF-8",
+    }
+    # The non-export command is surfaced separately so the caller can log the skip.
+    assert specs.eval_system_commands(spec) == [
+        "sed -i 's/x/y/' /etc/locale.gen && locale-gen"
+    ]
+    assert specs.eval_env({}) == {}
+    assert specs.eval_system_commands({}) == []
+
+
+def test_eval_env_strips_quotes_no_shell_expansion() -> None:
+    spec = {"eval_commands": ["export FOO='bar baz'", 'export QUX="q"', "export RAW=$HOME"]}
+    env = specs.eval_env(spec)
+    assert env["FOO"] == "bar baz"   # single quotes stripped
+    assert env["QUX"] == "q"         # double quotes stripped
+    assert env["RAW"] == "$HOME"     # left verbatim — no shell expansion
+
+
+def test_eval_env_real_vendored_django() -> None:
+    # Django specs carry the locale pins as export-style eval_commands; they must
+    # surface as a plain env dict for the Gate-2 collect (#311 P2-δ test fidelity).
+    m = specs._load()
+    dj = m["django/django"]["1.10"]
+    env = specs.eval_env(dj)
+    assert env.get("LANG") == "en_US.UTF-8"
+    assert env.get("LC_ALL") == "en_US.UTF-8"
+    assert env.get("LANGUAGE") == "en_US:en"
+    # Every value parsed is non-empty and quote-free.
+    assert all(v and "'" not in v and '"' not in v for v in env.values())
+
+
 def test_packages_kind_discrimination() -> None:
     assert specs.packages_kind({}) == "none"
     assert specs.packages_kind({"packages": "  "}) == "none"

--- a/tests/test_official_specs.py
+++ b/tests/test_official_specs.py
@@ -69,6 +69,87 @@ def test_vendored_map_nonempty() -> None:
 
 
 # --------------------------------------------------------------------------
+# Conda-native build accessors (P2-γ, #311)
+# --------------------------------------------------------------------------
+
+def test_conda_python_is_bare_version() -> None:
+    assert specs.conda_python({"python": "3.6"}) == "3.6"
+    assert specs.conda_python({"python": 3.9}) == "3.9"  # tolerate non-str
+    assert specs.conda_python({}) is None
+
+
+def test_install_command_verbatim() -> None:
+    spec = {"install": "python -m pip install -e .[test] --verbose"}
+    assert specs.install_command(spec) == "python -m pip install -e .[test] --verbose"
+    assert specs.install_command({}) is None
+    assert specs.install_command({"install": "   "}) is None
+
+
+def test_pre_install_commands_filters_blanks_keeps_order() -> None:
+    spec = {"pre_install": ["sed -i 's/a/b/' setup.py", "", "  ", "apt-get update"]}
+    assert specs.pre_install_commands(spec) == ["sed -i 's/a/b/' setup.py", "apt-get update"]
+    assert specs.pre_install_commands({}) == []
+
+
+def test_pip_packages_cleaned() -> None:
+    assert specs.pip_packages({"pip_packages": [" numpy==1.19.2 ", "", "pytest"]}) == [
+        "numpy==1.19.2", "pytest",
+    ]
+    assert specs.pip_packages({}) == []
+
+
+def test_eval_commands_and_no_use_env() -> None:
+    assert specs.eval_commands({"eval_commands": ["echo hi", ""]}) == ["echo hi"]
+    assert specs.eval_commands({}) == []
+    assert specs.no_use_env({"no_use_env": True}) is True
+    assert specs.no_use_env({}) is False
+
+
+def test_packages_kind_discrimination() -> None:
+    assert specs.packages_kind({}) == "none"
+    assert specs.packages_kind({"packages": "  "}) == "none"
+    assert specs.packages_kind({"packages": "requirements.txt"}) == "requirements_txt"
+    assert specs.packages_kind({"packages": "environment.yml"}) == "environment_yml"
+    assert specs.packages_kind({"packages": "environment.yaml"}) == "environment_yml"
+    assert specs.packages_kind({"packages": "numpy scipy 'pandas<2'"}) == "inline"
+
+
+def test_packages_file_only_for_file_refs() -> None:
+    assert specs.packages_file({"packages": "requirements.txt"}) == "requirements.txt"
+    assert specs.packages_file({"packages": "environment.yml"}) == "environment.yml"
+    assert specs.packages_file({"packages": "numpy scipy"}) is None
+    assert specs.packages_file({}) is None
+
+
+def test_conda_packages_unquotes_but_does_not_translate() -> None:
+    # Quotes stripped; conda single-'=' pins are NOT rewritten to '==' (conda syntax kept).
+    spec = {"packages": "'numpy==1.19.2' scipy 'pandas<2.0.0' setuptools=38.2.4"}
+    assert specs.conda_packages(spec) == [
+        "numpy==1.19.2", "scipy", "pandas<2.0.0", "setuptools=38.2.4",
+    ]
+    # File-ref / absent → no inline conda packages.
+    assert specs.conda_packages({"packages": "requirements.txt"}) == []
+    assert specs.conda_packages({}) == []
+
+
+def test_conda_accessors_against_real_vendored_data() -> None:
+    m = specs._load()
+    # astropy v5.3: the build-isolation-needing install line PR-1 broke.
+    ast = m["astropy/astropy"]["v5.3"]
+    assert specs.install_command(ast) == "python -m pip install -e .[test] --verbose"
+    assert specs.conda_python(ast) == "3.10"
+    # django uses a requirements.txt ref.
+    dj = next(iter(m["django/django"].values()))
+    assert specs.packages_kind(dj) == "requirements_txt"
+    assert specs.packages_file(dj) == "requirements.txt"
+    # matplotlib / xarray are the genuine conda-native (environment.yml) cases.
+    assert any(
+        specs.packages_kind(s) == "environment_yml"
+        for s in m["matplotlib/matplotlib"].values()
+    )
+
+
+# --------------------------------------------------------------------------
 # harness._venv_kwargs precedence: hand-tables > official-spec > default
 # --------------------------------------------------------------------------
 

--- a/tests/test_verified_validate.py
+++ b/tests/test_verified_validate.py
@@ -157,3 +157,54 @@ def test_write_summary_reports_shortfall(tmp_path: Path) -> None:
 def test_results_json_is_valid(tmp_path: Path) -> None:
     """Sanity: the record shape we write is JSON-serializable as-is."""
     json.dumps(_results())
+
+
+# --------------------------------------------------------------------------
+# conda-native wiring (#311 P2-δ): --conda flag, worker threading, report
+# --------------------------------------------------------------------------
+
+def test_conda_default_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ONLYCODES_CONDA_BUILD", raising=False)
+    assert vvs._conda_default() is False
+    for truthy in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("ONLYCODES_CONDA_BUILD", truthy)
+        assert vvs._conda_default() is True
+    for falsey in ("0", "no", "", "off"):
+        monkeypatch.setenv("ONLYCODES_CONDA_BUILD", falsey)
+        assert vvs._conda_default() is False
+
+
+@pytest.mark.parametrize("conda", [True, False])
+def test_worker_script_threads_conda_and_compiles(conda: bool) -> None:
+    """The per-instance worker template must embed the conda flag and compile
+    for both values — brace-escaping in the f-string-free .format() is fragile."""
+    code = vvs.WORKER_SCRIPT.format(
+        repo_root="/repo", yaml_path="/repo/x.yaml",
+        clone_base="/tmp/cb", force=False, conda=conda,
+    )
+    compile(code, "<worker>", "exec")
+    assert f"conda = {conda}" in code
+    # Gate 1 builds via the conda-aware path…
+    assert "_setup_one(problem, force=force, conda=conda)" in code
+    # …and Gate 2 layers the spec's eval_commands env over the hand-table.
+    assert "specs.eval_env(spec)" in code
+    assert "specs.eval_system_commands(spec)" in code
+    assert "_INSTANCE_ENV.get(iid)" in code
+
+
+def test_write_summary_notes_build_path(tmp_path: Path) -> None:
+    import datetime as dt
+    start = dt.datetime(2026, 6, 3, tzinfo=dt.timezone.utc)
+
+    venv_out = tmp_path / "venv.md"
+    vvs.write_summary(_results(), venv_out, set_name="swe/swebench-verified",
+                      start=start, pool_size=4, conda=False)
+    assert "Build path: **venv (generic)**" in venv_out.read_text()
+
+    conda_out = tmp_path / "conda.md"
+    vvs.write_summary(_results(), conda_out, set_name="swe/swebench-verified",
+                      start=start, pool_size=4, conda=True)
+    text = conda_out.read_text()
+    assert "conda-native (spec-faithful" in text
+    # the conda-only Gate-2 fidelity note is present
+    assert "eval_commands" in text and "locale-gen" in text


### PR DESCRIPTION
## WS-A.2.1 (#311) — conda-env-native Verified build (PR 2)

Builds SWE-bench Verified faithfully from the official `MAP_REPO_VERSION_TO_SPECS` (a conda env per (repo, version) via micromamba), replacing the generic venv + ~100 hand-curated fixups for this set.

> **Status — final.** This lands the conda-native build as a **complete, self-contained unit**. Per **[ADR-0004](docs/adr-0004-verified-docker-images.md)** (epic **#314**), Verified execution is migrating to **pulled prebuilt Docker images** for frozen reproducibility; this conda path is retained as the documented **fallback** (instances without a published image / custom tasks) and as the proven baseline the **#322** gold-patch gate measures. The original "full-500 buildable count" goal is **superseded by #314**, not abandoned.

### What landed
- **P2-α (overlay spike):** the production `venv_overlay` works unchanged on a conda env prefix (fuse backend) — feared overlay rework was ~zero.
- **P2-β (`b6808dc`):** full spec surface in `swebench/specs.py` (verbatim); pinned `swebench==4.1.0` extractor reproducing `official_specs.json` byte-for-byte.
- **P2-γ (`aaa19fa`):** `harness.setup_conda_env()` (micromamba create → packages-by-kind → pip → pre_install → verbatim install); `cache setup --conda`; `CondaBuildError` guard.
- **P2-δ:**
  - `ad0f9f2` — conda-aware `validate_verified_setup.py --conda` + `eval_commands` test fidelity (`specs.eval_env`); loud micromamba-absent preflight.
  - `5b318f2` — resolve `requirements.txt`/`environment.yml` **sentinels** via vendored `MAP_REPO_TO_REQS_PATHS`/`MAP_REPO_TO_ENV_YML_PATHS` (faithful `get_requirements` port). Fixed flask/django/xarray.
  - `b67b85e` — skip `pre_install` redirects into root-owned system dirs (django py3.5 `/etc/locale.gen`).

### Evidence
A stratified 38-instance coverage run (all 7 pythons, 4 packages-kinds, 12 repos) built **32/38** conda-native; the residual failures clustered into a few classes that turned out to be **structural** (conda-forge drift, no-root system deps) — the finding that motivated the image migration (full bug inventory + the 500/500-images-published verification are in #314 / the issue thread).

### Tests
Full suite `pytest tests/ -m "not integration"` → **862 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
