### PR TITLE
WS-C.3(#317): container runtime + per-arm reset (image arm)

### DIFF
--- a/docs/adr-0004-verified-docker-images.md
+++ b/docs/adr-0004-verified-docker-images.md
@@ -1,6 +1,7 @@
 # ADR 0004 — Run SWE-bench Verified from Official Prebuilt Docker Images
 
-**Status:** Accepted (pending the C2 de-risk spike — see Reversibility).
+**Status:** Accepted. C2 de-risk spike complete — **GO** (`docs/spike-c2-docker-images.md`,
+#316). C3 reset strategy decided (see below).
 **Date:** 2026-06-04.
 **Tracking issue:** [#314](https://github.com/hyang0129/onlycodes/issues/314).
 **Supersedes:** the *build half* of [#311](https://github.com/hyang0129/onlycodes/issues/311) / PR [#313](https://github.com/hyang0129/onlycodes/pull/313) (conda-native build) for Verified. Conda is retained as a fallback.
@@ -122,9 +123,17 @@ Decomposed into child issues on #314:
   and per-arm reset throughput — the numbers that decide C3's reset strategy and grid
   feasibility. Go/no-go before the rewrite.
 - **C3 (#317) — Container runtime + per-arm reset.** Pull/run/stop per instance; expose
-  `/testbed`; git-history strip inside; **reset strategy (fresh-container vs `docker commit`
-  snapshot vs checkpoint) is an open choice decided by C2's throughput numbers** — the
-  current overlay reset is fast; do not regress the grid blindly.
+  `/testbed`; git-history strip inside. **Reset strategy — DECIDED (settled by C2's numbers):
+  prepare-once + `docker commit` a stripped snapshot, then per-arm reset = fresh container
+  from that snapshot.** Rationale: the official image carries full upstream history (incl. the
+  fix), so the strip is mandatory; C2 measured strip at **~2.0 s** on matplotlib's 42k-commit
+  history (`git repack` dominates) vs. a fresh-container reset at **~286 ms**. Baking the strip
+  into the snapshot pays it **once per instance** instead of once per arm (×arms×seeds×500), and
+  a fresh container is pristine by construction — no in-place reset, no cross-arm leakage, and
+  no checkpoint/restore complexity. Delivered as `swebench/container.py`
+  (`prepare_instance`/`start_arm_container`/`reset_arm`/`exec_in`/`copy_in`/`copy_out`/`teardown`)
+  + `test_container_strip.py`; gated behind `--runtime image`. Files move by `docker cp`, **not
+  bind-mounts** (under DooD the `-v` source resolves on the docker host — C2 finding).
 - **C3b (#323) — Image + registry + disk management.** Pull-by-digest; Docker Hub
   rate-limits/auth/bandwidth (~1 TB for the set); optional registry mirror; prune/disk.
 - **C4 (#318) — In-container *Claude* agent execution.** Claude Code + the MCP exec-server
@@ -190,8 +199,8 @@ kill-switch, not an irreversible migration.
 
 ## Acceptance criteria (from #314)
 
-- [ ] C2 spike confirms a real pull + in-container agent turn + parsed test (go/no-go).
-- [ ] Container runtime with in-container git-strip and fresh-container per-arm reset (C3).
+- [x] C2 spike confirms a real pull + in-container agent turn + parsed test (go/no-go).
+- [x] Container runtime with in-container git-strip and fresh-container per-arm reset (C3).
 - [ ] Both arms run in-container with correct tool restriction + transcript capture (C4).
 - [ ] Official-parser grading + gold-patch fidelity gate + digest pinning (C5).
 - [ ] Image-vs-conda parity table + image-else-conda selection rule + docs updated (C6).

--- a/swebench/container.py
+++ b/swebench/container.py
@@ -237,6 +237,11 @@ def prepare_instance(
     Strip is the only per-instance cost paid here; per-arm resets
     (:func:`start_arm_container` / :func:`reset_arm`) inherit the stripped state
     for free.
+
+    Not concurrency-safe: two callers preparing the same instance would both
+    build + commit the snapshot (last commit wins). Harmless today — image mode
+    isn't wired into ``run.py``'s parallel loop yet — but C4 (#318) must serialise
+    prepare per instance (cf. ``cache.clone_bare_repo``'s per-slug lock).
     """
     base = base_image or official_image_for(instance_id)
     tag = prepared_tag(instance_id)

--- a/swebench/container.py
+++ b/swebench/container.py
@@ -1,0 +1,345 @@
+"""Container runtime for the Docker-image arm (epic #314 / ADR-0004, C3 #317).
+
+Image-arm analog of :mod:`swebench.cache`'s overlay backend.  Given an instance
+and its pinned official image, this module:
+
+* **prepares a per-instance snapshot** — start a container off the official
+  ``swebench/sweb.eval.*`` image, strip ``/testbed``'s git history (the
+  onlycodes invariant — the agent must not recover the reference fix via
+  ``git log``), then ``docker commit`` to ``onlycodes/prepared:<instance_id>``.
+  Strip is paid **once** here, not per arm (C2 #316 measured ~2 s on
+  matplotlib's 42k-commit history — see ``docs/spike-c2-docker-images.md``).
+* **starts a fresh container per arm** from that snapshot — pristine and
+  already-stripped, in ~286 ms (the per-arm reset chosen in C2).  This is the
+  image-world analog of ``_refresh_overlay``.
+* **moves files in/out via** ``docker cp`` — *not* bind-mounts: under
+  Docker-outside-of-Docker the ``-v`` source resolves on the docker host, not
+  this dev container (C2 finding).
+
+It shells out to the ``docker`` CLI via :mod:`subprocess`, consistent with
+:mod:`swebench.harness`'s git/pip wrappers (no ``docker-py`` dependency).  The
+daemon is reached however ``DOCKER_HOST`` / the socket is configured —
+daemon-agnostic, matching the SWE-bench harness.
+
+Scope (C3): hand back a ready container with a stripped ``/testbed`` plus the
+per-arm reset.  Registry/pull/disk-LRU is C3b (#323); agent execution is C4
+(#318); test execution is C5 (#319).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+
+
+# --------------------------------------------------------------------------
+# Errors + docker CLI wrapper
+# --------------------------------------------------------------------------
+
+class ContainerError(RuntimeError):
+    """A docker CLI invocation failed, or the runtime is misconfigured."""
+
+
+def _docker_bin() -> str:
+    """The docker CLI to invoke. Overridable for tests via ``ONLYCODES_DOCKER``."""
+    return os.environ.get("ONLYCODES_DOCKER", "docker")
+
+
+def _docker(
+    args: list[str],
+    *,
+    check: bool = True,
+    timeout: float | None = None,
+    input_bytes: bytes | None = None,
+) -> subprocess.CompletedProcess:
+    """Run ``docker <args>``; raise :class:`ContainerError` on non-zero unless
+    ``check=False``.  Binary-safe (``capture_output`` without text decoding) so
+    callers that pipe tar streams through ``docker cp -`` are not corrupted."""
+    cmd = [_docker_bin(), *args]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        input=input_bytes,
+        timeout=timeout,
+    )
+    if check and proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", "replace") if proc.stderr else ""
+        raise ContainerError(
+            f"`docker {' '.join(args)}` failed (exit {proc.returncode}): {stderr.strip()}"
+        )
+    return proc
+
+
+def _decode(proc: subprocess.CompletedProcess) -> str:
+    out = proc.stdout
+    return out.decode("utf-8", "replace").strip() if out else ""
+
+
+# --------------------------------------------------------------------------
+# Image / tag naming
+# --------------------------------------------------------------------------
+
+#: Token SWE-bench substitutes for the ``__`` instance-id separator in image
+#: names (so ``a__b`` -> ``a_1776_b``).  Fixed upstream constant.
+_NAMESPACE_TOKEN = "_1776_"
+
+
+def official_image_for(instance_id: str) -> str:
+    """The published SWE-bench eval image for an instance.
+
+    ``matplotlib__matplotlib-22865`` ->
+    ``swebench/sweb.eval.x86_64.matplotlib_1776_matplotlib-22865:latest``.
+    """
+    slug = instance_id.lower().replace("__", _NAMESPACE_TOKEN)
+    return f"swebench/sweb.eval.x86_64.{slug}:latest"
+
+
+def prepared_tag(instance_id: str) -> str:
+    """Local tag for the stripped per-instance snapshot.
+
+    Docker tags allow ``[A-Za-z0-9_.-]`` (<=128 chars); instance ids fit as-is.
+    """
+    return f"onlycodes/prepared:{instance_id}"
+
+
+# --------------------------------------------------------------------------
+# Handles
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PreparedImage:
+    """A per-instance snapshot whose ``/testbed`` history is already stripped."""
+
+    instance_id: str
+    base_image: str       # the official swebench image it was derived from
+    snapshot_tag: str     # onlycodes/prepared:<instance_id>
+
+
+@dataclass(frozen=True)
+class ContainerHandle:
+    """A running container started from a :class:`PreparedImage` snapshot."""
+
+    instance_id: str
+    container_id: str
+    snapshot_tag: str
+    testbed: str = "/testbed"
+
+
+# --------------------------------------------------------------------------
+# Image presence / pull (thin — registry/disk policy is C3b #323)
+# --------------------------------------------------------------------------
+
+def image_present(ref: str) -> bool:
+    """True if ``ref`` is a locally available image."""
+    proc = _docker(["image", "inspect", ref], check=False)
+    return proc.returncode == 0
+
+
+def pull_image(ref: str, *, timeout: float | None = 1800) -> None:
+    """Pull ``ref`` if not already local.  A no-op when present.
+
+    Heavy registry/disk handling (prefetch, LRU, parallelism) is C3b (#323);
+    this is the minimal helper C3's prepare step and the integration test need.
+    """
+    if image_present(ref):
+        return
+    _docker(["pull", ref], timeout=timeout)
+
+
+# --------------------------------------------------------------------------
+# Git-history strip inside /testbed (port of harness.strip_git_history)
+# --------------------------------------------------------------------------
+
+#: Strip script run inside the container.  Mirrors the 8-step procedure in
+#: ``harness.strip_git_history`` (orphan commit -> drop every other ref ->
+#: delete reflog -> repack -> drop alternates -> gc --prune=now), executed via
+#: ``docker exec bash``.  The image's ``/testbed`` owns its ``.git`` (no shared
+#: bare repo), so the alternates step is a harmless no-op.  Author/committer
+#: identity is pinned so the orphan SHA is deterministic (idempotent re-runs).
+_STRIP_SCRIPT = r"""
+set -eu
+cd "$1"
+export GIT_AUTHOR_NAME=swebench GIT_AUTHOR_EMAIL=swebench@localhost
+export GIT_AUTHOR_DATE="1970-01-01T00:00:00+0000"
+export GIT_COMMITTER_NAME=swebench GIT_COMMITTER_EMAIL=swebench@localhost
+export GIT_COMMITTER_DATE="1970-01-01T00:00:00+0000"
+TREE=$(git rev-parse HEAD^{tree})
+NEW=$(git commit-tree "$TREE" -m base)
+CUR=$(git symbolic-ref -q HEAD || true)
+if [ -n "$CUR" ]; then
+    mkdir -p "$(dirname ".git/$CUR")"
+    printf '%s\n' "$NEW" > ".git/$CUR"
+else
+    git update-ref --no-deref HEAD "$NEW"
+fi
+git for-each-ref --format='%(refname)' | while IFS= read -r ref; do
+    [ "$ref" = "$CUR" ] || git update-ref -d "$ref" 2>/dev/null || true
+done
+rm -f .git/packed-refs
+rm -rf .git/logs
+git repack -a -d -q
+rm -f .git/objects/info/alternates
+git gc --prune=now --quiet
+"""
+
+
+def strip_testbed(container_id: str, testbed: str = "/testbed") -> None:
+    """Collapse ``testbed``'s git history to a single orphan commit, in-container.
+
+    Post-condition (verified by ``tests/test_container_strip.py``, mirroring
+    ``test_harness_strip.py``): ``git rev-list --all --count`` == 1, the orphan
+    has no parents, and ``.git/logs`` / ``packed-refs`` / ``alternates`` are gone.
+    """
+    _docker(
+        ["exec", container_id, "bash", "-c", _STRIP_SCRIPT, "strip", testbed],
+        check=True,
+    )
+
+
+# --------------------------------------------------------------------------
+# Prepare (once per instance) -> snapshot
+# --------------------------------------------------------------------------
+
+# Standard SWE-bench eval-container args: privileged-ish (unshare -n for the
+# exec-server needs CAP_SYS_ADMIN — confirmed working in C2), root user, and a
+# no-op foreground command so the container stays up for `docker exec`.
+_RUN_ARGS = ["--cap-add=SYS_ADMIN", "--user", "root"]
+_IDLE_CMD = ["tail", "-f", "/dev/null"]
+
+
+def _run_detached(image: str, *, name: str | None = None) -> str:
+    args = ["run", "-d", *_RUN_ARGS]
+    if name:
+        args += ["--name", name]
+    args += [image, *_IDLE_CMD]
+    return _decode(_docker(args))
+
+
+def _rm_force(container_id: str) -> None:
+    _docker(["rm", "-f", container_id], check=False)
+
+
+def prepare_instance(
+    instance_id: str,
+    *,
+    base_image: str | None = None,
+    testbed: str = "/testbed",
+    force: bool = False,
+) -> PreparedImage:
+    """Build (or reuse) the stripped per-instance snapshot image.
+
+    Idempotent: if ``onlycodes/prepared:<instance_id>`` already exists and
+    ``force`` is False, returns it without rebuilding.  Otherwise: ensure the
+    base image is present, start a prep container, strip ``/testbed``, commit the
+    snapshot, and remove the prep container.
+
+    Strip is the only per-instance cost paid here; per-arm resets
+    (:func:`start_arm_container` / :func:`reset_arm`) inherit the stripped state
+    for free.
+    """
+    base = base_image or official_image_for(instance_id)
+    tag = prepared_tag(instance_id)
+
+    if not force and image_present(tag):
+        return PreparedImage(instance_id=instance_id, base_image=base, snapshot_tag=tag)
+
+    pull_image(base)
+    prep = _run_detached(base)
+    try:
+        strip_testbed(prep, testbed)
+        # Commit the stripped worktree as the snapshot.  --pause keeps the fs
+        # quiescent during commit (the idle container writes nothing, but be
+        # explicit).  The committed layer mostly *shrinks* .git (repack+gc),
+        # so the snapshot adds little on top of the shared base layers.
+        _docker(["commit", "--pause", prep, tag])
+    finally:
+        _rm_force(prep)
+
+    return PreparedImage(instance_id=instance_id, base_image=base, snapshot_tag=tag)
+
+
+# --------------------------------------------------------------------------
+# Per-arm container lifecycle
+# --------------------------------------------------------------------------
+
+def start_arm_container(
+    prepared: PreparedImage, *, name: str | None = None
+) -> ContainerHandle:
+    """Start a fresh container from the prepared snapshot.
+
+    The container's ``/testbed`` is pristine and already history-stripped (it
+    was stripped into the snapshot at prepare time).  ~286 ms in C2.
+    """
+    cid = _run_detached(prepared.snapshot_tag, name=name)
+    return ContainerHandle(
+        instance_id=prepared.instance_id,
+        container_id=cid,
+        snapshot_tag=prepared.snapshot_tag,
+    )
+
+
+def reset_arm(handle: ContainerHandle, *, name: str | None = None) -> ContainerHandle:
+    """Reset between arms: discard the current container and start a fresh one
+    from the same snapshot.  Returns a NEW handle (the old ``container_id`` is
+    dead) — mirrors ``_refresh_overlay`` returning a refreshed handle.
+
+    Chosen reset strategy (C3 #317, settled by C2's numbers): fresh container
+    from the stripped snapshot.  Pristine by construction, no in-place reset, no
+    cross-arm state leakage, no per-arm re-strip.
+    """
+    _rm_force(handle.container_id)
+    prepared = PreparedImage(
+        instance_id=handle.instance_id,
+        base_image="",  # not needed for a restart; snapshot already exists
+        snapshot_tag=handle.snapshot_tag,
+    )
+    return start_arm_container(prepared, name=name)
+
+
+def teardown(handle: ContainerHandle) -> None:
+    """Remove the arm container.  Best-effort; never raises."""
+    _rm_force(handle.container_id)
+
+
+# --------------------------------------------------------------------------
+# Exec + file movement (docker cp, never bind-mounts — C2 finding)
+# --------------------------------------------------------------------------
+
+def exec_in(
+    handle: ContainerHandle,
+    command: list[str],
+    *,
+    workdir: str | None = None,
+    user: str | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess:
+    """Run ``command`` inside the arm container via ``docker exec``.
+
+    Returns the raw :class:`~subprocess.CompletedProcess` (bytes stdout/stderr)
+    so callers (C4 agent invocation, C5 test execution) can stream/parse as
+    needed.  ``check=False`` to inspect non-zero exits (e.g. failing tests).
+    """
+    args = ["exec"]
+    if workdir:
+        args += ["-w", workdir]
+    if user:
+        args += ["-u", user]
+    for k, v in (env or {}).items():
+        args += ["-e", f"{k}={v}"]
+    args += [handle.container_id, *command]
+    return _docker(args, check=check, timeout=timeout)
+
+
+def copy_in(handle: ContainerHandle, src_host: str, dst_container: str) -> None:
+    """Copy a host path into the container (``docker cp``).  Used instead of
+    bind-mounts, which under DooD resolve on the docker host (C2 finding)."""
+    _docker(["cp", src_host, f"{handle.container_id}:{dst_container}"])
+
+
+def copy_out(handle: ContainerHandle, src_container: str, dst_host: str) -> None:
+    """Copy a path out of the container to the host (``docker cp``).  This is how
+    the agent JSONL transcript and test output reach the host."""
+    _docker(["cp", f"{handle.container_id}:{src_container}", dst_host])

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -850,6 +850,39 @@ def _parse_filter_ids(filter_spec: str) -> set[str]:
     return {s.strip() for s in spec.split(",") if s.strip()}
 
 
+def _run_image_runtime_preflight() -> None:
+    """Handle ``--runtime image`` for C3 (#317).
+
+    The container runtime (``swebench.container``) is built and tested, but a
+    full arm needs C3b's pull/disk policy (#323) and C4/C5's agent + test
+    execution (#318/#319).  Until those land, image mode does a real Docker
+    preflight and reports the runtime is ready, rather than running a partial
+    arm through the overlay-centric loop.
+    """
+    from swebench import container
+
+    proc = container._docker(["version", "--format", "{{.Server.Version}}"], check=False)
+    if proc.returncode != 0:
+        click.echo(
+            "ERROR: --runtime image needs a reachable Docker daemon "
+            "(DooD: the host socket must be mounted). `docker version` failed.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    server = proc.stdout.decode("utf-8", "replace").strip()
+    click.echo(f"Image runtime: Docker daemon reachable (server {server}).")
+    click.echo(
+        "Container layer ready (C3 #317): prepare_instance -> stripped snapshot, "
+        "per-arm reset = fresh container from the snapshot (~286 ms, measured in "
+        "C2 #316)."
+    )
+    click.echo(
+        "Not yet wired for a full arm: pull/disk policy is C3b (#323); agent + "
+        "test execution are C4/C5 (#318/#319). Use --runtime overlay to run."
+    )
+
+
 @click.command("run")
 @click.option(
     "--filter",
@@ -1009,6 +1042,22 @@ def _parse_filter_ids(filter_spec: str) -> set[str]:
         "this is a known follow-up."
     ),
 )
+@click.option(
+    "--runtime",
+    "runtime",
+    type=click.Choice(["overlay", "image"]),
+    default="overlay",
+    show_default=True,
+    help=(
+        "Environment backend. 'overlay' (default): clone + cache + per-arm "
+        "fuse-overlayfs on the host (the established path). 'image': run inside "
+        "the official prebuilt SWE-bench Docker images, resetting per arm from a "
+        "stripped snapshot container (ADR-0004, epic #314). The 'image' runtime "
+        "container layer is C3 (#317); pull/disk policy is C3b (#323) and agent + "
+        "test execution are C4/C5 (#318/#319), so selecting it today reports "
+        "readiness and exits rather than running a full arm."
+    ),
+)
 def run_command(
     filter_ids: str | None,
     arms: str,
@@ -1025,11 +1074,16 @@ def run_command(
     max_wall_seconds: int,
     cache_isolation: bool,
     venv_isolation: bool,
+    runtime: str,
 ) -> None:
     """Run SWE-bench evaluation arms on problem instances."""
     if parallel < 1:
         click.echo("ERROR: --parallel must be >= 1", err=True)
         raise SystemExit(1)
+
+    if runtime == "image":
+        _run_image_runtime_preflight()
+        return
 
     root = repo_root()
     problems_dir = root / "problems" / "swe"

--- a/tests/test_container_strip.py
+++ b/tests/test_container_strip.py
@@ -1,0 +1,261 @@
+"""Tests for the C3 container runtime (``swebench/container.py``, #317).
+
+Two layers:
+
+* **Hermetic** — the pure naming helpers (``official_image_for`` /
+  ``prepared_tag``), no Docker required.
+* **``@integration``** — the real container surface: strip ``/testbed`` git
+  history inside a container (mirrors ``test_harness_strip.py``'s guarantees:
+  single orphan, no reflog/packed-refs, clean tree, idempotent, detached HEAD),
+  and the full ``prepare -> start -> reset -> teardown`` lifecycle.
+
+The integration tests need a Docker daemon and one already-present SWE-bench
+image; they **skip** (never pull multi-GB images in CI) when either is absent.
+Override the image with ``ONLYCODES_TEST_IMAGE`` (default: the requests image,
+the smallest in the published set).  They build their git repo at a throwaway
+path, never touching a real ``/testbed`` snapshot, and clean up any container /
+snapshot image they create.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+
+import pytest
+
+from swebench import container
+from swebench.container import (
+    ContainerHandle,
+    PreparedImage,
+    official_image_for,
+    prepared_tag,
+)
+
+
+# --------------------------------------------------------------------------
+# Hermetic: naming helpers
+# --------------------------------------------------------------------------
+
+def test_official_image_for_maps_double_underscore_to_token() -> None:
+    assert official_image_for("matplotlib__matplotlib-22865") == (
+        "swebench/sweb.eval.x86_64.matplotlib_1776_matplotlib-22865:latest"
+    )
+    # Mixed case is lowercased (registry refs are lowercase).
+    assert official_image_for("PSF__Requests-1142") == (
+        "swebench/sweb.eval.x86_64.psf_1776_requests-1142:latest"
+    )
+
+
+def test_prepared_tag_is_local_and_carries_instance_id() -> None:
+    tag = prepared_tag("django__django-10097")
+    assert tag == "onlycodes/prepared:django__django-10097"
+    # Repo:tag split is unambiguous and the tag part is a legal docker tag.
+    repo, _, tagpart = tag.partition(":")
+    assert repo == "onlycodes/prepared"
+    assert len(tagpart) <= 128 and all(c.isalnum() or c in "_.-" for c in tagpart)
+
+
+# --------------------------------------------------------------------------
+# Integration scaffolding
+# --------------------------------------------------------------------------
+
+def _docker_available() -> bool:
+    try:
+        return subprocess.run(
+            ["docker", "version"], capture_output=True, timeout=15
+        ).returncode == 0
+    except Exception:
+        return False
+
+
+def _test_image() -> str:
+    return os.environ.get(
+        "ONLYCODES_TEST_IMAGE",
+        "swebench/sweb.eval.x86_64.psf_1776_requests-1142:latest",
+    )
+
+
+def _image_present(ref: str) -> bool:
+    return container.image_present(ref)
+
+
+# Docker tests are both slow/stateful (``integration`` — excluded by CI's
+# ``pytest -m "not integration"``) and require a live daemon (``skipif``).
+def requires_docker(fn):
+    fn = pytest.mark.integration(fn)
+    return pytest.mark.skipif(
+        not _docker_available(), reason="docker daemon not available"
+    )(fn)
+
+
+@pytest.fixture()
+def base_image() -> str:
+    img = _test_image()
+    if not _image_present(img):
+        pytest.skip(f"test image not present locally: {img} (set ONLYCODES_TEST_IMAGE)")
+    return img
+
+
+@pytest.fixture()
+def throwaway_container(base_image: str):
+    """A running container off the test image; removed on teardown."""
+    cid = container._run_detached(base_image)
+    handle = ContainerHandle(
+        instance_id="test__instance",
+        container_id=cid,
+        snapshot_tag=base_image,
+    )
+    try:
+        yield handle
+    finally:
+        container._rm_force(cid)
+
+
+# Build a multi-commit repo (3 commits on main + feature branch + tag + remote
+# ref + reflog) at $1 inside the container — the container analog of
+# test_harness_strip.py:_make_repo.
+_MAKE_REPO = r"""
+set -eu
+d="$1"
+rm -rf "$d"; mkdir -p "$d"; cd "$d"
+git init -q -b main
+git config user.email test@test; git config user.name test
+echo one > a.txt; git add a.txt; git commit -q -m "commit one"
+echo two > a.txt; git add a.txt; git commit -q -m "commit two -- REFERENCE FIX"
+echo three > b.txt; git add b.txt; git commit -q -m "commit three"
+git branch feature
+git checkout -q feature; echo feat > c.txt; git add c.txt; git commit -q -m "feature work"
+git checkout -q main
+git tag -a v1.0 HEAD~1 -m release
+git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)"
+"""
+
+
+def _exec(handle: ContainerHandle, *cmd: str, workdir: str | None = None) -> str:
+    proc = container.exec_in(handle, list(cmd), workdir=workdir, check=True)
+    return proc.stdout.decode("utf-8", "replace").strip()
+
+
+# --------------------------------------------------------------------------
+# Integration: strip_testbed mirrors the host strip guarantees
+# --------------------------------------------------------------------------
+
+@requires_docker
+def test_strip_testbed_leaves_single_orphan_clean_and_reflogless(throwaway_container):
+    h = throwaway_container
+    repo = "/tmp/striprepo"
+    container.exec_in(h, ["bash", "-c", _MAKE_REPO, "mk", repo], check=True)
+
+    pre_tree = _exec(h, "git", "rev-parse", "HEAD^{tree}", workdir=repo)
+    container.strip_testbed(h.container_id, repo)
+
+    # Exactly one reachable commit, with no parents.
+    assert _exec(h, "git", "rev-list", "--all", "--count", workdir=repo) == "1"
+    parents = _exec(h, "git", "rev-list", "--parents", "-n", "1", "HEAD", workdir=repo)
+    assert len(parents.split()) == 1, f"orphan should have no parents: {parents!r}"
+
+    # Tree (worktree content) preserved.
+    assert _exec(h, "git", "rev-parse", "HEAD^{tree}", workdir=repo) == pre_tree
+
+    # Branches/tags/remotes gone — only the current branch survives.
+    refs = _exec(h, "git", "for-each-ref", "--format=%(refname)", workdir=repo)
+    assert [r for r in refs.splitlines() if r.strip()] == ["refs/heads/main"]
+    assert _exec(h, "git", "tag", "-l", workdir=repo) == ""
+
+    # Reflog gone; if gc regenerated packed-refs it may only name the orphan.
+    assert container.exec_in(
+        h, ["test", "-d", f"{repo}/.git/logs"], check=False
+    ).returncode != 0, "reflog dir must be removed"
+
+    # Working tree clean; an agent can still commit on top of the orphan.
+    assert _exec(h, "git", "status", "--porcelain", workdir=repo) == ""
+    container.exec_in(h, ["bash", "-c", f"cd {repo} && echo hi > agent.txt"], check=True)
+    _exec(h, "git", "add", "agent.txt", workdir=repo)
+    container.exec_in(
+        h,
+        ["git", "-c", "user.email=a@a", "-c", "user.name=a", "commit", "-q", "-m", "agent"],
+        workdir=repo,
+        check=True,
+    )
+    assert _exec(h, "git", "rev-list", "--all", "--count", workdir=repo) == "2"
+
+
+@requires_docker
+def test_strip_testbed_is_idempotent(throwaway_container):
+    h = throwaway_container
+    repo = "/tmp/striprepo2"
+    container.exec_in(h, ["bash", "-c", _MAKE_REPO, "mk", repo], check=True)
+
+    container.strip_testbed(h.container_id, repo)
+    first = _exec(h, "git", "rev-parse", "HEAD", workdir=repo)
+    container.strip_testbed(h.container_id, repo)
+    second = _exec(h, "git", "rev-parse", "HEAD", workdir=repo)
+
+    assert _exec(h, "git", "rev-list", "--all", "--count", workdir=repo) == "1"
+    assert first == second, "orphan SHA must be deterministic (fixed author/date)"
+
+
+@requires_docker
+def test_strip_testbed_handles_detached_head(throwaway_container):
+    h = throwaway_container
+    repo = "/tmp/striprepo3"
+    container.exec_in(h, ["bash", "-c", _MAKE_REPO, "mk", repo], check=True)
+    container.exec_in(h, ["git", "checkout", "-q", "HEAD~1"], workdir=repo, check=True)
+
+    container.strip_testbed(h.container_id, repo)
+
+    assert _exec(h, "git", "rev-list", "--all", "--count", workdir=repo) == "1"
+    _exec(h, "git", "rev-parse", "HEAD", workdir=repo)  # HEAD resolves
+
+
+# --------------------------------------------------------------------------
+# Integration: prepare -> start -> reset -> teardown lifecycle
+# --------------------------------------------------------------------------
+
+@requires_docker
+def test_prepare_start_reset_teardown_lifecycle(base_image):
+    # Derive the instance id from the test image so prepare_instance resolves
+    # the same base image (and a real /testbed history to strip).
+    # swebench/sweb.eval.x86_64.<slug>:latest  ->  slug -> instance_id.
+    slug = base_image.split("sweb.eval.x86_64.", 1)[1].rsplit(":", 1)[0]
+    instance_id = slug.replace(container._NAMESPACE_TOKEN, "__")
+    snapshot = prepared_tag(instance_id)
+
+    # Unique throwaway snapshot so we never collide with / clobber a real one.
+    uniq = f"{snapshot}-test-{uuid.uuid4().hex[:8]}"
+    handle = None
+    try:
+        prepared = container.prepare_instance(instance_id, force=True)
+        assert prepared.snapshot_tag == snapshot
+        assert container.image_present(snapshot)
+
+        handle = container.start_arm_container(prepared)
+        # /testbed in the started container is already stripped (single orphan).
+        count = _exec(
+            ContainerHandle(instance_id, handle.container_id, snapshot, "/testbed"),
+            "git", "rev-list", "--all", "--count", workdir="/testbed",
+        )
+        assert count == "1", f"/testbed should be a single orphan, got {count}"
+
+        first_cid = handle.container_id
+        handle = container.reset_arm(handle)
+        assert handle.container_id != first_cid, "reset must yield a fresh container"
+        # Old container is gone.
+        assert container.exec_in(
+            ContainerHandle(instance_id, first_cid, snapshot),
+            ["true"], check=False,
+        ).returncode != 0
+        # Fresh container's /testbed is still a single orphan.
+        assert _exec(handle, "git", "rev-list", "--all", "--count", workdir="/testbed") == "1"
+
+        container.teardown(handle)
+        assert container.exec_in(handle, ["true"], check=False).returncode != 0
+        handle = None
+    finally:
+        if handle is not None:
+            container.teardown(handle)
+        # Remove the snapshot image we built so the test leaves no disk residue.
+        subprocess.run(["docker", "rmi", "-f", snapshot], capture_output=True)
+        subprocess.run(["docker", "rmi", "-f", uniq], capture_output=True)

--- a/tests/test_container_strip.py
+++ b/tests/test_container_strip.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import uuid
 
 import pytest
 
@@ -223,8 +222,12 @@ def test_prepare_start_reset_teardown_lifecycle(base_image):
     instance_id = slug.replace(container._NAMESPACE_TOKEN, "__")
     snapshot = prepared_tag(instance_id)
 
-    # Unique throwaway snapshot so we never collide with / clobber a real one.
-    uniq = f"{snapshot}-test-{uuid.uuid4().hex[:8]}"
+    # prepare_instance derives the snapshot tag from the instance id, so the
+    # test necessarily uses the canonical tag — and its cleanup `rmi`s it. Skip
+    # rather than rebuild+delete a snapshot a real run may have prepared.
+    if container.image_present(snapshot):
+        pytest.skip(f"would clobber an existing snapshot: {snapshot}")
+
     handle = None
     try:
         prepared = container.prepare_instance(instance_id, force=True)
@@ -258,4 +261,3 @@ def test_prepare_start_reset_teardown_lifecycle(base_image):
             container.teardown(handle)
         # Remove the snapshot image we built so the test leaves no disk residue.
         subprocess.run(["docker", "rmi", "-f", snapshot], capture_output=True)
-        subprocess.run(["docker", "rmi", "-f", uniq], capture_output=True)


### PR DESCRIPTION
Closes #317. Part of epic #314 (ADR-0004). Builds on the C2 spike (#316).

## What this delivers
The image-arm analog of `cache.py`'s overlay backend — a container runtime that, given an instance, hands back a ready container with a **history-stripped `/testbed`**, plus the per-arm reset.

New `swebench/container.py`:
- `prepare_instance` — pull base image → strip `/testbed` git history → `docker commit` a per-instance snapshot (`onlycodes/prepared:<id>`). Idempotent.
- `start_arm_container` / `reset_arm` — fresh container from the snapshot (pristine, already stripped).
- `exec_in`, `copy_in` / `copy_out` (via `docker cp`, **not** bind-mounts), `teardown`.
- `strip_testbed` — ports `strip_git_history` to run via `docker exec` (same orphan / no-reflog guarantees).

## Reset strategy — DECIDED (settled by C2's numbers)
**Prepare-once + `docker commit` snapshot; per-arm reset = fresh container from the snapshot.**

The official images carry full upstream history *including the fix commit*, so stripping is mandatory. Measured on matplotlib's 42,746-commit history:
| Op | Cost |
|---|---|
| Strip (`repack` + `gc`) | **~2.0 s** |
| Fresh-container reset | **~286 ms** |

Baking the strip into the snapshot pays it **once per instance**, not once per arm (×arms×seeds×500). A fresh container is pristine by construction — no in-place reset, no cross-arm leakage, no checkpoint/restore complexity.

## Tests
`tests/test_container_strip.py`:
- **Hermetic** (run in CI): naming helpers `official_image_for` / `prepared_tag`.
- **`@integration`** (skip without Docker): in-container strip mirrors `test_harness_strip.py` (single orphan, no reflog/packed-refs, clean tree, idempotent, detached HEAD) + a full `prepare → start → reset → teardown` lifecycle asserting `/testbed` is a single orphan in both the started and reset container.

Locally: **864 hermetic pass**, **4 live integration pass**.

## CLI
`--runtime overlay|image` added to `run`. `image` does a Docker preflight and reports the container layer is ready; a full arm still needs C3b (#323 pull/disk policy) + C4/C5 (#318/#319 agent + test execution), so it doesn't run a partial arm through the overlay-centric loop.

## Scope boundary
Registry/pull/disk-LRU → C3b #323 · agent exec → C4 #318 · test exec → C5 #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)