### PR TITLE
WS-C.4b(#324): in-container agent output capture + no-leak

### DIFF
--- a/swebench/container_agent.py
+++ b/swebench/container_agent.py
@@ -419,3 +419,124 @@ def run_agent(
             max_attempts, arm,
         )
     return rc
+
+
+# --------------------------------------------------------------------------
+# Output capture + no-leak (C4b #324)
+# --------------------------------------------------------------------------
+
+class ContainerLeakError(RuntimeError):
+    """A held-out grader / reference / test artifact was visible to the agent.
+
+    The image-runtime analog of artifact ``MaterializationError`` — raised by
+    :func:`assert_no_leak` (mirror of ``artifact_materialize._assert_no_leak``).
+    """
+
+
+def extract_agent_diff(handle: ContainerHandle, dest_path: str) -> str:
+    """Write the agent's repo diff (``git diff`` over ``/testbed``) to the host.
+
+    The snapshot's ``/testbed`` is a single orphan commit at the instance's
+    ``base_commit`` tree (C3 strip), so ``git diff`` is exactly the agent's
+    change set vs base — the *model patch* C5 grades.  Run as the agent user
+    (it owns ``/testbed``).  ``dest_path`` is a **host** path, never mounted into
+    the container, so the agent cannot read its own captured result.  Returns the
+    diff text.
+    """
+    proc = container._docker(
+        ["exec", "-u", AGENT_USER, "-w", "/testbed", handle.container_id,
+         "git", "diff"],
+        check=True,
+    )
+    diff = proc.stdout.decode("utf-8", "replace") if proc.stdout else ""
+    Path(dest_path).write_text(diff)
+    return diff
+
+
+def held_out_markers_from_patch(test_patch: str) -> list[str]:
+    """Names of test functions/classes *added* by a held-out test patch.
+
+    These are the content markers that must NOT already be present in the
+    agent's ``/testbed`` (the SWE-bench leak vector is added assertions in
+    existing files, which a filename scan can't catch).  Parses ``+def test_*``
+    / ``+class *Test*`` from the patch's added lines.
+    """
+    markers: list[str] = []
+    for line in test_patch.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        s = line[1:].strip()
+        if s.startswith("def "):
+            name = s[4:].split("(", 1)[0].strip()
+            if name.startswith("test") or name.startswith("Test"):
+                markers.append(name)
+        elif s.startswith("class ") and "Test" in s:
+            markers.append(s[6:].split("(", 1)[0].split(":", 1)[0].strip())
+    return markers
+
+
+#: Held-out artifact basenames that must never be visible in-container — mirrors
+#: the artifact no-leak scan (``hidden.py`` grader module, ``reference_output.*``
+#: golden artifact) plus the SWE-bench held-out test patch file.
+_LEAK_FIND_SCRIPT = r"""
+set -eu
+for root in "$@"; do
+    [ -e "$root" ] || continue
+    find "$root" -type f \( \
+        -name hidden.py -o \
+        -name 'reference_output*' -o \
+        -name '*_tests.patch' -o \
+        -name '*.gold.patch' \
+    \) 2>/dev/null
+done
+"""
+
+
+def assert_no_leak(
+    handle: ContainerHandle,
+    *,
+    test_patch: str | None = None,
+    extra_markers: tuple[str, ...] = (),
+    roots: tuple[str, ...] = ("/testbed", CFG_DIR),
+) -> None:
+    """Fail loudly if any held-out grader/reference/test artifact is visible to
+    the agent inside the container (mirror of ``_assert_no_leak``).
+
+    Two checks over ``roots`` (default ``/testbed`` + the agent-readable
+    ``/opt/cfg``):
+
+    1. **Filenames** — ``hidden.py``, ``reference_output*``, ``*_tests.patch``,
+       ``*.gold.patch`` must not exist.
+    2. **Content markers** — the held-out test names added by ``test_patch``
+       (plus ``extra_markers``) must not already appear in ``/testbed`` sources;
+       their presence means the held-out assertions leaked.
+
+    Call after the agent finishes and **before** the held-out test patch is
+    applied (C5).  Raises :class:`ContainerLeakError` on any hit.
+    """
+    cid = handle.container_id
+    leaks: list[str] = []
+
+    found = container._docker(
+        ["exec", cid, "bash", "-c", _LEAK_FIND_SCRIPT, "scan", *roots], check=False,
+    )
+    names = [l for l in (found.stdout or b"").decode("utf-8", "replace").splitlines() if l.strip()]
+    leaks += [f"file: {n}" for n in names]
+
+    markers = list(held_out_markers_from_patch(test_patch or "")) + list(extra_markers)
+    if markers:
+        # grep -F (fixed strings) -r -l: list files in /testbed containing a marker.
+        pattern = "\n".join(markers)
+        hit = container._docker(
+            ["exec", "-i", cid, "bash", "-c",
+             'grep -rlF -f - /testbed 2>/dev/null || true'],
+            check=False, input_bytes=pattern.encode(),
+        )
+        hits = [l for l in (hit.stdout or b"").decode("utf-8", "replace").splitlines() if l.strip()]
+        leaks += [f"held-out marker in: {h}" for h in hits]
+
+    if leaks:
+        raise ContainerLeakError(
+            "held-out artifacts visible to the agent in-container:\n  "
+            + "\n  ".join(leaks)
+        )

--- a/tests/test_container_agent.py
+++ b/tests/test_container_agent.py
@@ -215,6 +215,69 @@ def test_run_agent_gives_up_after_max_attempts(monkeypatch, tmp_path) -> None:
 
 
 # --------------------------------------------------------------------------
+# Hermetic: output capture + no-leak (C4b #324)
+# --------------------------------------------------------------------------
+
+_TEST_PATCH = (
+    "diff --git a/test_requests.py b/test_requests.py\n"
+    "--- a/test_requests.py\n"
+    "+++ b/test_requests.py\n"
+    "@@ -58,6 +58,13 @@ def test_basic_building(self):\n"
+    "+    def test_no_content_length(self):\n"
+    "+        get_req = requests.Request('GET', httpbin('get')).prepare()\n"
+    "+        self.assertTrue('Content-Length' not in get_req.headers)\n"
+    "+class ExtraTestCase(unittest.TestCase):\n"
+)
+
+
+def test_held_out_markers_from_patch_extracts_added_test_names() -> None:
+    markers = ca.held_out_markers_from_patch(_TEST_PATCH)
+    assert "test_no_content_length" in markers
+    assert "ExtraTestCase" in markers
+    # context/removed lines and the +++ header are not markers.
+    assert "test_basic_building" not in markers
+
+
+def test_extract_agent_diff_writes_host_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(container, "_docker",
+                        lambda args, **kw: types.SimpleNamespace(
+                            returncode=0, stdout=b"diff --git a/m.py b/m.py\n-x\n", stderr=b""))
+    dest = tmp_path / "model.patch"
+    out = ca.extract_agent_diff(ContainerHandle("i", "c", "s"), str(dest))
+    assert "diff --git a/m.py" in out
+    assert dest.read_text() == out  # host file written, agent can't reach host fs
+
+
+def test_assert_no_leak_passes_when_clean(monkeypatch) -> None:
+    # find -> nothing; grep -> nothing.
+    monkeypatch.setattr(container, "_docker",
+                        lambda args, **kw: types.SimpleNamespace(
+                            returncode=0, stdout=b"", stderr=b""))
+    ca.assert_no_leak(ContainerHandle("i", "c", "s"), test_patch=_TEST_PATCH)  # no raise
+
+
+def test_assert_no_leak_raises_on_forbidden_filename(monkeypatch) -> None:
+    def _fake(args, **kw):
+        # the find script (bash -c ... scan) returns a grader file.
+        if "bash" in args and any("find" in a for a in args):
+            return types.SimpleNamespace(returncode=0, stdout=b"/testbed/grader/hidden.py\n", stderr=b"")
+        return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+    monkeypatch.setattr(container, "_docker", _fake)
+    with pytest.raises(ca.ContainerLeakError, match="hidden.py"):
+        ca.assert_no_leak(ContainerHandle("i", "c", "s"))
+
+
+def test_assert_no_leak_raises_on_held_out_marker(monkeypatch) -> None:
+    def _fake(args, **kw):
+        if "grep" in " ".join(a for a in args if isinstance(a, str)):
+            return types.SimpleNamespace(returncode=0, stdout=b"/testbed/test_requests.py\n", stderr=b"")
+        return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+    monkeypatch.setattr(container, "_docker", _fake)
+    with pytest.raises(ca.ContainerLeakError, match="held-out marker"):
+        ca.assert_no_leak(ContainerHandle("i", "c", "s"), test_patch=_TEST_PATCH)
+
+
+# --------------------------------------------------------------------------
 # Integration scaffolding
 # --------------------------------------------------------------------------
 
@@ -403,3 +466,38 @@ def test_baseline_turn_keeps_native_tools(staged_arm, tmp_path) -> None:
     }
     # baseline arm has native tools available and used at least one.
     assert used and used & {"Read", "Bash", "Glob", "Grep"}, f"tools used: {used}"
+
+
+# --------------------------------------------------------------------------
+# Integration (no cost — no agent turn): output capture + no-leak (C4b #324)
+# --------------------------------------------------------------------------
+
+@requires_docker
+def test_extract_diff_and_no_leak_on_clean_container(staged_arm, tmp_path) -> None:
+    # A freshly staged container (no agent edits yet): the model diff is empty,
+    # and the held-out test markers are absent from /testbed.
+    dest = tmp_path / "model.patch"
+    diff = ca.extract_agent_diff(staged_arm, str(dest))
+    assert diff == "" and dest.read_text() == "", "pristine /testbed should have empty diff"
+    # No-leak passes: requests-1142's held-out test name isn't in base /testbed.
+    ca.assert_no_leak(staged_arm, test_patch=_TEST_PATCH)
+
+
+@requires_docker
+def test_assert_no_leak_catches_a_real_in_container_leak(staged_arm) -> None:
+    # Simulate the held-out test leaking into /testbed; the scan must catch it.
+    container._docker(
+        ["exec", "-u", ca.AGENT_USER, staged_arm.container_id, "bash", "-c",
+         "echo 'def test_no_content_length(self): pass' > /testbed/leaked_test.py"],
+        check=True,
+    )
+    with pytest.raises(ca.ContainerLeakError, match="held-out marker"):
+        ca.assert_no_leak(staged_arm, test_patch=_TEST_PATCH)
+    # And a forbidden filename is caught too.
+    container._docker(
+        ["exec", staged_arm.container_id, "bash", "-c",
+         "mkdir -p /testbed/grader && touch /testbed/grader/hidden.py"],
+        check=True,
+    )
+    with pytest.raises(ca.ContainerLeakError, match="hidden.py"):
+        ca.assert_no_leak(staged_arm)


### PR DESCRIPTION
Closes #324. Part of epic #314 (ADR-0004). Split out of C4 (#318); depends on it.

Get the agent's output **out of** the container, intact and leak-free.

## Added to `swebench/container_agent.py`
- **`extract_agent_diff(handle, dest)`** — `git diff` over `/testbed` → host file. The snapshot's `/testbed` is an orphan commit at `base_commit` (C3 strip), so the diff *is* the model patch C5 grades. Written to a **host** path never mounted into the container ⇒ the agent can't read its own captured result. (Transcript is already host-side via `run_agent`.)
- **`assert_no_leak` + `ContainerLeakError`** — image-runtime analog of artifact `_assert_no_leak`. Scans `/testbed` + `/opt/cfg` for:
  - forbidden **filenames**: `hidden.py`, `reference_output*`, `*_tests.patch`, `*.gold.patch`;
  - forbidden **content markers**: held-out `def test_*` / `Test*` names parsed from the test patch (`held_out_markers_from_patch`) — the real SWE-bench leak vector (added assertions in *existing* files, which a filename scan misses).
  Call after the agent, before the held-out test patch is applied (C5).

## Acceptance criteria
- ✅ Transcript + result land on host for both arms (transcript via `run_agent`; diff via `extract_agent_diff`).
- ✅ No-leak check mirrors the artifact `materialize()` scan, runs in-container.

## Tests
- **5 hermetic** (CI): marker parsing, diff write, no-leak clean/filename/marker (docker mocked).
- **2 free `@integration`** (docker, no agent turn → no cost): clean diff + no-leak pass on a staged container; a synthetic leak (held-out marker file + `hidden.py`) is caught.

880 hermetic pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)