### PR TITLE
WS-C.5(#319): wire --runtime image into a graded end-to-end arm

### DIFF
--- a/docs/adr-0004-verified-docker-images.md
+++ b/docs/adr-0004-verified-docker-images.md
@@ -140,9 +140,21 @@ Decomposed into child issues on #314:
   - *Pull-by-digest* — `resolve_remote_digest` (`buildx imagetools inspect`, **no pull**)
     pins `:latest`→`repo@sha256:…`; digests vendored in
     `swebench/data/verified_image_digests.json` (backfill: `scripts/resolve_image_digests.py`).
-  - *Measured disk* — marginal **~4–6 GB per same-repo image** (conda env layer shared only
-    within repo+version; first image of a repo is full, e.g. matplotlib 11.2 GB). Full set is
-    hundreds of GB → ~1 TB on disk; **can't be held at once**.
+  - *Measured disk + layer profile* (profiled 2026-06-06, requests/matplotlib/django/sympy,
+    10 django + 10 sympy pulled to verify dedup). Each image = ~15 content layers in three tiers:
+    | tier | layer | size | shared scope |
+    |---|---|---|---|
+    | base | ubuntu + apt + miniconda | ~1.5 GB | **all images** (every repo) |
+    | env | `setup_env.sh` (conda env) | django ~1.2 GB · mpl 1.7–3.8 GB | **same repo+version** |
+    | instance | `setup_repo.sh` (/testbed + build) | **django ~0.32 GB · sympy ~0.3 GB · mpl ~2.65 GB** | **unique per instance** |
+    Sharing is real and large: **10 django images added only ~3.6 GB** (vs 39.6 GB nominal, ~91%
+    saved); each additional same-version instance is **~0.2–0.3 GB** (just its thin instance layer).
+    matplotlib is the heavy outlier — its env bakes a full GUI/render stack (PyQt5 + wxPython + Qt
+    runtime) and its repo layer carries image-comparison baselines, so it is 2–3× a typical image.
+    **Grounded full-500 deduped cache ≈ ~400 GB** (base once + ~100 GB of per-repo-version envs +
+    ~290 GB of per-instance layers) — firmly **sub-TB**, dominated by matplotlib + the env spread,
+    *not* the django/sympy bulk. A single pass never needs the whole cache; the 150 GB cap holds
+    hundreds of django/sympy or ~15–20 matplotlib at once.
   - *Disk policy* — **default cap 150 GB** (`ONLYCODES_IMAGE_CAP_GB`); `ensure_image` pulls on
     demand and `prune_to_cap` LRU-evicts prepared snapshots + base images (after reclaiming
     dangling images/stopped containers) to stay under cap. `group_by_repo_version` clusters a

--- a/problems/swe/swebench-verified/psf__requests-1142.yaml
+++ b/problems/swe/swebench-verified/psf__requests-1142.yaml
@@ -27,3 +27,11 @@ added_at: '2026-06-03'
 hf_split: test
 version: '1.1'
 environment_setup_commit: ba25184ed5f0bf9b876dea3cf4312fa35b539a7c
+fail_to_pass:
+- test_requests.py::RequestsTestCase::test_no_content_length
+pass_to_pass:
+- test_requests.py::RequestsTestCase::test_basic_building
+- test_requests.py::RequestsTestCase::test_entry_points
+- test_requests.py::RequestsTestCase::test_invalid_url
+- test_requests.py::RequestsTestCase::test_params_are_added_before_fragment
+- test_requests.py::RequestsTestCase::test_path_is_not_double_encoded

--- a/swebench/add.py
+++ b/swebench/add.py
@@ -105,6 +105,19 @@ def _validate_instance(instance_id: str, repo_slug: str, base_commit: str) -> No
     _echo(f"  Validation complete for {instance_id}.")
 
 
+def _coerce_test_list(value) -> list[str] | None:
+    """Normalise a dataset ``FAIL_TO_PASS``/``PASS_TO_PASS`` field to a list of
+    test node-ids (the HF dataset stores them as a JSON string or a list)."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return [value]
+    return [str(t) for t in value] or None
+
+
 def _build_test_cmd(row: dict, repo_slug: str) -> str:
     """Derive a test command from the dataset row.
 
@@ -193,6 +206,9 @@ def _write_problem(
         # SWE-bench environment keys — drive the official build spec (#311).
         version=(str(row["version"]) if row.get("version") not in (None, "") else None),
         environment_setup_commit=row.get("environment_setup_commit") or None,
+        # Transition-grading ground truth for the image-runtime path (#319).
+        fail_to_pass=_coerce_test_list(row.get("FAIL_TO_PASS")),
+        pass_to_pass=_coerce_test_list(row.get("PASS_TO_PASS")),
     )
 
     yaml_path = problems_dir / set_name / f"{instance_id}.yaml"

--- a/swebench/image_run.py
+++ b/swebench/image_run.py
@@ -1,0 +1,221 @@
+"""Image-runtime arm orchestrator (C5 #319 wiring).
+
+Runs SWE-bench arms end-to-end on the **official prebuilt images**, tying the
+merged building blocks into one graded loop (dispatched from ``run.py`` when
+``--runtime image``):
+
+    image_store.ensure_image      # pull-by-digest + LRU prune to the disk cap
+    container.prepare_instance    # strip /testbed -> snapshot (+ agent user)
+    container.start_arm_container  # fresh container per (arm, run) from the snapshot
+    container_agent.stage_arm      # mount runtime volume + creds + exec-server
+    container_agent.run_agent      # one Claude turn in-container (restricted, net-iso)
+    container_test.grade_agent_run # no-leak -> apply test patch -> eval -> official grade
+
+This is a **dedicated, serial** orchestrator — deliberately separate from the
+overlay path's serial/parallel loop in ``run.py`` (no surgery on that code).
+Instances are processed in repo+version-grouped order so the shared conda layer
+is reused before eviction (C3b).
+
+Scope: a working graded ``--runtime image`` arm. Parallelism, ``--resume`` for
+the image path, and the Codex surface are follow-ups.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from swebench import container, container_agent, container_test, image_store, official_grade, specs
+from swebench.container_agent import runtime_volume_spec
+from swebench.models import Problem
+
+#: SWE-bench image canonical paths.
+_TESTBED = "/testbed"
+_TESTBED_PY = "/opt/miniconda3/envs/testbed/bin/python"
+
+
+def _build_prompt(problem: Problem, arm: str) -> str:
+    """Faithful in-container prompt (mirrors ``run.py`` for /testbed paths)."""
+    parts = [
+        f"You are working in the repository at: {_TESTBED}\n",
+        f"The project's Python interpreter and dependencies are pre-installed at: {_TESTBED_PY}\n",
+    ]
+    if arm in ("onlycode", "code_only"):
+        parts.append(
+            "A `codebox` helper module is auto-imported into your cwd. Workflow: "
+            "OUTLINE -> GREP -> READ_LINES -> EDIT_REPLACE -> RUN.\n"
+            "  import codebox\n"
+            "  codebox.outline(path); codebox.read_lines(path, 200, 250); codebox.peek(path, 182, around=10)\n"
+            "  codebox.grep('pattern', path); codebox.source_of(symbol, root); codebox.files(root)\n"
+            "  codebox.edit_replace(path, old, new)  # exact-once swap\n"
+            "  codebox.write(path, content); codebox.run('cmd', tail=20)\n"
+            "Do NOT use subprocess to run tests; use codebox.run. Do NOT hand-build edits with re.sub.\n"
+            "The execute_code interpreter is a PERSISTENT REPL keyed by cwd: state survives across calls.\n"
+        )
+    parts.append("Fix the following bug. Make the minimal change needed.\n\n" + problem.problem_statement)
+    return "\n".join(parts)
+
+
+def _grading_instance(problem: Problem, test_patch_text: str) -> dict:
+    """Build the SWE-bench instance dict the official grader needs from a Problem.
+
+    The agent arm grades against the agent's own diff, so the gold ``patch`` is
+    not required (``make_test_spec`` builds without it — verified)."""
+    return {
+        "instance_id": problem.instance_id,
+        "repo": problem.repo_slug,
+        "version": problem.version,
+        "base_commit": problem.base_commit,
+        "environment_setup_commit": problem.environment_setup_commit or problem.base_commit,
+        "problem_statement": problem.problem_statement,
+        "FAIL_TO_PASS": problem.fail_to_pass or [],
+        "PASS_TO_PASS": problem.pass_to_pass or [],
+        "test_patch": test_patch_text,
+        "patch": "",
+    }
+
+
+def _read_test_patch(problem: Problem, root: Path) -> str:
+    if not problem.patch_file:
+        return ""
+    p = root / problem.patch_file
+    return p.read_text() if p.is_file() else ""
+
+
+def _extract_cost_turns(transcript_path: str) -> tuple[float | None, int | None]:
+    cost = turns = None
+    try:
+        for line in Path(transcript_path).read_text().splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            rec = json.loads(line)
+            if rec.get("type") == "result":
+                cost = rec.get("total_cost_usd", cost)
+                turns = rec.get("num_turns", turns)
+    except (OSError, json.JSONDecodeError):
+        pass
+    return cost, turns
+
+
+def run_one_arm(
+    problem: Problem,
+    *,
+    arm: str,
+    run_idx: int,
+    prepared: container.PreparedImage,
+    digest_info: dict,
+    grading_instance: dict,
+    spec_test_cmd: str,
+    eval_env: dict,
+    results_dir: str,
+    agent_surface: str = "claude_code",
+    wall_timeout: int = 1800,
+    _now=None,
+) -> str:
+    """Run + grade one (arm, run) in a fresh container; write the record. Returns the verdict."""
+    handle = container.start_arm_container(prepared, volumes=[runtime_volume_spec()])
+    transcript = os.path.join(tempfile.mkdtemp(prefix="img-arm-"), "transcript.jsonl")
+    verdict, resolution, cost, turns = "ERROR", None, None, None
+    try:
+        container_agent.stage_arm(handle)
+        rc = container_agent.run_agent(
+            handle, arm=arm, prompt=_build_prompt(problem, arm),
+            result_path=transcript, wall_timeout=wall_timeout,
+        )
+        log_dest = os.path.join(os.path.dirname(transcript), "eval.txt")
+        grade = container_test.grade_agent_run(
+            handle, grading_instance, spec_test_cmd=spec_test_cmd,
+            eval_env=eval_env, log_dest=log_dest,
+        )
+        resolution = grade.get("resolution")
+        verdict = "PASS" if official_grade.is_resolved(grade) else "FAIL"
+        cost, turns = _extract_cost_turns(transcript)
+        logging.info("image_run %s %s run%d: rc=%s resolution=%s -> %s",
+                     problem.instance_id, arm, run_idx, rc, resolution, verdict)
+    finally:
+        _write_record(
+            results_dir, problem, arm, run_idx,
+            transcript=transcript, verdict=verdict, resolution=resolution,
+            digest_info=digest_info, cost=cost, turns=turns, agent_surface=agent_surface,
+            now=_now if _now is not None else time.time(),
+        )
+        container.teardown(handle)
+    return verdict
+
+
+def _write_record(results_dir, problem, arm, run_idx, *, transcript, verdict, resolution,
+                  digest_info, cost, turns, agent_surface, now) -> None:
+    """Write ``<instance>_<arm>_run<N>.jsonl``: meta line + agent transcript + verdict line."""
+    out = os.path.join(results_dir, f"{problem.instance_id}_{arm}_run{run_idx}.jsonl")
+    meta = {
+        "type": "meta", "instance_id": problem.instance_id, "arm": arm, "run": run_idx,
+        "agent_surface": agent_surface, "runtime": "image",
+        "image_digest": digest_info.get("digest"), "image_arch": digest_info.get("arch"),
+        "resolution": resolution, "verdict": verdict,
+        "total_cost_usd": cost, "num_turns": turns, "graded_utc": now,
+    }
+    os.makedirs(results_dir, exist_ok=True)
+    with open(out, "w") as f:
+        f.write(json.dumps(meta) + "\n")
+        if os.path.isfile(transcript):
+            with open(transcript) as t:
+                for line in t:
+                    if line.strip():
+                        f.write(line if line.endswith("\n") else line + "\n")
+        f.write(json.dumps({"type": "verdict", "verdict": verdict, "resolution": resolution}) + "\n")
+
+
+def run_image_arms(
+    problems: list[Problem],
+    *,
+    arms: list[str],
+    num_runs: int,
+    results_dir: str,
+    agent_binary: str,
+    cap_gb: float | None = None,
+    wall_timeout: int = 1800,
+    echo=print,
+) -> list[tuple[str, str, str]]:
+    """Run ``arms`` over ``problems`` on the image runtime. Returns
+    ``(instance_id, arm, verdict)`` triples."""
+    image_store.registry_login()
+    container_agent.ensure_agent_runtime(agent_binary)
+    root = Path(os.environ.get("ONLYCODES_REPO_ROOT", ".")).resolve()
+
+    order = {iid: i for i, iid in enumerate(
+        image_store.group_by_repo_version([p.instance_id for p in problems]))}
+    problems = sorted(problems, key=lambda p: order.get(p.instance_id, 1 << 30))
+
+    results: list[tuple[str, str, str]] = []
+    for problem in problems:
+        if not problem.fail_to_pass:
+            echo(f"  SKIP {problem.instance_id}: no fail_to_pass (re-run `add` to backfill grading data)")
+            continue
+        spec = specs.spec_for(problem.repo_slug, problem.version)
+        if not spec or not spec.get("test_cmd"):
+            echo(f"  SKIP {problem.instance_id}: no spec test_cmd for {problem.repo_slug}@{problem.version}")
+            continue
+
+        echo(f"--- Instance: {problem.instance_id} ({problem.repo_slug}@{problem.version}) ---")
+        digest_info = image_store.ensure_image(problem.instance_id, cap_gb=cap_gb)
+        prepared = container.prepare_instance(
+            problem.instance_id, post_strip_exec=container_agent.agent_user_setup_commands())
+        gi = _grading_instance(problem, _read_test_patch(problem, root))
+        eval_env = specs.eval_env(spec)
+
+        for arm in arms:
+            for run_idx in range(num_runs):
+                verdict = run_one_arm(
+                    problem, arm=arm, run_idx=run_idx, prepared=prepared,
+                    digest_info=digest_info, grading_instance=gi,
+                    spec_test_cmd=spec["test_cmd"], eval_env=eval_env,
+                    results_dir=results_dir, wall_timeout=wall_timeout,
+                )
+                echo(f"  [{arm} run {run_idx}] {verdict}")
+                results.append((problem.instance_id, arm, verdict))
+    return results

--- a/swebench/image_store.py
+++ b/swebench/image_store.py
@@ -68,11 +68,17 @@ def _load_usage() -> dict[str, float]:
 
 
 def _stamp_usage(instance_id: str, *, now: float) -> None:
-    p = _usage_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    usage = _load_usage()
-    usage[instance_id] = now
-    p.write_text(json.dumps(usage))
+    # Best-effort: LRU usage tracking must never crash a run if the cache dir
+    # isn't writable (falls back to losing recency info, i.e. FIFO-ish prune).
+    try:
+        p = _usage_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        usage = _load_usage()
+        usage[instance_id] = now
+        p.write_text(json.dumps(usage))
+    except OSError as e:
+        logging.warning("image_store: could not record image usage (%s); "
+                        "LRU prune will lack recency info", e)
 
 
 # --------------------------------------------------------------------------
@@ -177,7 +183,12 @@ def pull_pinned(
         _pull_with_backoff(ref, retries=retries, timeout=timeout)
     if record and newly_resolved:
         record_digest(instance_id, digest)
-    return {"instance_id": instance_id, "ref": ref, "digest": digest}
+    # Architecture for the run record (acceptance: digest + arch). Present after
+    # pull; fall back to the x86_64 the image name encodes.
+    proc = container._docker(
+        ["image", "inspect", ref, "--format", "{{.Architecture}}"], check=False)
+    arch = container._decode(proc) if proc.returncode == 0 else "amd64"
+    return {"instance_id": instance_id, "ref": ref, "digest": digest, "arch": arch or "amd64"}
 
 
 def _pull_with_backoff(ref: str, *, retries: int, timeout: float | None,

--- a/swebench/models.py
+++ b/swebench/models.py
@@ -28,6 +28,12 @@ class Problem:
     # The commit SWE-bench installs the environment from (deps may be pinned to
     # it). Captured for fidelity; the install-at-env-commit flow is a follow-up.
     environment_setup_commit: str | None = None
+    # Official transition-grading ground truth (the test node-ids that must flip
+    # red->green, and those that must stay green). Needed by the image-runtime
+    # grading path (C5 #319) via the official parsers; small lists, so stored
+    # inline. Optional for backward compat with pre-#319 YAMLs.
+    fail_to_pass: list[str] | None = None
+    pass_to_pass: list[str] | None = None
 
     def to_yaml(self, path: Path) -> None:
         """Write this problem to a YAML file."""
@@ -42,6 +48,8 @@ class Problem:
             "hf_split": self.hf_split,
             "version": self.version,
             "environment_setup_commit": self.environment_setup_commit,
+            "fail_to_pass": self.fail_to_pass,
+            "pass_to_pass": self.pass_to_pass,
         }
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
@@ -70,6 +78,8 @@ class Problem:
             hf_split=data.get("hf_split", "test"),
             version=data.get("version"),
             environment_setup_commit=data.get("environment_setup_commit"),
+            fail_to_pass=data.get("fail_to_pass"),
+            pass_to_pass=data.get("pass_to_pass"),
         )
 
 

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -850,16 +850,18 @@ def _parse_filter_ids(filter_spec: str) -> set[str]:
     return {s.strip() for s in spec.split(",") if s.strip()}
 
 
-def _run_image_runtime_preflight() -> None:
-    """Handle ``--runtime image`` for C3 (#317).
-
-    The container runtime (``swebench.container``) is built and tested, but a
-    full arm needs C3b's pull/disk policy (#323) and C4/C5's agent + test
-    execution (#318/#319).  Until those land, image mode does a real Docker
-    preflight and reports the runtime is ready, rather than running a partial
-    arm through the overlay-centric loop.
-    """
-    from swebench import container
+def _run_image_runtime(
+    problems: list[Problem],
+    arm_list: list[str],
+    *,
+    results_dir: str,
+    agent_binary: str,
+    num_runs: int,
+    max_wall_seconds: int,
+) -> None:
+    """Handle ``--runtime image`` (C5 #319): Docker preflight, then dispatch to
+    the dedicated image-runtime orchestrator (``swebench.image_run``)."""
+    from swebench import container, image_run
 
     proc = container._docker(["version", "--format", "{{.Server.Version}}"], check=False)
     if proc.returncode != 0:
@@ -869,18 +871,21 @@ def _run_image_runtime_preflight() -> None:
             err=True,
         )
         raise SystemExit(1)
+    click.echo(f"Image runtime: Docker daemon reachable "
+               f"(server {proc.stdout.decode('utf-8', 'replace').strip()}).")
 
-    server = proc.stdout.decode("utf-8", "replace").strip()
-    click.echo(f"Image runtime: Docker daemon reachable (server {server}).")
-    click.echo(
-        "Container layer ready (C3 #317): prepare_instance -> stripped snapshot, "
-        "per-arm reset = fresh container from the snapshot (~286 ms, measured in "
-        "C2 #316)."
+    os.environ.setdefault("ONLYCODES_REPO_ROOT", str(repo_root()))
+    # wall_timeout: max_wall_seconds==0 means unlimited; the orchestrator wants a
+    # positive bound (in-container `timeout`), so fall back to 1800s when unset.
+    wall = max_wall_seconds if max_wall_seconds and max_wall_seconds > 0 else 1800
+    results = image_run.run_image_arms(
+        problems, arms=arm_list, num_runs=num_runs,
+        results_dir=results_dir, agent_binary=agent_binary,
+        wall_timeout=wall, echo=click.echo,
     )
-    click.echo(
-        "Not yet wired for a full arm: pull/disk policy is C3b (#323); agent + "
-        "test execution are C4/C5 (#318/#319). Use --runtime overlay to run."
-    )
+    n_pass = sum(1 for _, _, v in results if v == "PASS")
+    click.echo(f"\nImage runtime: {n_pass}/{len(results)} PASS across "
+               f"{len({i for i, _, _ in results})} instances.")
 
 
 @click.command("run")
@@ -1081,10 +1086,6 @@ def run_command(
         click.echo("ERROR: --parallel must be >= 1", err=True)
         raise SystemExit(1)
 
-    if runtime == "image":
-        _run_image_runtime_preflight()
-        return
-
     root = repo_root()
     problems_dir = root / "problems" / "swe"
     results_dir = Path(output_dir) if output_dir else root / "runs" / "swebench"
@@ -1128,6 +1129,18 @@ def run_command(
         arm_list.append("onlycode")
     if arms in ("bash_only", "all"):
         arm_list.append("bash_only")
+
+    # --- Image runtime: dispatch to the dedicated orchestrator (C5 #319) -------
+    # Runs on the official prebuilt images (pull-by-digest + LRU + in-container
+    # agent + official-parser grading). Deliberately separate from the overlay
+    # serial/parallel loop below.
+    if runtime == "image":
+        _run_image_runtime(
+            problems, arm_list,
+            results_dir=str(results_dir), agent_binary=agent_binary,
+            num_runs=num_runs, max_wall_seconds=max_wall_seconds,
+        )
+        return
 
     # Codex exec-server pre-flight: only needed for arms that use the MCP exec-server.
     # baseline and bash_only run on Codex's native shell/apply_patch surface

--- a/tests/test_image_run.py
+++ b/tests/test_image_run.py
@@ -1,0 +1,116 @@
+"""Tests for the image-runtime orchestrator (``swebench/image_run.py``, C5 #319).
+
+Hermetic: prompt/record/grading-instance assembly and the orchestration flow with
+every container/agent/grade/image-store call mocked. The live end-to-end graded
+arm is exercised via ``--runtime image`` (validated manually; too heavy/costly for
+CI — it needs Docker, the official venv, and a paid agent turn).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from swebench import image_run
+from swebench.container import PreparedImage
+from swebench.models import Problem
+
+
+def _problem(**kw) -> Problem:
+    base = dict(
+        instance_id="psf__requests-1142", repo_slug="psf/requests", base_commit="abc",
+        test_cmd="pytest", problem_statement="GET sends Content-Length", patch_file=None,
+        added_at="", hf_split="test", version="1.1",
+        fail_to_pass=["test_requests.py::T::test_no_content_length"],
+        pass_to_pass=["test_requests.py::T::test_basic_building"],
+    )
+    base.update(kw)
+    return Problem(**base)
+
+
+def test_build_prompt_onlycode_vs_baseline() -> None:
+    p = _problem()
+    only = image_run._build_prompt(p, "onlycode")
+    base = image_run._build_prompt(p, "baseline")
+    assert "/testbed" in only and "/opt/miniconda3/envs/testbed/bin/python" in only
+    assert "codebox" in only and "codebox" not in base  # restriction guidance only for code arm
+    assert p.problem_statement in only and p.problem_statement in base
+
+
+def test_grading_instance_from_problem_has_f2p_p2p_no_gold() -> None:
+    gi = image_run._grading_instance(_problem(), "TESTPATCH")
+    assert gi["repo"] == "psf/requests" and gi["version"] == "1.1"
+    assert gi["FAIL_TO_PASS"] == ["test_requests.py::T::test_no_content_length"]
+    assert gi["PASS_TO_PASS"] == ["test_requests.py::T::test_basic_building"]
+    assert gi["test_patch"] == "TESTPATCH" and gi["patch"] == ""  # gold not needed for agent arm
+
+
+def test_extract_cost_turns(tmp_path) -> None:
+    f = tmp_path / "t.jsonl"
+    f.write_text('{"type":"assistant"}\n{"type":"result","total_cost_usd":0.05,"num_turns":7}\n')
+    assert image_run._extract_cost_turns(str(f)) == (0.05, 7)
+
+
+def test_write_record_meta_transcript_verdict(tmp_path) -> None:
+    transcript = tmp_path / "tr.jsonl"
+    transcript.write_text('{"type":"assistant"}\n{"type":"result","total_cost_usd":0.1}\n')
+    image_run._write_record(
+        str(tmp_path), _problem(), "onlycode", 0,
+        transcript=str(transcript), verdict="PASS", resolution="RESOLVED_FULL",
+        digest_info={"digest": "sha256:abc", "arch": "amd64"},
+        cost=0.1, turns=3, agent_surface="claude_code", now=1.0,
+    )
+    rec = (tmp_path / "psf__requests-1142_onlycode_run0.jsonl").read_text().splitlines()
+    meta = json.loads(rec[0])
+    assert meta["type"] == "meta" and meta["runtime"] == "image"
+    assert meta["verdict"] == "PASS" and meta["image_digest"] == "sha256:abc"
+    assert meta["image_arch"] == "amd64" and meta["resolution"] == "RESOLVED_FULL"
+    assert json.loads(rec[-1]) == {"type": "verdict", "verdict": "PASS", "resolution": "RESOLVED_FULL"}
+    assert any('"type":"assistant"' in l or '"type": "assistant"' in l for l in rec)  # transcript inlined
+
+
+def test_run_one_arm_pass_path(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(image_run.container, "start_arm_container",
+                        lambda prepared, **kw: image_run.container.ContainerHandle("i", "cid", "snap"))
+    monkeypatch.setattr(image_run.container_agent, "stage_arm", lambda h, **kw: None)
+    def _fake_run_agent(h, **kw):
+        Path(kw["result_path"]).write_text('{"type":"result","total_cost_usd":0.2,"num_turns":5}\n')
+        return 0
+    monkeypatch.setattr(image_run.container_agent, "run_agent", _fake_run_agent)
+    monkeypatch.setattr(image_run.container_test, "grade_agent_run",
+                        lambda h, gi, **kw: {"resolution": "RESOLVED_FULL"})
+    monkeypatch.setattr(image_run.official_grade, "is_resolved", lambda g: True)
+    teardown = []
+    monkeypatch.setattr(image_run.container, "teardown", lambda h: teardown.append(h))
+
+    verdict = image_run.run_one_arm(
+        _problem(), arm="onlycode", run_idx=0,
+        prepared=PreparedImage("psf__requests-1142", "base", "snap"),
+        digest_info={"digest": "sha256:x", "arch": "amd64"},
+        grading_instance={"repo": "psf/requests"}, spec_test_cmd="pytest -rA",
+        eval_env={}, results_dir=str(tmp_path), _now=1.0,
+    )
+    assert verdict == "PASS"
+    assert teardown, "container must be torn down"
+    meta = json.loads((tmp_path / "psf__requests-1142_onlycode_run0.jsonl").read_text().splitlines()[0])
+    assert meta["verdict"] == "PASS" and meta["total_cost_usd"] == 0.2
+
+
+def test_run_image_arms_skips_without_grading_data(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(image_run.image_store, "registry_login", lambda: False)
+    monkeypatch.setattr(image_run.container_agent, "ensure_agent_runtime", lambda b, **k: "vol")
+    calls = []
+    monkeypatch.setattr(image_run, "run_one_arm", lambda *a, **k: calls.append(k["arm"]) or "PASS")
+    monkeypatch.setattr(image_run.image_store, "ensure_image",
+                        lambda iid, **k: {"digest": "sha256:x", "arch": "amd64"})
+    monkeypatch.setattr(image_run.container, "prepare_instance", lambda iid, **k: PreparedImage(iid, "b", "s"))
+    monkeypatch.setattr(image_run.specs, "spec_for", lambda r, v: {"test_cmd": "pytest -rA"})
+    monkeypatch.setattr(image_run.specs, "eval_env", lambda s: {})
+
+    good = _problem(instance_id="psf__requests-1142")
+    bad = _problem(instance_id="psf__requests-9999", fail_to_pass=None)
+    out = image_run.run_image_arms([good, bad], arms=["onlycode"], num_runs=1,
+                                   results_dir=str(tmp_path), agent_binary="claude", echo=lambda *a: None)
+    assert out == [("psf__requests-1142", "onlycode", "PASS")]  # bad one skipped (no f2p)

--- a/tests/test_image_store.py
+++ b/tests/test_image_store.py
@@ -132,11 +132,13 @@ def test_pull_with_backoff_non_ratelimit_raises_immediately(monkeypatch) -> None
 def test_pull_pinned_uses_manifest_digest_and_skips_present(monkeypatch) -> None:
     monkeypatch.setattr(ims, "load_digest_manifest", lambda: {"psf__requests-1142": _DIGEST})
     monkeypatch.setattr(container, "image_present", lambda ref: True)
+    monkeypatch.setattr(container, "_docker", lambda a, **k: _proc(0, b"amd64\n"))  # arch lookup
     pulled = []
     monkeypatch.setattr(ims, "_pull_with_backoff", lambda ref, **k: pulled.append(ref))
     info = ims.pull_pinned("psf__requests-1142")
     assert info["digest"] == _DIGEST
     assert info["ref"].endswith(f"@{_DIGEST}")
+    assert info["arch"] == "amd64"
     assert pulled == []  # already present -> no pull
 
 


### PR DESCRIPTION
Part of epic #314 (ADR-0004). The C5 keystone — turns the merged image-runtime pieces into a runnable, graded `--runtime image` arm. Also records the measured layer-sharing profile in ADR-0004 (first commit).

## What this delivers
**`swebench/image_run.py`** — a dedicated, serial image-runtime orchestrator (deliberately *separate* from the overlay serial/parallel loop, no surgery on it):
```
ensure_image (pull-by-digest + LRU)  ->  prepare_instance (strip + snapshot + agent user)
  -> per (arm, run): start fresh container + stage_arm -> run_agent
     -> grade_agent_run (no-leak -> apply test patch -> eval -> official parser) -> record
```
Instances run in **repo+version-grouped** order (C3b). `run.py` dispatches `--runtime image` here after a Docker preflight, writing `<instance>_<arm>_run<N>.jsonl` (meta + transcript + verdict, including **image digest + arch**, cost, turns).

**Grading data** — `Problem`/YAML gain `fail_to_pass`/`pass_to_pass` (small lists). The agent arm grades the agent's *own diff*, so the gold patch isn't needed (`make_test_spec` builds without it). `add.py` persists them; `requests-1142` YAML backfilled.

**Fixes** — `pull_pinned` now records arch; `image_store` usage-stamp is best-effort (a non-writable cache dir no longer crashes a run).

## Validated end-to-end (real CLI)
```
run --runtime image --filter psf__requests-1142 --arms onlycode
  -> 1/1 PASS, RESOLVED_FULL, $0.13, 20 turns, digest+arch recorded (MCP retry fired & recovered)
```

## Tests
6 `image_run` hermetic tests (prompt/record/grading-instance/orchestration, all mocked) + the updated `image_store` arch test. **913 pass.**

## Follow-ups (#319, kept open)
Broad **≥10-instance / ≥4-repo parity sweep**, image-path `--resume`, parallelism, and backfilling `fail_to_pass`/`pass_to_pass` across all instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)