### PR TITLE
WS-C.3b(#323): image registry + disk management (pull-by-digest, LRU prune, repo grouping)

### DIFF
--- a/docs/adr-0004-verified-docker-images.md
+++ b/docs/adr-0004-verified-docker-images.md
@@ -136,6 +136,25 @@ Decomposed into child issues on #314:
   bind-mounts** (under DooD the `-v` source resolves on the docker host — C2 finding).
 - **C3b (#323) — Image + registry + disk management.** Pull-by-digest; Docker Hub
   rate-limits/auth/bandwidth (~1 TB for the set); optional registry mirror; prune/disk.
+  **Implemented (`swebench/image_store.py`):**
+  - *Pull-by-digest* — `resolve_remote_digest` (`buildx imagetools inspect`, **no pull**)
+    pins `:latest`→`repo@sha256:…`; digests vendored in
+    `swebench/data/verified_image_digests.json` (backfill: `scripts/resolve_image_digests.py`).
+  - *Measured disk* — marginal **~4–6 GB per same-repo image** (conda env layer shared only
+    within repo+version; first image of a repo is full, e.g. matplotlib 11.2 GB). Full set is
+    hundreds of GB → ~1 TB on disk; **can't be held at once**.
+  - *Disk policy* — **default cap 150 GB** (`ONLYCODES_IMAGE_CAP_GB`); `ensure_image` pulls on
+    demand and `prune_to_cap` LRU-evicts prepared snapshots + base images (after reclaiming
+    dangling images/stopped containers) to stay under cap. `group_by_repo_version` clusters a
+    repo's instances so its shared layer is reused before eviction (minimises re-pulls).
+  - *Auth — token now, mirror later.* `registry_login` uses `ONLYCODES_DOCKERHUB_TOKEN`
+    (token via stdin, never argv) for a higher pull limit; pulls retry on `toomanyrequests`
+    with exponential backoff. A **registry:2 pull-through cache** is the documented scale-up for
+    the full 500-image sweep (each image hits Hub once; re-pulls after prune served locally) —
+    deferred until the sweep is actually run (needs host dockerd `registry-mirrors` config).
+  - *Op note (C1 follow-up):* the DooD socket reverts to `root:root 0660` on a host Docker
+    Desktop restart; `vscode` then needs re-adding (post-create `chmod a+rw /var/run/docker.sock`).
+    Not a C3b code concern, but it gates any image-runtime run.
 - **C4 (#318) — In-container *Claude* agent execution.** Claude Code + the MCP exec-server
   inside the container; tool restriction (mirror `runner.py:build_tools_flags`); isolated
   config/creds; **preserve the exec-server's executed-code network isolation**. (Codex is the

--- a/scripts/resolve_image_digests.py
+++ b/scripts/resolve_image_digests.py
@@ -1,0 +1,78 @@
+"""Backfill ``swebench/data/verified_image_digests.json`` (C3b #323).
+
+Resolve each Verified instance's official image to a content digest **without
+pulling** (registry manifest inspect via ``buildx imagetools``), so runs pin to
+an exact image rather than the moving ``:latest`` tag.
+
+Authenticate first (``ONLYCODES_DOCKERHUB_TOKEN``) — resolving ~500 manifests
+anonymously will hit Docker Hub's rate limit. Idempotent: skips instances
+already in the manifest unless ``--force``.
+
+    # all 500 from a frozen id list
+    python scripts/resolve_image_digests.py --from-file verified-spine.txt
+    # a few explicit ids
+    python scripts/resolve_image_digests.py --ids psf__requests-1142,django__django-10097
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from swebench import container, image_store as ims  # noqa: E402
+
+
+def _read_ids(args: argparse.Namespace) -> list[str]:
+    ids: list[str] = []
+    if args.ids:
+        ids += [s.strip() for s in args.ids.split(",") if s.strip()]
+    if args.from_file:
+        for line in Path(args.from_file).read_text().splitlines():
+            line = line.split("#", 1)[0].strip()
+            if line:
+                ids.append(line)
+    # de-dup, preserve order
+    seen: set[str] = set()
+    return [i for i in ids if not (i in seen or seen.add(i))]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--from-file", help="file of instance ids (one per line, # comments ok)")
+    ap.add_argument("--ids", help="comma-separated instance ids")
+    ap.add_argument("--force", action="store_true", help="re-resolve ids already in the manifest")
+    args = ap.parse_args()
+
+    ids = _read_ids(args)
+    if not ids:
+        ap.error("provide --from-file and/or --ids")
+
+    if not ims.registry_login():
+        print("WARNING: no ONLYCODES_DOCKERHUB_TOKEN — resolving anonymously "
+              "(rate-limited; fine for a handful, not 500).", file=sys.stderr)
+
+    manifest = ims.load_digest_manifest()
+    resolved = skipped = failed = 0
+    for iid in ids:
+        if iid in manifest and not args.force:
+            skipped += 1
+            continue
+        try:
+            digest = ims.resolve_remote_digest(container.official_image_for(iid))
+            ims.record_digest(iid, digest)
+            resolved += 1
+            print(f"{iid} {digest}")
+        except Exception as e:  # noqa: BLE001 — report and continue the sweep
+            failed += 1
+            print(f"WARN {iid}: {e}", file=sys.stderr)
+
+    print(f"\nresolved={resolved} skipped={skipped} failed={failed} "
+          f"(manifest now {len(ims.load_digest_manifest())} entries)", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/swebench/data/verified_image_digests.json
+++ b/swebench/data/verified_image_digests.json
@@ -1,0 +1,6 @@
+{
+ "matplotlib__matplotlib-20826": "sha256:6e34ae7f0c917617fe48b1d29bf8f07cd9ca48b471df62c8c8d407de3368737d",
+ "matplotlib__matplotlib-20859": "sha256:e74c8dcf1966a38f12c006153569fd813144bf8afa2eece4912dd37a0c5ce10c",
+ "matplotlib__matplotlib-22865": "sha256:4bb5781835eaff37b779787ccfed5e8baef26abbd3c6af187caef594bdc3b882",
+ "psf__requests-1142": "sha256:9b0b13a4a762e809a60424f8fd9ba40b45f87874de87479a771e4e673f937d59"
+}

--- a/swebench/image_store.py
+++ b/swebench/image_store.py
@@ -1,0 +1,329 @@
+"""Image acquisition + on-disk storage policy for the Verified image path (C3b #323).
+
+The image runtime (:mod:`swebench.container`) assumes an instance image is
+present locally.  This module gets it there and keeps the disk bounded:
+
+* **Pull by digest** — resolve ``:latest`` -> digest once (``buildx imagetools
+  inspect``, *no pull*), pin to ``repo@sha256:...``, and record the digest per
+  instance (``swebench/data/verified_image_digests.json``) so runs are
+  reproducible against an exact image, not a moving tag.
+* **Auth** — anonymous Docker Hub is ~100 pulls/6 h; the 500-image set blows past
+  it.  Token now (``ONLYCODES_DOCKERHUB_TOKEN``), pull-through-cache mirror later
+  (the documented scale-up; see the C3b ADR note).  Pulls retry on
+  ``toomanyrequests`` with backoff.
+* **Disk** — measured marginal cost is ~4–6 GB per *same-repo* image (the conda
+  env layer is shared only within repo+version), so the full set is hundreds of
+  GB → ~1 TB and **can't be held at once**.  :func:`ensure_image` pulls on demand
+  and :func:`prune_to_cap` LRU-evicts to a cap (default 150 GB).  Pair with
+  :func:`group_by_repo_version` so a repo's shared layer is reused before it's
+  evicted.
+
+Shells out to the ``docker`` CLI (consistent with :mod:`swebench.container`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+from swebench import container
+from swebench.container import ContainerError, official_image_for
+
+#: Default on-disk cap for the image store. Tight on purpose (holds one–two
+#: repo-groups hot), forcing repo-grouped scheduling. Override with
+#: ``ONLYCODES_IMAGE_CAP_GB``.
+DEFAULT_IMAGE_CAP_GB = 150.0
+
+_DIGEST_MANIFEST = Path(__file__).resolve().parent / "data" / "verified_image_digests.json"
+
+
+def image_cap_gb() -> float:
+    raw = os.environ.get("ONLYCODES_IMAGE_CAP_GB")
+    try:
+        return float(raw) if raw else DEFAULT_IMAGE_CAP_GB
+    except ValueError:
+        return DEFAULT_IMAGE_CAP_GB
+
+
+# --------------------------------------------------------------------------
+# Usage log (for LRU) — runtime cache, not committed
+# --------------------------------------------------------------------------
+
+def _usage_path() -> Path:
+    root = os.environ.get("SWEBENCH_CACHE_ROOT", "/workspaces/.swebench-cache")
+    return Path(root) / "image_usage.json"
+
+
+def _load_usage() -> dict[str, float]:
+    p = _usage_path()
+    if p.is_file():
+        try:
+            return json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {}
+    return {}
+
+
+def _stamp_usage(instance_id: str, *, now: float) -> None:
+    p = _usage_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    usage = _load_usage()
+    usage[instance_id] = now
+    p.write_text(json.dumps(usage))
+
+
+# --------------------------------------------------------------------------
+# Digest manifest (committed) + remote resolution
+# --------------------------------------------------------------------------
+
+def load_digest_manifest() -> dict[str, str]:
+    if _DIGEST_MANIFEST.is_file():
+        try:
+            return json.loads(_DIGEST_MANIFEST.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {}
+    return {}
+
+
+def record_digest(instance_id: str, digest: str, *, manifest_path: Path | None = None) -> None:
+    """Persist ``instance_id -> digest`` into the vendored manifest (sorted)."""
+    path = manifest_path or _DIGEST_MANIFEST
+    data = {}
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            data = {}
+    data[instance_id] = digest
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(sorted(data.items())), indent=1) + "\n")
+
+
+def resolve_remote_digest(ref: str) -> str:
+    """Return the registry manifest digest (``sha256:...``) for ``ref`` WITHOUT
+    pulling it (``docker buildx imagetools inspect``).  Used to pin a moving
+    ``:latest`` to an exact image before any pull."""
+    proc = container._docker(
+        ["buildx", "imagetools", "inspect", ref, "--format", "{{.Manifest.Digest}}"],
+        check=False,
+    )
+    digest = container._decode(proc) if proc.returncode == 0 else ""
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise ContainerError(
+            f"could not resolve remote digest for {ref!r}: "
+            f"{container._decode(proc) or proc.stderr.decode('utf-8','replace')[:200]}"
+        )
+    return digest
+
+
+def pinned_ref(instance_id: str, digest: str) -> str:
+    """``repo@sha256:...`` form of an instance image, for a reproducible pull."""
+    repo = official_image_for(instance_id).rsplit(":", 1)[0]
+    return f"{repo}@{digest}"
+
+
+# --------------------------------------------------------------------------
+# Auth
+# --------------------------------------------------------------------------
+
+def registry_login() -> bool:
+    """``docker login`` Docker Hub if ``ONLYCODES_DOCKERHUB_TOKEN`` (and optional
+    ``ONLYCODES_DOCKERHUB_USER``) are set.  Returns True if a login was attempted
+    successfully, False if no token (anonymous — fine for small runs, but
+    rate-limited; see the mirror note for the full sweep)."""
+    token = os.environ.get("ONLYCODES_DOCKERHUB_TOKEN")
+    if not token:
+        return False
+    user = os.environ.get("ONLYCODES_DOCKERHUB_USER", "")
+    proc = container._docker(
+        ["login", "--username", user or "_", "--password-stdin"],
+        check=False, input_bytes=token.encode(),
+    )
+    return proc.returncode == 0
+
+
+# --------------------------------------------------------------------------
+# Pull (by digest, rate-limit aware)
+# --------------------------------------------------------------------------
+
+def pull_pinned(
+    instance_id: str,
+    *,
+    digest: str | None = None,
+    record: bool = True,
+    retries: int = 4,
+    timeout: float | None = 1800,
+) -> dict:
+    """Ensure the instance image is present, pinned by digest.
+
+    Resolves the digest (from ``digest``, else the committed manifest, else
+    remotely) and pulls ``repo@sha256:...``.  Retries on Docker Hub
+    ``toomanyrequests`` with exponential backoff.  Returns
+    ``{"instance_id", "ref", "digest"}``.  When ``record``, persists a freshly
+    resolved digest into the manifest.
+    """
+    ref_latest = official_image_for(instance_id)
+    if digest is None:
+        digest = load_digest_manifest().get(instance_id)
+    newly_resolved = digest is None
+    if digest is None:
+        digest = resolve_remote_digest(ref_latest)
+
+    ref = pinned_ref(instance_id, digest)
+    if not container.image_present(ref):
+        _pull_with_backoff(ref, retries=retries, timeout=timeout)
+    if record and newly_resolved:
+        record_digest(instance_id, digest)
+    return {"instance_id": instance_id, "ref": ref, "digest": digest}
+
+
+def _pull_with_backoff(ref: str, *, retries: int, timeout: float | None,
+                       _sleep=time.sleep) -> None:
+    delay = 30.0
+    for attempt in range(1, retries + 1):
+        proc = container._docker(["pull", ref], check=False, timeout=timeout)
+        if proc.returncode == 0:
+            return
+        err = (proc.stderr or b"").decode("utf-8", "replace")
+        if "toomanyrequests" in err.lower() or "rate limit" in err.lower():
+            if attempt < retries:
+                _sleep(delay)
+                delay *= 2
+                continue
+        raise ContainerError(f"pull {ref!r} failed: {err.strip()[:300]}")
+    raise ContainerError(f"pull {ref!r} exhausted {retries} retries (rate limited)")
+
+
+# --------------------------------------------------------------------------
+# Disk accounting + prune (LRU)
+# --------------------------------------------------------------------------
+
+_SIZE_RE = re.compile(r"([0-9.]+)\s*([KMGT]?i?B)", re.IGNORECASE)
+_UNIT_GB = {"b": 1e-9, "kb": 1e-6, "mb": 1e-3, "gb": 1.0, "tb": 1e3,
+            "kib": 2 ** 10 / 1e9, "mib": 2 ** 20 / 1e9, "gib": 2 ** 30 / 1e9,
+            "tib": 2 ** 40 / 1e9}
+
+
+def _to_gb(human: str) -> float:
+    m = _SIZE_RE.search(human or "")
+    if not m:
+        return 0.0
+    return float(m.group(1)) * _UNIT_GB.get(m.group(2).lower(), 1.0)
+
+
+def image_disk_gb() -> float:
+    """Total (dedup-aware) on-disk size of all images, in GB, per ``docker system df``."""
+    proc = container._docker(["system", "df", "--format", "{{.Type}}|{{.Size}}"], check=False)
+    for line in container._decode(proc).splitlines():
+        kind, _, size = line.partition("|")
+        if kind.strip().lower().startswith("image"):
+            return _to_gb(size)
+    return 0.0
+
+
+def _our_images() -> list[tuple[str, str]]:
+    """(repository, image_id) for swebench eval images + our prepared snapshots."""
+    proc = container._docker(
+        ["images", "--format", "{{.Repository}}|{{.ID}}", "--no-trunc"], check=False)
+    out = []
+    for line in container._decode(proc).splitlines():
+        repo, _, iid = line.partition("|")
+        if "sweb.eval" in repo or repo.startswith("onlycodes/prepared"):
+            out.append((repo, iid))
+    return out
+
+
+def _instance_of_repo(repo: str) -> str | None:
+    if repo.startswith("onlycodes/prepared:"):
+        return repo.split(":", 1)[1]
+    m = re.search(r"sweb\.eval\.x86_64\.(.+)", repo)
+    if m:
+        return m.group(1).rsplit(":", 1)[0].replace(container._NAMESPACE_TOKEN, "__")
+    return None
+
+
+def prune_to_cap(cap_gb: float, *, protect: tuple[str, ...] = (), _now=None) -> dict:
+    """Evict images LRU until image disk is under ``cap_gb``.
+
+    Order: dangling images + stopped containers first (free reclaimable space —
+    the daemon routinely carries tens of GB here), then our images (prepared
+    snapshots and base eval images) by least-recently-used instance, skipping any
+    instance in ``protect``.  Returns ``{"removed": [...], "disk_gb_after": ...}``.
+    """
+    removed: list[str] = []
+    # Cheap reclaim first: stopped containers + dangling images.
+    container._docker(["container", "prune", "-f"], check=False)
+    container._docker(["image", "prune", "-f"], check=False)
+    if image_disk_gb() <= cap_gb:
+        return {"removed": removed, "disk_gb_after": image_disk_gb()}
+
+    usage = _load_usage()
+    protect_set = set(protect)
+    # LRU order: oldest-used (or never-used = -inf) first.
+    images = _our_images()
+
+    def _key(item: tuple[str, str]) -> float:
+        inst = _instance_of_repo(item[0])
+        return usage.get(inst, float("-inf")) if inst else float("-inf")
+
+    for repo, _iid in sorted(images, key=_key):
+        if image_disk_gb() <= cap_gb:
+            break
+        inst = _instance_of_repo(repo)
+        if inst and inst in protect_set:
+            continue
+        if container._docker(["rmi", "-f", repo], check=False).returncode == 0:
+            removed.append(repo)
+    return {"removed": removed, "disk_gb_after": image_disk_gb()}
+
+
+# --------------------------------------------------------------------------
+# Orchestration entry for the run loop
+# --------------------------------------------------------------------------
+
+def ensure_image(instance_id: str, *, cap_gb: float | None = None, _now=None) -> dict:
+    """Make the instance image present (pinned by digest), keeping disk under the
+    cap.  Stamps LRU usage, prunes if over cap (protecting this instance), then
+    pulls.  Returns :func:`pull_pinned`'s dict plus ``"pruned"``.
+
+    This is the single entry the image-runtime arm loop calls before
+    :func:`container.prepare_instance`.
+    """
+    cap = cap_gb if cap_gb is not None else image_cap_gb()
+    now = _now if _now is not None else time.time()
+    _stamp_usage(instance_id, now=now)
+
+    pruned: dict = {"removed": []}
+    if image_disk_gb() > cap:
+        pruned = prune_to_cap(cap, protect=(instance_id,), _now=now)
+
+    info = pull_pinned(instance_id)
+    info["pruned"] = pruned["removed"]
+    return info
+
+
+# --------------------------------------------------------------------------
+# Repo-grouped scheduling
+# --------------------------------------------------------------------------
+
+def _repo_version_key(instance_id: str) -> str:
+    """Group key — ``<repo>`` from the instance id (``psf__requests-1142`` ->
+    ``psf__requests``).  Same-repo instances share the heavy conda layer, so
+    grouping them keeps re-pulls near zero under a tight cap."""
+    return instance_id.rsplit("-", 1)[0]
+
+
+def group_by_repo_version(instance_ids: list[str]) -> list[str]:
+    """Reorder instance ids so same-repo instances are contiguous — process a
+    repo's group together to reuse its shared layer before eviction.  Stable
+    within a group (preserves input order)."""
+    groups: dict[str, list[str]] = {}
+    for iid in instance_ids:
+        groups.setdefault(_repo_version_key(iid), []).append(iid)
+    out: list[str] = []
+    for key in sorted(groups):
+        out.extend(groups[key])
+    return out

--- a/tests/test_image_store.py
+++ b/tests/test_image_store.py
@@ -1,0 +1,246 @@
+"""Tests for the image store / registry + disk policy (``swebench/image_store.py``, C3b #323).
+
+* **Hermetic** (CI): digest resolution/manifest, size parsing, LRU prune + protect,
+  pull-by-digest, rate-limit backoff, ensure_image orchestration, repo grouping —
+  docker mocked.
+* **``@integration``** (needs Docker): non-destructive live checks — real remote
+  digest resolution, disk accounting, and idempotent pinned pull on a present image.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import types
+from pathlib import Path
+
+import pytest
+
+from swebench import container, image_store as ims
+
+
+def _proc(rc=0, stdout=b"", stderr=b""):
+    return types.SimpleNamespace(returncode=rc, stdout=stdout, stderr=stderr)
+
+
+# --------------------------------------------------------------------------
+# Digest resolution + manifest
+# --------------------------------------------------------------------------
+
+_DIGEST = "sha256:" + "9b0b13a4" * 8
+
+
+def test_resolve_remote_digest_ok_and_bad(monkeypatch) -> None:
+    monkeypatch.setattr(container, "_docker", lambda a, **k: _proc(0, (_DIGEST + "\n").encode()))
+    assert ims.resolve_remote_digest("repo:latest") == _DIGEST
+    monkeypatch.setattr(container, "_docker", lambda a, **k: _proc(1, b"", b"not found"))
+    with pytest.raises(container.ContainerError, match="could not resolve"):
+        ims.resolve_remote_digest("repo:latest")
+
+
+def test_pinned_ref() -> None:
+    assert ims.pinned_ref("psf__requests-1142", _DIGEST) == (
+        f"swebench/sweb.eval.x86_64.psf_1776_requests-1142@{_DIGEST}")
+
+
+def test_digest_manifest_roundtrip_sorted(tmp_path, monkeypatch) -> None:
+    mf = tmp_path / "digests.json"
+    monkeypatch.setattr(ims, "_DIGEST_MANIFEST", mf)
+    ims.record_digest("z__z-2", "sha256:bbb")
+    ims.record_digest("a__a-1", "sha256:aaa")
+    data = ims.load_digest_manifest()
+    assert data == {"a__a-1": "sha256:aaa", "z__z-2": "sha256:bbb"}
+    assert list(data) == ["a__a-1", "z__z-2"]  # persisted sorted
+
+
+# --------------------------------------------------------------------------
+# Sizes / cap / grouping
+# --------------------------------------------------------------------------
+
+def test_to_gb_units() -> None:
+    assert round(ims._to_gb("293.2GB"), 1) == 293.2
+    assert round(ims._to_gb("512MiB"), 3) == 0.537
+    assert ims._to_gb("garbage") == 0.0
+
+
+def test_image_disk_gb_parses_df(monkeypatch) -> None:
+    monkeypatch.setattr(container, "_docker",
+                        lambda a, **k: _proc(0, b"Images|293.0GB\nContainers|10GB\n"))
+    assert round(ims.image_disk_gb(), 1) == 293.0
+
+
+def test_image_cap_gb_env(monkeypatch) -> None:
+    monkeypatch.delenv("ONLYCODES_IMAGE_CAP_GB", raising=False)
+    assert ims.image_cap_gb() == ims.DEFAULT_IMAGE_CAP_GB
+    monkeypatch.setenv("ONLYCODES_IMAGE_CAP_GB", "42.5")
+    assert ims.image_cap_gb() == 42.5
+    monkeypatch.setenv("ONLYCODES_IMAGE_CAP_GB", "nonsense")
+    assert ims.image_cap_gb() == ims.DEFAULT_IMAGE_CAP_GB
+
+
+def test_group_by_repo_version_clusters_same_repo() -> None:
+    ids = ["sympy__sympy-1", "psf__requests-9", "sympy__sympy-2",
+           "matplotlib__matplotlib-5", "psf__requests-1"]
+    out = ims.group_by_repo_version(ids)
+    # contiguous per repo, sorted by repo key, input order kept within a group.
+    assert out == ["matplotlib__matplotlib-5", "psf__requests-9", "psf__requests-1",
+                   "sympy__sympy-1", "sympy__sympy-2"]
+
+
+# --------------------------------------------------------------------------
+# Auth + pull
+# --------------------------------------------------------------------------
+
+def test_registry_login_token_and_anon(monkeypatch) -> None:
+    monkeypatch.delenv("ONLYCODES_DOCKERHUB_TOKEN", raising=False)
+    assert ims.registry_login() is False
+    seen = {}
+    monkeypatch.setenv("ONLYCODES_DOCKERHUB_TOKEN", "tok")
+    monkeypatch.setenv("ONLYCODES_DOCKERHUB_USER", "alice")
+    def _fake(args, **kw):
+        seen["args"] = args
+        seen["input"] = kw.get("input_bytes")
+        return _proc(0)
+    monkeypatch.setattr(container, "_docker", _fake)
+    assert ims.registry_login() is True
+    assert "login" in seen["args"] and "alice" in seen["args"]
+    assert seen["input"] == b"tok"  # token via stdin, never argv
+
+
+def test_pull_with_backoff_retries_then_succeeds(monkeypatch) -> None:
+    calls = {"n": 0}
+    def _fake(args, **kw):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _proc(1, b"", b"toomanyrequests: rate limit exceeded")
+        return _proc(0)
+    monkeypatch.setattr(container, "_docker", _fake)
+    ims._pull_with_backoff("repo@sha256:x", retries=4, timeout=10, _sleep=lambda s: None)
+    assert calls["n"] == 3
+
+
+def test_pull_with_backoff_non_ratelimit_raises_immediately(monkeypatch) -> None:
+    calls = {"n": 0}
+    def _fake(args, **kw):
+        calls["n"] += 1
+        return _proc(1, b"", b"manifest unknown")
+    monkeypatch.setattr(container, "_docker", _fake)
+    with pytest.raises(container.ContainerError, match="manifest unknown"):
+        ims._pull_with_backoff("repo@sha256:x", retries=4, timeout=10, _sleep=lambda s: None)
+    assert calls["n"] == 1  # no retry for non-ratelimit errors
+
+
+def test_pull_pinned_uses_manifest_digest_and_skips_present(monkeypatch) -> None:
+    monkeypatch.setattr(ims, "load_digest_manifest", lambda: {"psf__requests-1142": _DIGEST})
+    monkeypatch.setattr(container, "image_present", lambda ref: True)
+    pulled = []
+    monkeypatch.setattr(ims, "_pull_with_backoff", lambda ref, **k: pulled.append(ref))
+    info = ims.pull_pinned("psf__requests-1142")
+    assert info["digest"] == _DIGEST
+    assert info["ref"].endswith(f"@{_DIGEST}")
+    assert pulled == []  # already present -> no pull
+
+
+# --------------------------------------------------------------------------
+# Prune (LRU + protect)
+# --------------------------------------------------------------------------
+
+def test_prune_to_cap_evicts_lru_and_protects(monkeypatch) -> None:
+    # Three distinct instances; c is oldest-used but protected, a is next LRU.
+    monkeypatch.setattr(ims, "_our_images", lambda: [
+        ("swebench/sweb.eval.x86_64.a_1776_a-1:latest", "id1"),   # instance a__a-1, usage 100
+        ("swebench/sweb.eval.x86_64.b_1776_b-2:latest", "id2"),   # instance b__b-2, usage 999 (recent)
+        ("onlycodes/prepared:c__c-3", "id3"),                     # instance c__c-3, usage 50 (protected)
+    ])
+    monkeypatch.setattr(ims, "_load_usage",
+                        lambda: {"a__a-1": 100.0, "b__b-2": 999.0, "c__c-3": 50.0})
+    # over cap through the protected-skip + the a eviction, then under.
+    sizes = iter([150.0, 150.0, 150.0, 50.0, 50.0])
+    monkeypatch.setattr(ims, "image_disk_gb", lambda: next(sizes))
+    removed = []
+    def _fake(args, **kw):
+        if args[:2] == ["rmi", "-f"]:
+            removed.append(args[2])
+        return _proc(0)
+    monkeypatch.setattr(container, "_docker", _fake)
+
+    res = ims.prune_to_cap(100.0, protect=("c__c-3",))
+    # c is the most-LRU but protected; a (next LRU) is evicted; b (recent) untouched.
+    assert "swebench/sweb.eval.x86_64.a_1776_a-1:latest" in res["removed"]
+    assert "onlycodes/prepared:c__c-3" not in res["removed"]
+    assert "swebench/sweb.eval.x86_64.b_1776_b-2:latest" not in res["removed"]
+
+
+def test_prune_to_cap_noop_when_under_cap(monkeypatch) -> None:
+    monkeypatch.setattr(container, "_docker", lambda a, **k: _proc(0))
+    monkeypatch.setattr(ims, "image_disk_gb", lambda: 10.0)
+    res = ims.prune_to_cap(100.0)
+    assert res["removed"] == []
+
+
+# --------------------------------------------------------------------------
+# ensure_image orchestration
+# --------------------------------------------------------------------------
+
+def test_ensure_image_stamps_prunes_and_pulls(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("SWEBENCH_CACHE_ROOT", str(tmp_path))
+    monkeypatch.setattr(ims, "image_disk_gb", lambda: 999.0)  # over cap
+    pruned = {"called": False}
+    def _fake_prune(cap, *, protect=(), _now=None):
+        pruned["called"] = True
+        pruned["protect"] = protect
+        return {"removed": ["x"], "disk_gb_after": 10.0}
+    monkeypatch.setattr(ims, "prune_to_cap", _fake_prune)
+    monkeypatch.setattr(ims, "pull_pinned",
+                        lambda iid: {"instance_id": iid, "ref": "r", "digest": _DIGEST})
+    info = ims.ensure_image("psf__requests-1142", cap_gb=150.0, _now=1234.0)
+    assert pruned["called"] and pruned["protect"] == ("psf__requests-1142",)
+    assert info["pruned"] == ["x"] and info["digest"] == _DIGEST
+    # usage was stamped for the instance.
+    assert ims._load_usage().get("psf__requests-1142") == 1234.0
+
+
+def test_ensure_image_skips_prune_under_cap(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("SWEBENCH_CACHE_ROOT", str(tmp_path))
+    monkeypatch.setattr(ims, "image_disk_gb", lambda: 10.0)  # under cap
+    monkeypatch.setattr(ims, "prune_to_cap",
+                        lambda *a, **k: pytest.fail("should not prune under cap"))
+    monkeypatch.setattr(ims, "pull_pinned",
+                        lambda iid: {"instance_id": iid, "ref": "r", "digest": _DIGEST})
+    info = ims.ensure_image("psf__requests-1142", cap_gb=150.0, _now=1.0)
+    assert info["pruned"] == []
+
+
+# --------------------------------------------------------------------------
+# Integration (Docker, non-destructive)
+# --------------------------------------------------------------------------
+
+def _docker_available() -> bool:
+    try:
+        return subprocess.run(["docker", "version"], capture_output=True, timeout=15).returncode == 0
+    except Exception:
+        return False
+
+
+requires_docker = pytest.mark.skipif(not _docker_available(), reason="docker not available")
+
+
+@pytest.mark.integration
+@requires_docker
+def test_resolve_digest_and_disk_live() -> None:
+    ref = "swebench/sweb.eval.x86_64.psf_1776_requests-1142:latest"
+    digest = ims.resolve_remote_digest(ref)
+    assert digest.startswith("sha256:") and len(digest) == 71
+    assert ims.image_disk_gb() > 0
+
+
+@pytest.mark.integration
+@requires_docker
+def test_pull_pinned_idempotent_on_present_image() -> None:
+    iid = "psf__requests-1142"
+    ref = container.official_image_for(iid)
+    if not container.image_present(ref) and not container.image_present(
+            ims.pinned_ref(iid, ims.load_digest_manifest().get(iid, "sha256:0"))):
+        pytest.skip("requests image not present; skip to stay non-destructive")
+    info = ims.pull_pinned(iid)
+    assert info["digest"].startswith("sha256:")
+    assert info["ref"].endswith(f"@{info['digest']}")


### PR DESCRIPTION
Closes #323. Part of epic #314 (ADR-0004). Split from C3; sizes the storage the full sweep needs.

## Measurement that drove the design
Marginal on-disk cost of additional **same-repo** images: **+6.3 GB** then **+3.9 GB** (matplotlib; same-version images share the conda env layer, different versions don't). So the full 500-set is **hundreds of GB → ~1 TB on disk and can't be held at once** → pull-on-demand + LRU prune + repo-grouped scheduling are load-bearing.

## `swebench/image_store.py`
- **Pull-by-digest** — `resolve_remote_digest` (`buildx imagetools inspect`, **no pull**) pins `:latest` → `repo@sha256:…`. Digests vendored in `swebench/data/verified_image_digests.json` (seeded with 4; backfill via `scripts/resolve_image_digests.py`). Each run records the resolved digest.
- **Disk policy** — default cap **150 GB** (`ONLYCODES_IMAGE_CAP_GB`). `ensure_image` pulls on demand + `prune_to_cap` LRU-evicts prepared snapshots + base images (after reclaiming dangling images / stopped containers — the daemon routinely carries tens of GB) to hold the cap. `group_by_repo_version` clusters a repo's instances so its shared layer is reused before eviction (near-zero re-pulls).
- **Auth — token now, mirror later** — `registry_login` via `ONLYCODES_DOCKERHUB_TOKEN` (token via **stdin, never argv**) for a higher pull limit; pulls retry on `toomanyrequests` with exponential backoff. A **registry:2 pull-through cache** is documented as the scale-up for the full sweep (deferred — needs host dockerd config).

## Acceptance criteria
- ✅ Pull-by-digest with the digest recorded per instance.
- ✅ Rate-limit/auth strategy chosen + documented (token + mirror note in ADR-0004).
- ✅ Prune policy keeps disk under a stated cap across a multi-instance run.

## Tests
- **15 hermetic** (CI): digest/manifest, size parsing, **LRU prune + protect**, pull-by-digest, rate-limit backoff, `ensure_image` orchestration, repo grouping (docker mocked).
- **2 `@integration`** (non-destructive): live remote digest resolution, disk accounting, idempotent pinned pull on a present image.

907 hermetic pass. ADR-0004 updated with the C3b decisions + measured numbers (and a C1 socket-perm op note).

## Follow-ups (ops)
Full 500-digest backfill (needs `ONLYCODES_DOCKERHUB_TOKEN`) and registry-mirror standup — when the broad sweep is actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)