### PR TITLE
WS-C.4(#318): in-container Claude agent execution

### DIFF
--- a/swebench/container.py
+++ b/swebench/container.py
@@ -208,10 +208,18 @@ _RUN_ARGS = ["--cap-add=SYS_ADMIN", "--user", "root"]
 _IDLE_CMD = ["tail", "-f", "/dev/null"]
 
 
-def _run_detached(image: str, *, name: str | None = None) -> str:
+def _run_detached(
+    image: str, *, name: str | None = None, volumes: list[str] | None = None
+) -> str:
+    """Start a detached idle container.  ``volumes`` are raw ``docker -v`` specs
+    (e.g. ``"onlycodes-agent-rt:/opt/agent:ro"``) — used by C4 to mount the
+    shared agent runtime.  Named volumes live in the daemon, so they are immune
+    to the DooD bind-mount-resolves-on-host problem (C2)."""
     args = ["run", "-d", *_RUN_ARGS]
     if name:
         args += ["--name", name]
+    for spec in volumes or []:
+        args += ["-v", spec]
     args += [image, *_IDLE_CMD]
     return _decode(_docker(args))
 
@@ -226,17 +234,26 @@ def prepare_instance(
     base_image: str | None = None,
     testbed: str = "/testbed",
     force: bool = False,
+    post_strip_exec: list[list[str]] | None = None,
 ) -> PreparedImage:
     """Build (or reuse) the stripped per-instance snapshot image.
 
     Idempotent: if ``onlycodes/prepared:<instance_id>`` already exists and
     ``force`` is False, returns it without rebuilding.  Otherwise: ensure the
-    base image is present, start a prep container, strip ``/testbed``, commit the
-    snapshot, and remove the prep container.
+    base image is present, start a prep container, strip ``/testbed``, run any
+    ``post_strip_exec`` setup commands, commit the snapshot, and remove the prep
+    container.
 
-    Strip is the only per-instance cost paid here; per-arm resets
-    (:func:`start_arm_container` / :func:`reset_arm`) inherit the stripped state
-    for free.
+    ``post_strip_exec`` is a list of argv lists run via ``docker exec`` (as root)
+    after the strip and before the commit, so their effect is baked into the
+    snapshot.  C4 (#318) uses it to create the non-root agent user and
+    ``chown /testbed`` to it once per instance — avoiding a per-arm ``chown -R``
+    on large repos.  Keep it free of secrets: anything run here lands in the
+    committed image.
+
+    Strip is the only mandatory per-instance cost paid here; per-arm resets
+    (:func:`start_arm_container` / :func:`reset_arm`) inherit the stripped (and
+    set-up) state for free.
 
     Not concurrency-safe: two callers preparing the same instance would both
     build + commit the snapshot (last commit wins). Harmless today — image mode
@@ -253,6 +270,8 @@ def prepare_instance(
     prep = _run_detached(base)
     try:
         strip_testbed(prep, testbed)
+        for argv in post_strip_exec or []:
+            _docker(["exec", prep, *argv], check=True)
         # Commit the stripped worktree as the snapshot.  --pause keeps the fs
         # quiescent during commit (the idle container writes nothing, but be
         # explicit).  The committed layer mostly *shrinks* .git (repack+gc),
@@ -269,14 +288,18 @@ def prepare_instance(
 # --------------------------------------------------------------------------
 
 def start_arm_container(
-    prepared: PreparedImage, *, name: str | None = None
+    prepared: PreparedImage,
+    *,
+    name: str | None = None,
+    volumes: list[str] | None = None,
 ) -> ContainerHandle:
     """Start a fresh container from the prepared snapshot.
 
     The container's ``/testbed`` is pristine and already history-stripped (it
-    was stripped into the snapshot at prepare time).  ~286 ms in C2.
+    was stripped into the snapshot at prepare time).  ~286 ms in C2.  ``volumes``
+    (raw ``-v`` specs) let C4 mount the shared read-only agent runtime.
     """
-    cid = _run_detached(prepared.snapshot_tag, name=name)
+    cid = _run_detached(prepared.snapshot_tag, name=name, volumes=volumes)
     return ContainerHandle(
         instance_id=prepared.instance_id,
         container_id=cid,
@@ -284,10 +307,16 @@ def start_arm_container(
     )
 
 
-def reset_arm(handle: ContainerHandle, *, name: str | None = None) -> ContainerHandle:
+def reset_arm(
+    handle: ContainerHandle,
+    *,
+    name: str | None = None,
+    volumes: list[str] | None = None,
+) -> ContainerHandle:
     """Reset between arms: discard the current container and start a fresh one
     from the same snapshot.  Returns a NEW handle (the old ``container_id`` is
-    dead) — mirrors ``_refresh_overlay`` returning a refreshed handle.
+    dead) — mirrors ``_refresh_overlay`` returning a refreshed handle.  Pass the
+    same ``volumes`` as the original start so the agent runtime stays mounted.
 
     Chosen reset strategy (C3 #317, settled by C2's numbers): fresh container
     from the stripped snapshot.  Pristine by construction, no in-place reset, no
@@ -299,7 +328,7 @@ def reset_arm(handle: ContainerHandle, *, name: str | None = None) -> ContainerH
         base_image="",  # not needed for a restart; snapshot already exists
         snapshot_tag=handle.snapshot_tag,
     )
-    return start_arm_container(prepared, name=name)
+    return start_arm_container(prepared, name=name, volumes=volumes)
 
 
 def teardown(handle: ContainerHandle) -> None:

--- a/swebench/container_agent.py
+++ b/swebench/container_agent.py
@@ -1,0 +1,421 @@
+"""In-container Claude agent execution (epic #314 / ADR-0004, C4 #318).
+
+Runs the **Claude** agent *inside* a prepared instance container (C3
+:mod:`swebench.container`), for both arms, with the same tool-restriction and
+isolation guarantees as the host path — only relocated into the container.
+
+Staging strategy (de-risked in the C4 spike):
+
+* **Shared read-only runtime volume** ``onlycodes-agent-rt`` holds the big,
+  instance-independent binaries — the host's ``node`` and the Claude native
+  binary — populated **once** (~12 s) and mounted ``:ro`` at ``/opt/agent`` in
+  every arm container.  Named volumes live in the daemon, so they sidestep the
+  DooD "bind-mount source resolves on the host" problem (C2).  The base SWE-bench
+  images ship **no node** (contrary to #318's premise — verified absent), hence
+  node is staged here too.
+* **Per-arm writable config** ``/opt/cfg`` holds the small bits: the exec-server
+  bundle + python helpers (~0.8 MB — staged per arm rather than on the ro volume
+  so the server never assumes its own dir is writable), a rewritten
+  ``mcp-config.json`` pointing at the staged node/bundle, and the **credentials**.
+* **Agent user** (non-root — Claude refuses ``--dangerously-skip-permissions``
+  as uid 0) and ``chown /testbed`` are baked into the snapshot at *prepare* time
+  (see :func:`agent_user_setup_commands`), so no per-arm ``chown -R``.
+
+**Credentials never persist in an image/commit:** the snapshot is committed at
+prepare time, before any creds exist; creds are ``docker cp``'d only into
+ephemeral arm containers, which are ``docker rm``'d and never committed.
+
+The **executed-code network isolation** (`unshare -n`, hard-required in the
+exec-server) needs only ``CAP_SYS_ADMIN``, which :mod:`swebench.container`
+already grants — C2 confirmed both unshare strategies work in-container.  The
+agent process keeps API network; only *executed code* is isolated.
+
+Tool-restriction logic is **not** duplicated here — :func:`run_agent` calls
+``ClaudeRunner.build_tools_flags`` so the ``--tools`` / ``--disallowedTools``
+contract stays single-sourced with the host path.
+
+Scope (C4): the agent runs correctly in-container.  Getting the transcript +
+result *out* with a no-leak scan is C4b (#324); the Codex surface is #325.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+from pathlib import Path
+
+from swebench import container
+from swebench.container import ContainerHandle
+from swebench.runner import ClaudeRunner
+
+
+# --------------------------------------------------------------------------
+# Layout constants
+# --------------------------------------------------------------------------
+
+RUNTIME_VOLUME = "onlycodes-agent-rt"   # shared, read-only
+AGENT_MOUNT = "/opt/agent"              # where the volume mounts (node, claude)
+CFG_DIR = "/opt/cfg"                    # per-arm, writable (exec-server, mcp-config, creds)
+AGENT_USER = "agent"
+AGENT_UID = 4000
+AGENT_HOME = f"/home/{AGENT_USER}"
+
+NODE_BIN = f"{AGENT_MOUNT}/node"
+CLAUDE_BIN = f"{AGENT_MOUNT}/claude"
+BUNDLE_IN_CFG = f"{CFG_DIR}/exec_server/exec-server.bundle.mjs"
+MCP_CONFIG_IN_CFG = f"{CFG_DIR}/mcp-config.json"
+RESULT_IN_CONTAINER = f"{CFG_DIR}/transcript.jsonl"
+
+#: Pinned model — mirrors ``ClaudeRunner.invoke`` on the host path.
+MODEL = "claude-sonnet-4-6"
+
+#: The SWE-bench image's project conda env (repo installed editable here).
+TESTBED_ENV = "/opt/miniconda3/envs/testbed"
+
+#: MCP init timeout (ms).  The exec-server's persistent python kernel cold-starts
+#: slower under the in-container conda env than Claude Code's default MCP timeout,
+#: which leaves the codebox server stuck ``status:pending`` (init record
+#: ``tools:[]``).  A generous timeout absorbs the cold-start variance (warm
+#: ~6 s; a truly cold conda import can exceed 60 s).  Note the init record's
+#: ``mcp_servers`` status is only a snapshot at emit time — it may read
+#: ``pending`` even when the server connects microseconds later and the tool
+#: works, so don't treat it as the readiness signal (the tool_result is).
+MCP_TIMEOUT_MS = 120000
+
+#: Sentinel inside the volume marking a complete population.
+_VOLUME_SENTINEL = f"{AGENT_MOUNT}/.populated"
+
+#: exec-server runtime files staged per-arm (alongside the bundle, read via
+#: ``__dirname``).  Sourced from the built ``exec_server/dist/``.
+_EXEC_SERVER_FILES = (
+    "exec-server.bundle.mjs",
+    "codebox.py",
+    "mcp_bridge.py",
+    "python_kernel.py",
+    "passthrough-config.json",
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _exec_server_dist() -> Path:
+    return _repo_root() / "exec_server" / "dist"
+
+
+class AgentRuntimeError(RuntimeError):
+    """Agent runtime staging or invocation failed."""
+
+
+# --------------------------------------------------------------------------
+# Snapshot-time setup (baked in by container.prepare_instance(post_strip_exec=))
+# --------------------------------------------------------------------------
+
+def agent_user_setup_commands(
+    testbed: str = "/testbed", *, uid: int = AGENT_UID
+) -> list[list[str]]:
+    """argv lists for :func:`container.prepare_instance`'s ``post_strip_exec``.
+
+    Creates the non-root agent user and chowns ``/testbed`` to it — baked into
+    the snapshot once, so per-arm starts pay no ``chown -R``.  Secret-free, as
+    required for anything committed into the image.
+    """
+    return [
+        ["bash", "-c",
+         f"id {AGENT_USER} >/dev/null 2>&1 || useradd -m -u {uid} {AGENT_USER}"],
+        ["chown", "-R", f"{AGENT_USER}:{AGENT_USER}", testbed],
+    ]
+
+
+# --------------------------------------------------------------------------
+# Shared read-only runtime volume (node + claude), populated once
+# --------------------------------------------------------------------------
+
+def runtime_volume_spec(*, read_only: bool = True) -> str:
+    """The ``docker -v`` spec to mount the runtime volume in an arm container."""
+    return f"{RUNTIME_VOLUME}:{AGENT_MOUNT}" + (":ro" if read_only else "")
+
+
+def _volume_exists(name: str) -> bool:
+    return container._docker(["volume", "inspect", name], check=False).returncode == 0
+
+
+def _find_node() -> str:
+    node = shutil.which("node")
+    if not node:
+        raise AgentRuntimeError(
+            "host `node` not found on PATH — required to stage the exec-server "
+            "runtime (base SWE-bench images ship no node)."
+        )
+    return node
+
+
+def ensure_agent_runtime(
+    claude_binary: str,
+    *,
+    helper_image: str = "busybox:latest",
+    force: bool = False,
+) -> str:
+    """Create + populate the shared read-only runtime volume (node + claude).
+
+    Idempotent: returns immediately if the volume already carries the sentinel
+    (unless ``force``).  Population copies the host ``node`` and ``claude_binary``
+    into the volume via a throwaway helper container — paid once globally, not
+    per arm.  Returns the volume name.
+    """
+    if not force and _volume_exists(RUNTIME_VOLUME):
+        probe = container._docker(
+            ["run", "--rm", "-v", f"{RUNTIME_VOLUME}:{AGENT_MOUNT}:ro",
+             helper_image, "test", "-f", _VOLUME_SENTINEL],
+            check=False,
+        )
+        if probe.returncode == 0:
+            return RUNTIME_VOLUME
+
+    node = _find_node()
+    container.pull_image(helper_image)
+    container._docker(["volume", "create", RUNTIME_VOLUME], check=False)
+
+    # Stage a host tree, then cp it into the volume in one shot (preserves the
+    # executable bits on node/claude; auto-creates the dir).
+    staging = tempfile.mkdtemp(prefix="agent-rt-")
+    helper = ""
+    try:
+        shutil.copy2(node, os.path.join(staging, "node"))
+        shutil.copy2(claude_binary, os.path.join(staging, "claude"))
+        os.chmod(os.path.join(staging, "node"), 0o755)
+        os.chmod(os.path.join(staging, "claude"), 0o755)
+        Path(staging, ".populated").write_text("1\n")
+
+        helper = container._decode(container._docker(
+            ["run", "-d", "-v", f"{RUNTIME_VOLUME}:/stage", helper_image,
+             "sleep", "86400"]
+        ))
+        # `cp <dir>/.` copies the directory *contents* into /stage.
+        container._docker(["cp", f"{staging}/.", f"{helper}:/stage"])
+    finally:
+        if helper:
+            container._rm_force(helper)
+        shutil.rmtree(staging, ignore_errors=True)
+    return RUNTIME_VOLUME
+
+
+# --------------------------------------------------------------------------
+# Per-arm staging: exec-server bundle + mcp-config + credentials -> /opt/cfg
+# --------------------------------------------------------------------------
+
+def _incontainer_mcp_config(*, persistent_kernel: bool = True) -> dict:
+    # Prepend the testbed env's bin so the exec-server's python kernel runs in the
+    # *project* conda env (where the repo is installed editable) — not the base
+    # env — so executed code can import the package under test.
+    path = (
+        f"{TESTBED_ENV}/bin:/opt/miniconda3/bin:"
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    )
+    return {
+        "mcpServers": {
+            "codebox": {
+                "type": "stdio",
+                "command": NODE_BIN,
+                "args": [BUNDLE_IN_CFG],
+                "cwd": "/testbed",
+                "env": {
+                    "ONLYCODES_PERSISTENT_KERNEL": "1" if persistent_kernel else "0",
+                    "PATH": path,
+                },
+            }
+        }
+    }
+
+
+def stage_arm(
+    handle: ContainerHandle,
+    *,
+    creds_src: str | None = None,
+    persistent_kernel: bool = True,
+) -> None:
+    """Stage the per-arm config into ``/opt/cfg`` of a running arm container.
+
+    Copies the exec-server bundle + helpers, writes the in-container
+    ``mcp-config.json``, and ``docker cp``'s the Claude credentials
+    (``.credentials.json`` + ``.claude.json``) from ``creds_src`` (default
+    ``~/.claude``).  Everything is chowned to the agent user.  None of this is
+    ever committed — arm containers are torn down, not snapshotted.
+    """
+    creds_src = creds_src or os.path.expanduser("~/.claude")
+    dist = _exec_server_dist()
+    for fname in _EXEC_SERVER_FILES:
+        if not (dist / fname).is_file():
+            raise AgentRuntimeError(
+                f"exec-server file missing: {dist / fname} — run `npm run build` "
+                "in exec_server/ first."
+            )
+
+    cid = handle.container_id
+    container._docker(["exec", cid, "mkdir", "-p", f"{CFG_DIR}/exec_server"])
+    for fname in _EXEC_SERVER_FILES:
+        container._docker(["cp", str(dist / fname), f"{cid}:{CFG_DIR}/exec_server/{fname}"])
+
+    # In-container mcp-config.
+    tmp = tempfile.mkdtemp(prefix="arm-cfg-")
+    try:
+        cfg_path = os.path.join(tmp, "mcp-config.json")
+        Path(cfg_path).write_text(json.dumps(_incontainer_mcp_config(
+            persistent_kernel=persistent_kernel)))
+        container._docker(["cp", cfg_path, f"{cid}:{MCP_CONFIG_IN_CFG}"])
+
+        # Credentials — copied last, then the whole /opt/cfg chowned to agent.
+        for fname in (".credentials.json", ".claude.json"):
+            src = os.path.join(creds_src, fname)
+            if os.path.isfile(src):
+                container._docker(["cp", src, f"{cid}:{CFG_DIR}/{fname}"])
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    container._docker(["exec", cid, "chown", "-R", f"{AGENT_USER}:{AGENT_USER}", CFG_DIR])
+
+
+# --------------------------------------------------------------------------
+# Invocation
+# --------------------------------------------------------------------------
+
+def build_agent_argv(
+    arm: str,
+    *,
+    prompt: str,
+    system_prompt: str,
+    model: str = MODEL,
+    wall_timeout: int = 3600,
+) -> list[str]:
+    """The in-container claude argv for an arm (no docker wrapper).
+
+    Tool flags come from ``ClaudeRunner.build_tools_flags`` (single-sourced with
+    the host path); only the mcp-config path is in-container.  A ``timeout``
+    prefix bounds wall time *inside* the container so the agent is killed even if
+    the host ``docker exec`` client is interrupted.
+    """
+    tools_flags = ClaudeRunner().build_tools_flags(arm, MCP_CONFIG_IN_CFG)
+    argv = [
+        CLAUDE_BIN,
+        "-p", prompt,
+        "--model", model,
+        "--system-prompt", system_prompt,
+        *tools_flags,
+        "--dangerously-skip-permissions",
+        "--no-session-persistence",
+        "--output-format", "stream-json",
+        "--verbose",
+    ]
+    if wall_timeout and wall_timeout > 0:
+        argv = ["timeout", f"{wall_timeout}s", *argv]
+    return argv
+
+
+#: Arms whose only tools are the codebox MCP — a turn with zero ``mcp__codebox__``
+#: use means the MCP server never connected (the agent had no tools), not that
+#: the task needed none.
+_MCP_REQUIRED_ARMS = {"code_only", "onlycode"}
+
+
+def _codebox_was_used(result_path: str) -> bool:
+    try:
+        text = Path(result_path).read_text()
+    except OSError:
+        return False
+    # Cheap + robust: the tool name appears in the assistant's tool_use blocks.
+    return "mcp__codebox__" in text
+
+
+def _invoke_once(
+    handle: ContainerHandle, agent_argv: list[str], result_path: str,
+    host_timeout: int | None,
+) -> int:
+    docker_argv = [
+        container._docker_bin(), "exec",
+        "-u", AGENT_USER,
+        "-w", "/testbed",
+        "-e", f"CLAUDE_CONFIG_DIR={CFG_DIR}",
+        "-e", f"HOME={AGENT_HOME}",
+        "-e", "FORCE_PROMPT_CACHING_5M=1",
+        "-e", f"MCP_TIMEOUT={MCP_TIMEOUT_MS}",
+        handle.container_id,
+        *agent_argv,
+    ]
+    with open(result_path, "wb") as out:
+        with subprocess.Popen(
+            docker_argv, stdout=out, stderr=subprocess.STDOUT, start_new_session=True,
+        ) as proc:
+            try:
+                return proc.wait(timeout=host_timeout)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                proc.wait()
+                return 124
+
+
+def run_agent(
+    handle: ContainerHandle,
+    *,
+    arm: str,
+    prompt: str,
+    system_prompt: str = "You are a helpful assistant.",
+    result_path: str,
+    model: str = MODEL,
+    wall_timeout: int = 3600,
+    mcp_required: bool | None = None,
+    max_attempts: int = 4,
+) -> int:
+    """Run one Claude turn inside the arm container, streaming the JSONL
+    transcript to ``result_path`` on the host.
+
+    Runs as the non-root agent user, ``CLAUDE_CONFIG_DIR=/opt/cfg``, cwd
+    ``/testbed``.  Returns the exit code (124 = wall timeout from the in-container
+    ``timeout``).  Requires :func:`stage_arm` to have run on this container and
+    the runtime volume to be mounted.
+
+    **MCP-startup-race retry.** Claude Code's MCP init is a nondeterministic race
+    (documented "uncontrolled" — cf. the iso-nonce note in ``runner.py``); under
+    the in-container cold start the codebox server sometimes registers too late
+    and a ``code_only`` turn sees no ``execute_code``.  For arms that *require*
+    the codebox tool (``mcp_required``, defaulting to ``code_only``/``onlycode``),
+    a turn that used zero ``mcp__codebox__`` tools is retried (up to
+    ``max_attempts``).  Failed rolls are cheap — the tool-less agent gives up in
+    seconds — and successful turns are never retried.
+
+    NOTE: writing the transcript to the host here is the minimal capture C4 needs
+    to verify a turn; the full transcript/result + no-leak contract is C4b
+    (#324).
+    """
+    if mcp_required is None:
+        mcp_required = arm in _MCP_REQUIRED_ARMS
+    agent_argv = build_agent_argv(
+        arm, prompt=prompt, system_prompt=system_prompt,
+        model=model, wall_timeout=wall_timeout,
+    )
+    host_timeout = (wall_timeout + 120) if wall_timeout and wall_timeout > 0 else None
+
+    rc = 0
+    for attempt in range(1, max_attempts + 1):
+        rc = _invoke_once(handle, agent_argv, result_path, host_timeout)
+        if not mcp_required or _codebox_was_used(result_path):
+            return rc
+        if attempt < max_attempts:
+            logging.warning(
+                "container_agent: codebox MCP did not connect (arm=%s, attempt %d/%d) "
+                "— retrying (Claude Code MCP startup race)", arm, attempt, max_attempts,
+            )
+    if mcp_required and not _codebox_was_used(result_path):
+        logging.error(
+            "container_agent: codebox MCP failed to connect after %d attempts (arm=%s)",
+            max_attempts, arm,
+        )
+    return rc

--- a/tests/test_container_agent.py
+++ b/tests/test_container_agent.py
@@ -130,6 +130,12 @@ def test_stage_arm_copies_bundle_creds_and_chowns(monkeypatch, tmp_path) -> None
         return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr(container, "_docker", _fake_docker)
+    # Fake the (gitignored, build-only) exec-server dist so the test is hermetic.
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    for fname in ca._EXEC_SERVER_FILES:
+        (dist / fname).write_text("x")
+    monkeypatch.setattr(ca, "_exec_server_dist", lambda: dist)
     creds = tmp_path / "creds"
     creds.mkdir()
     (creds / ".credentials.json").write_text("{}")

--- a/tests/test_container_agent.py
+++ b/tests/test_container_agent.py
@@ -1,0 +1,399 @@
+"""Tests for in-container Claude agent execution (``swebench/container_agent.py``, C4 #318).
+
+Layers:
+
+* **Hermetic** (CI) — argv / mcp-config / setup-command assembly and per-arm
+  staging, with the ``docker`` boundary mocked. No daemon, no cost.
+* **``@integration``** (needs Docker + an image) — the cred-never-persists
+  guarantee: prepare a snapshot and assert no credentials are baked in. No agent
+  turn, so no cost.
+* **``@integration`` + ``ONLYCODES_RUN_AGENT_TESTS=1``** — real in-container
+  agent turns proving tool restriction (`code_only` can't reach native tools),
+  executed-code network isolation, and that the baseline arm keeps native tools.
+  These cost money and need live credentials, so they are off by default.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import types
+from pathlib import Path
+
+import pytest
+
+from swebench import container, container_agent as ca
+from swebench.container import ContainerHandle
+from swebench.runner import BLOCKED_BUILTINS
+
+
+# --------------------------------------------------------------------------
+# Hermetic: assembly
+# --------------------------------------------------------------------------
+
+def test_agent_user_setup_commands_are_secret_free_useradd_and_chown() -> None:
+    cmds = ca.agent_user_setup_commands("/testbed")
+    assert cmds[0][:2] == ["bash", "-c"]
+    assert f"useradd -m -u {ca.AGENT_UID} {ca.AGENT_USER}" in cmds[0][2]
+    assert cmds[1] == ["chown", "-R", f"{ca.AGENT_USER}:{ca.AGENT_USER}", "/testbed"]
+    # Nothing secret-bearing — these are baked into the committed snapshot.
+    assert not any("cred" in part.lower() for cmd in cmds for part in cmd)
+
+
+def test_runtime_volume_spec_ro_and_rw() -> None:
+    assert ca.runtime_volume_spec() == f"{ca.RUNTIME_VOLUME}:{ca.AGENT_MOUNT}:ro"
+    assert ca.runtime_volume_spec(read_only=False) == f"{ca.RUNTIME_VOLUME}:{ca.AGENT_MOUNT}"
+
+
+def test_incontainer_mcp_config_points_at_staged_node_and_bundle() -> None:
+    cfg = ca._incontainer_mcp_config()
+    box = cfg["mcpServers"]["codebox"]
+    assert box["command"] == ca.NODE_BIN == f"{ca.AGENT_MOUNT}/node"
+    assert box["args"] == [ca.BUNDLE_IN_CFG]
+    assert ca.BUNDLE_IN_CFG.startswith(ca.CFG_DIR)   # writable per-arm dir, not the ro volume
+    assert box["cwd"] == "/testbed"
+    assert box["env"]["ONLYCODES_PERSISTENT_KERNEL"] == "1"
+    # kernel runs in the testbed conda env so executed code imports the project.
+    assert box["env"]["PATH"].startswith(f"{ca.TESTBED_ENV}/bin:")
+    assert ca._incontainer_mcp_config(persistent_kernel=False)[
+        "mcpServers"]["codebox"]["env"]["ONLYCODES_PERSISTENT_KERNEL"] == "0"
+
+
+def test_build_agent_argv_code_only_restricts_to_codebox() -> None:
+    argv = ca.build_agent_argv(
+        "code_only", prompt="do x", system_prompt="sys", wall_timeout=300)
+    # in-container timeout prefix bounds wall time.
+    assert argv[:2] == ["timeout", "300s"]
+    assert ca.CLAUDE_BIN in argv
+    # single-sourced tool flags: mcp-config (in-container) + codebox tools + disallow natives.
+    assert "--mcp-config" in argv and ca.MCP_CONFIG_IN_CFG in argv
+    assert "--strict-mcp-config" in argv
+    i = argv.index("--tools")
+    assert argv[i + 1] == "mcp__codebox__execute_code,mcp__codebox__list_tools"
+    j = argv.index("--disallowedTools")
+    assert argv[j + 1] == BLOCKED_BUILTINS
+    for flag in ("--dangerously-skip-permissions", "--no-session-persistence"):
+        assert flag in argv
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+    assert argv[argv.index("--model") + 1] == ca.MODEL
+
+
+def test_build_agent_argv_baseline_has_no_tool_restriction() -> None:
+    argv = ca.build_agent_argv(
+        "baseline", prompt="p", system_prompt="s", wall_timeout=0)
+    # No timeout prefix when wall_timeout == 0.
+    assert argv[0] == ca.CLAUDE_BIN
+    # baseline => native tools; no restriction flags.
+    assert "--tools" not in argv and "--disallowedTools" not in argv
+    assert "--mcp-config" not in argv
+
+
+def test_run_agent_builds_isolated_nonroot_docker_exec(monkeypatch, tmp_path) -> None:
+    captured = {}
+
+    class _FakeProc:
+        def __init__(self, argv, **kw):
+            captured["argv"] = argv
+            captured["stdout"] = kw.get("stdout")
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def wait(self, timeout=None):
+            # Prove the transcript file handle is what we stream into.
+            captured["stdout"].write(b'{"type":"result"}\n')
+            return 0
+
+    monkeypatch.setattr(ca.subprocess, "Popen", _FakeProc)
+    result = tmp_path / "t.jsonl"
+    rc = ca.run_agent(
+        ContainerHandle("i", "cid123", "snap"),
+        arm="code_only", prompt="p", result_path=str(result), wall_timeout=60,
+        mcp_required=False,  # isolate the argv assembly from the MCP retry path
+    )
+    assert rc == 0
+    argv = captured["argv"]
+    assert argv[0] == container._docker_bin() and argv[1] == "exec"
+    # Non-root, isolated config dir, cwd /testbed.
+    assert argv[argv.index("-u") + 1] == ca.AGENT_USER
+    assert argv[argv.index("-w") + 1] == "/testbed"
+    assert f"CLAUDE_CONFIG_DIR={ca.CFG_DIR}" in argv
+    assert f"MCP_TIMEOUT={ca.MCP_TIMEOUT_MS}" in argv  # avoids the codebox pending race
+    assert "cid123" in argv
+    assert result.read_text() == '{"type":"result"}\n'
+
+
+def test_stage_arm_copies_bundle_creds_and_chowns(monkeypatch, tmp_path) -> None:
+    calls: list[list[str]] = []
+
+    def _fake_docker(args, **kw):
+        calls.append(args)
+        return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(container, "_docker", _fake_docker)
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / ".credentials.json").write_text("{}")
+    (creds / ".claude.json").write_text("{}")
+
+    ca.stage_arm(ContainerHandle("i", "cidX", "snap"), creds_src=str(creds))
+
+    joined = [" ".join(a) for a in calls]
+    # exec-server bundle staged under the writable cfg dir.
+    assert any("exec-server.bundle.mjs" in s and f"cidX:{ca.CFG_DIR}/exec_server" in s
+               for s in joined)
+    # mcp-config + both cred files cp'd in.
+    assert any(ca.MCP_CONFIG_IN_CFG in s for s in joined)
+    assert any(".credentials.json" in s for s in joined)
+    assert any(".claude.json" in s for s in joined)
+    # final chown -R of the whole cfg dir to the agent user.
+    assert calls[-1] == ["exec", "cidX", "chown", "-R",
+                         f"{ca.AGENT_USER}:{ca.AGENT_USER}", ca.CFG_DIR]
+
+
+def test_stage_arm_raises_if_exec_server_unbuilt(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(ca, "_exec_server_dist", lambda: tmp_path / "nope")
+    with pytest.raises(ca.AgentRuntimeError, match="npm run build"):
+        ca.stage_arm(ContainerHandle("i", "c", "s"))
+
+
+def test_run_agent_retries_code_only_until_codebox_connects(monkeypatch, tmp_path) -> None:
+    # Simulate the MCP startup race: first two invocations produce a transcript
+    # with no codebox use; the third connects.
+    result = tmp_path / "r.jsonl"
+    calls = {"n": 0}
+
+    def _fake_invoke(handle, argv, path, host_timeout):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            Path(path).write_text('{"type":"assistant"}\n')  # no codebox tool
+        else:
+            Path(path).write_text('{"type":"assistant"}\n'
+                                  '{"tool":"mcp__codebox__execute_code"}\n')
+        return 0
+
+    monkeypatch.setattr(ca, "_invoke_once", _fake_invoke)
+    rc = ca.run_agent(ContainerHandle("i", "c", "s"), arm="code_only",
+                      prompt="p", result_path=str(result), max_attempts=4)
+    assert rc == 0
+    assert calls["n"] == 3, "should retry until codebox connects, then stop"
+
+
+def test_run_agent_baseline_never_retries(monkeypatch, tmp_path) -> None:
+    result = tmp_path / "b.jsonl"
+    calls = {"n": 0}
+
+    def _fake_invoke(handle, argv, path, host_timeout):
+        calls["n"] += 1
+        Path(path).write_text('{"type":"assistant"}\n')  # no codebox — irrelevant for baseline
+        return 0
+
+    monkeypatch.setattr(ca, "_invoke_once", _fake_invoke)
+    ca.run_agent(ContainerHandle("i", "c", "s"), arm="baseline",
+                 prompt="p", result_path=str(result), max_attempts=4)
+    assert calls["n"] == 1, "baseline does not require codebox; no retry"
+
+
+def test_run_agent_gives_up_after_max_attempts(monkeypatch, tmp_path) -> None:
+    result = tmp_path / "g.jsonl"
+    calls = {"n": 0}
+
+    def _fake_invoke(handle, argv, path, host_timeout):
+        calls["n"] += 1
+        Path(path).write_text('{"type":"assistant"}\n')  # never connects
+        return 0
+
+    monkeypatch.setattr(ca, "_invoke_once", _fake_invoke)
+    ca.run_agent(ContainerHandle("i", "c", "s"), arm="code_only",
+                 prompt="p", result_path=str(result), max_attempts=3)
+    assert calls["n"] == 3, "exhausts max_attempts then returns"
+
+
+# --------------------------------------------------------------------------
+# Integration scaffolding
+# --------------------------------------------------------------------------
+
+def _docker_available() -> bool:
+    try:
+        return subprocess.run(
+            ["docker", "version"], capture_output=True, timeout=15
+        ).returncode == 0
+    except Exception:
+        return False
+
+
+def _test_image() -> str:
+    return os.environ.get(
+        "ONLYCODES_TEST_IMAGE",
+        "swebench/sweb.eval.x86_64.psf_1776_requests-1142:latest",
+    )
+
+
+requires_docker = lambda fn: pytest.mark.integration(  # noqa: E731
+    pytest.mark.skipif(not _docker_available(), reason="docker daemon not available")(fn)
+)
+
+requires_agent_run = pytest.mark.skipif(
+    os.environ.get("ONLYCODES_RUN_AGENT_TESTS") != "1",
+    reason="live agent turn (costs money, needs creds); set ONLYCODES_RUN_AGENT_TESTS=1",
+)
+
+
+def _instance_from_image(img: str) -> str:
+    slug = img.split("sweb.eval.x86_64.", 1)[1].rsplit(":", 1)[0]
+    return slug.replace(container._NAMESPACE_TOKEN, "__")
+
+
+# --------------------------------------------------------------------------
+# Integration (no cost): credentials never persist into the snapshot
+# --------------------------------------------------------------------------
+
+@requires_docker
+def test_credentials_absent_from_snapshot_image() -> None:
+    img = _test_image()
+    if not container.image_present(img):
+        pytest.skip(f"test image not present: {img}")
+    instance_id = _instance_from_image(img)
+    snapshot = container.prepared_tag(instance_id)
+    if container.image_present(snapshot):
+        pytest.skip(f"would clobber an existing snapshot: {snapshot}")
+    try:
+        container.prepare_instance(
+            instance_id, force=True,
+            post_strip_exec=ca.agent_user_setup_commands(),
+        )
+        # A fresh container off the snapshot must carry NO credentials and no
+        # /opt/cfg — those only ever exist in ephemeral arm containers.
+        probe = container._docker(
+            ["run", "--rm", snapshot, "bash", "-c",
+             "find / -name .credentials.json 2>/dev/null; ls -d /opt/cfg 2>/dev/null; "
+             "id agent >/dev/null 2>&1 && echo AGENT_USER_BAKED"],
+            check=False,
+        )
+        out = probe.stdout.decode("utf-8", "replace")
+        assert ".credentials.json" not in out, f"creds leaked into snapshot:\n{out}"
+        assert "/opt/cfg" not in out
+        # But the agent user IS baked in (post_strip_exec ran).
+        assert "AGENT_USER_BAKED" in out
+    finally:
+        subprocess.run(["docker", "rmi", "-f", snapshot], capture_output=True)
+
+
+# --------------------------------------------------------------------------
+# Integration (costs money): real in-container agent turns
+# --------------------------------------------------------------------------
+
+@pytest.fixture()
+def staged_arm():
+    """A prepared+started arm container with runtime mounted and creds staged."""
+    img = _test_image()
+    if not container.image_present(img):
+        pytest.skip(f"test image not present: {img}")
+    instance_id = _instance_from_image(img)
+    snapshot = container.prepared_tag(instance_id)
+    clobbers = container.image_present(snapshot)
+    if clobbers:
+        pytest.skip(f"would clobber an existing snapshot: {snapshot}")
+
+    claude = __import__("swebench.runner", fromlist=["ClaudeRunner"]).ClaudeRunner().find_binary()
+    ca.ensure_agent_runtime(claude)
+    prepared = container.prepare_instance(
+        instance_id, force=True, post_strip_exec=ca.agent_user_setup_commands())
+    handle = container.start_arm_container(
+        prepared, volumes=[ca.runtime_volume_spec()])
+    ca.stage_arm(handle)
+    try:
+        yield handle
+    finally:
+        container.teardown(handle)
+        subprocess.run(["docker", "rmi", "-f", snapshot], capture_output=True)
+
+
+def _records(path: Path) -> list[dict]:
+    out = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return out
+
+
+def _tool_uses(recs: list[dict]) -> list[dict]:
+    return [
+        c for r in recs if r.get("type") == "assistant"
+        for c in r.get("message", {}).get("content", []) if c.get("type") == "tool_use"
+    ]
+
+
+def _tool_result_text(recs: list[dict]) -> str:
+    """Concatenated text of all tool_result blocks — the *actual* executed
+    output, distinct from the assistant's prose (which may paraphrase code)."""
+    parts = []
+    for r in recs:
+        if r.get("type") != "user":
+            continue
+        for c in r.get("message", {}).get("content", []):
+            if isinstance(c, dict) and c.get("type") == "tool_result":
+                body = c.get("content")
+                if isinstance(body, list):
+                    body = "".join(b.get("text", "") for b in body if isinstance(b, dict))
+                parts.append(body if isinstance(body, str) else json.dumps(body))
+    return "\n".join(parts)
+
+
+@requires_docker
+@requires_agent_run
+def test_code_only_turn_restriction_and_netiso(staged_arm, tmp_path) -> None:
+    # One paid turn covering: codebox reachable, executed-code net-iso, and no
+    # native file tools.
+    prompt = (
+        "Use the execute_code tool to run this exact Python and report what it "
+        "prints:\n"
+        "print('SENTINEL_42')\n"
+        "import urllib.request\n"
+        "try:\n"
+        "    urllib.request.urlopen('http://1.1.1.1', timeout=5); print('NET_REACHABLE')\n"
+        "except Exception as e:\n"
+        "    print('NET_ISOLATED', type(e).__name__)\n"
+    )
+    result = tmp_path / "code_only.jsonl"
+    rc = ca.run_agent(staged_arm, arm="code_only", prompt=prompt,
+                      result_path=str(result), wall_timeout=300)
+    assert rc == 0, f"agent exited {rc}"
+    recs = _records(result)
+    uses = _tool_uses(recs)
+    # The codebox MCP tool was reachable and actually used (proves it connected —
+    # the init-record mcp_servers status is an unreliable snapshot).
+    assert any(u.get("name", "").startswith("mcp__codebox__") for u in uses), (
+        f"execute_code was never used; tools used: {[u.get('name') for u in uses]}"
+    )
+    # Assert on the *executed output* (tool_result), not the agent's prose.
+    out = _tool_result_text(recs)
+    assert "SENTINEL_42" in out, "executed code did not run via codebox"
+    # executed code could NOT reach the network (unshare -n active in-container).
+    assert "NET_ISOLATED" in out and "NET_REACHABLE" not in out, f"net-iso failed:\n{out}"
+    # restriction: no native file-tool use anywhere in the transcript.
+    native = {"Read", "Write", "Edit", "Bash", "Glob", "Grep"}
+    assert not (native & {u.get("name") for u in uses}), (
+        f"native tool used under code_only: {[u.get('name') for u in uses]}"
+    )
+
+
+@requires_docker
+@requires_agent_run
+def test_baseline_turn_keeps_native_tools(staged_arm, tmp_path) -> None:
+    prompt = "Use the Read tool to read /testbed/setup.py and report its first line."
+    result = tmp_path / "baseline.jsonl"
+    rc = ca.run_agent(staged_arm, arm="baseline", prompt=prompt,
+                      result_path=str(result), wall_timeout=300)
+    assert rc == 0
+    recs = _records(result)
+    used = {
+        c.get("name")
+        for r in recs if r.get("type") == "assistant"
+        for c in r.get("message", {}).get("content", []) if c.get("type") == "tool_use"
+    }
+    # baseline arm has native tools available and used at least one.
+    assert used and used & {"Read", "Bash", "Glob", "Grep"}, f"tools used: {used}"


### PR DESCRIPTION
Closes #318. Part of epic #314 (ADR-0004). Builds on C2 (#316) + C3 (#317). **Claude surface only** (Codex is #325; output capture is C4b #324).

## What this delivers
Runs the Claude agent **inside** a prepared instance container for both arms, with the host path's tool-restriction + isolation relocated into the container.

### Staging (de-risked in the C4 spike)
- **Shared read-only runtime volume** `onlycodes-agent-rt`: host `node` + the claude binary, populated **once** (~12 s), mounted `:ro` at `/opt/agent` in every arm container. (The base SWE-bench images ship **no node** — contrary to #318's premise — so node is staged too.)
- **Per-arm `/opt/cfg`** (writable): exec-server bundle + helpers, a rewritten in-container `mcp-config.json` (PATH points the kernel at the **testbed conda env** so executed code imports the project), and credentials.
- **Agent user + `chown /testbed`** baked into the snapshot at *prepare* time (no per-arm chown). `container.py` gains a `volumes=` param + a `post_strip_exec` hook.

### Isolation guarantees (acceptance criteria)
- **Tool restriction** single-sourced via `ClaudeRunner.build_tools_flags` — `code_only` gets codebox + `--disallowedTools`; verified in-container the agent **cannot** reach native file tools.
- **Executed-code network isolation** (`unshare -n`) confirmed active in-container (real `execute_code` → `URLError`; agent keeps API network).
- **Credentials never persist in an image/commit**: snapshot committed pre-creds; creds live only in ephemeral arm containers.

### MCP startup race (root-caused + fixed)
Claude Code's MCP init is a **nondeterministic, documented "uncontrolled" race**; under the in-container cold start the codebox server sometimes registers too late and a `code_only` turn sees no `execute_code`. Fixed with **detect-and-retry** — zero `mcp__codebox__` use on a code-required arm ⇒ MCP never connected ⇒ retry (failed rolls are cheap; successes never retried) — plus a generous `MCP_TIMEOUT`.

## Tests
- **11 hermetic** (CI): flag/path/config/staging assembly + the retry state machine, docker mocked.
- **`@integration`** (no cost): credentials absent from the snapshot image; agent user baked.
- **`ONLYCODES_RUN_AGENT_TESTS=1`** (live, gated — costs \$ + creds): `code_only` restriction + net-iso, baseline keeps native tools.

Locally: **875 hermetic pass**; live suite green; `code_only` **reliable 3/3** on fresh cold containers.

## Scope boundary
Transcript/result cp-out + no-leak scan → C4b #324. Codex → #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)