### PR TITLE
WS-C(#333): pipe in-container eval script over stdin to avoid MAX_ARG_STRLEN

### DIFF
--- a/swebench/container_test.py
+++ b/swebench/container_test.py
@@ -98,10 +98,16 @@ def run_eval_in_container(
         f"source /opt/miniconda3/bin/activate {testbed_env.rsplit('/', 1)[-1]}\n"
         f"{exports}cd /testbed\n{cmd}\n"
     )
+    # Feed the script over stdin (``bash -ls``), NOT as a ``-lc`` argv element.
+    # High-test-count instances (e.g. django-10097: 1870 ids) produce a >128 KiB
+    # eval line, and a single argv string is capped at MAX_ARG_STRLEN (32 pages =
+    # 128 KiB) by execve -> E2BIG / "Argument list too long" before docker starts
+    # (#333). Over stdin the per-arg cap does not apply; the ids still reach the
+    # test command as separate words, well under the ~2 MB total ARG_MAX.
     proc = container._docker(
-        ["exec", "-u", AGENT_USER, "-e", f"HOME={AGENT_HOME}", handle.container_id,
-         "bash", "-lc", script],
-        check=False, timeout=timeout,
+        ["exec", "-i", "-u", AGENT_USER, "-e", f"HOME={AGENT_HOME}", handle.container_id,
+         "bash", "-ls"],
+        check=False, timeout=timeout, input_bytes=script.encode(),
     )
     log = (proc.stdout or b"").decode("utf-8", "replace")
     with open(log_dest, "w") as f:

--- a/tests/test_container_test.py
+++ b/tests/test_container_test.py
@@ -62,7 +62,8 @@ def test_run_eval_writes_log_and_activates_testbed(monkeypatch, tmp_path) -> Non
     captured = {}
 
     def _fake(args, **kw):
-        captured["script"] = args[-1]  # bash -lc <script>
+        captured["args"] = args
+        captured["script"] = (kw.get("input_bytes") or b"").decode()  # piped via stdin
         return types.SimpleNamespace(returncode=0, stdout=b"PASSED a.py::test_x\n", stderr=b"")
 
     monkeypatch.setattr(container, "_docker", _fake)
@@ -73,9 +74,38 @@ def test_run_eval_writes_log_and_activates_testbed(monkeypatch, tmp_path) -> Non
         eval_env={"LANG": "en_US.UTF-8"}, log_dest=str(dest),
     )
     assert "PASSED a.py::test_x" in log and dest.read_text() == log
+    # script goes over stdin (``bash -ls`` + ``-i``), never as a ``-lc`` argv element (#333).
+    assert "-i" in captured["args"] and captured["args"][-2:] == ["bash", "-ls"]
     assert "activate" in captured["script"] and "testbed" in captured["script"]
     assert "export LANG=" in captured["script"]
     assert "pytest -rA a.py::test_x" in captured["script"]
+
+
+def test_run_eval_large_id_list_stays_under_max_arg_strlen(monkeypatch, tmp_path) -> None:
+    """High-test-count instances must not blow MAX_ARG_STRLEN (128 KiB per argv
+    string). With 1870 django-style ids the eval line is ~150 KiB; it must travel
+    over stdin, leaving every individual argv element small (#333)."""
+    MAX_ARG_STRLEN = 128 * 1024
+    captured = {}
+
+    def _fake(args, **kw):
+        captured["args"] = args
+        captured["script"] = (kw.get("input_bytes") or b"").decode()
+        return types.SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(container, "_docker", _fake)
+    ids = [f"tests.deeply.nested.module.path.SomeReallyLongTestClassName"
+           f".test_case_with_a_descriptive_name_number_{i:04d}" for i in range(1870)]
+    ct.run_eval_in_container(
+        container.ContainerHandle("i", "c", "s"),
+        spec_test_cmd="pytest -rA", test_ids=ids,
+        eval_env={}, log_dest=str(tmp_path / "eval.log"),
+    )
+    # the giant id list lands in the stdin script, not argv...
+    assert len(captured["script"].encode()) > MAX_ARG_STRLEN
+    # ...and no single argv string is anywhere near the per-arg cap.
+    assert all(len(a.encode()) < MAX_ARG_STRLEN for a in captured["args"])
+    assert all(id_ in captured["script"] for id_ in (ids[0], ids[-1]))
 
 
 def test_gold_patch_gate_orchestrates(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Closes #333.

## Problem
`run_eval_in_container` passed the eval shell script as a single `bash -lc <script>` argv element. High-test-count instances (django-10097: 438 FAIL_TO_PASS + 1432 PASS_TO_PASS = 1870 ids) make that string >128 KiB. `execve()` caps any **single** argv string at `MAX_ARG_STRLEN` (32 pages = 128 KiB; distinct from the ~2 MB total `ARG_MAX`, not configurable) → `E2BIG` surfaced as `OSError: [Errno 7] Argument list too long: 'docker'`, **before** docker starts. Surfaced by the gold-gate sweep.

## Fix
Feed the script over **stdin** — `docker exec -i … bash -ls` with the script via `input_bytes` — instead of as a `-lc` argv element. The per-arg cap no longer applies; the ids still reach the test command as separate words, far under the 2 MB total `ARG_MAX`. The eval line is **byte-identical**, so grading semantics are unchanged. This also aligns with `apply_patch_in_container`, which already pipes via stdin.

## Verification
- **django-10097 gold gate**: the `OSError` is gone; `runtests.py` now launches (creates test DBs, runs migrations). *(It still grades `RESOLVED_NO` for a separate test-**selection** reason — django needs official file-directives, not method-ids — tracked in #335. Out of scope here.)*
- New regression test: a 1870-id synthetic eval asserts the script travels over stdin (`-i` + `bash -ls`) and **no** argv element approaches `MAX_ARG_STRLEN`.
- `tests/test_container_test.py` green; full `-m "not integration"` suite green (exit 0) with these changes.

## Scope
- `swebench/container_test.py` — `run_eval_in_container` only (used by both gold gate and agent-arm grading).
- `tests/test_container_test.py` — updated existing eval test for stdin; added the oversized-list regression.

Follow-up to #319 (epic #314); siblings #334 (baseline tool surface), #335 (test-selection fidelity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)