### PR TITLE
WS-C(#335): faithful test selection (directives) + combined output capture

### DIFF
--- a/swebench/container_test.py
+++ b/swebench/container_test.py
@@ -5,17 +5,21 @@ apply the held-out ``test_patch`` to ``/testbed``, run the spec's test command
 over ``FAIL_TO_PASS + PASS_TO_PASS`` in the testbed conda env, capture the log to
 the host, and grade it with the **official** parsers (:mod:`swebench.official_grade`).
 
-The eval command is the faithful SWE-bench one: ``<spec test_cmd> <test ids>``
-(e.g. ``pytest -rA <node ids>`` for pytest repos; ``./tests/runtests.py ...
-<dotted ids>`` for django).  The ``-rA``-style per-test ``PASSED``/``FAILED``
-lines are what ``MAP_REPO_TO_PARSER`` consumes.
-
-Grading runs over the union of FAIL_TO_PASS + PASS_TO_PASS so resolution checks
-both transitions (bug tests flip red->green, regression tests stay green).
+The eval command is the faithful SWE-bench one: ``<spec test_cmd> <directives>``,
+where the directives are the test FILES touched by the ``test_patch`` (via
+:func:`eval_directives`, ported from the official harness) — NOT the F2P/P2P
+method-ids.  pytest accepts node-ids so the old method-id form worked for pytest
+repos, but non-pytest runners (django ``runtests.py``, etc.) reject it and select
+zero tests (#335).  The per-test ``PASSED``/``FAILED`` lines are what
+``MAP_REPO_TO_PARSER`` consumes; the official parser then extracts the F2P/P2P
+statuses, so resolution still checks both transitions (bug tests flip
+red->green, regression tests stay green) regardless of how many tests the
+directives run.
 """
 
 from __future__ import annotations
 
+import re
 import shlex
 
 from swebench import container, official_grade
@@ -66,8 +70,57 @@ def _patch_targets(patch_text: str) -> list[str]:
     return out
 
 
+# Non-test file extensions, mirrored from swebench==4.1.0
+# (harness/constants NON_TEST_EXTS) — the grader package pinned in
+# :mod:`official_grade`.  Keep in sync if PINNED_SWEBENCH changes.
+_NON_TEST_EXTS = (".json", ".png", "csv", ".txt", ".md", ".jpg", ".jpeg",
+                  ".pkl", ".yml", ".yaml", ".toml")
+_DIFF_PAT = re.compile(r"diff --git a/.* b/(.*)")
+
+
+def eval_directives(instance: dict) -> list[str]:
+    """Test-selection directives for the eval command, derived the **official**
+    way: the test FILES touched by the held-out ``test_patch`` — NOT the
+    FAIL_TO_PASS/PASS_TO_PASS method-ids.
+
+    Ported verbatim from ``swebench.harness.test_spec.python.get_test_directives``
+    (swebench==4.1.0, the package pinned in :mod:`official_grade`) so our test
+    selection matches the grader **by construction** (#335).  pytest accepts
+    node-ids, so the old "append the method-ids" approach happened to work for
+    pytest repos; but django's ``runtests.py`` (and other non-pytest runners)
+    reject that format and select **zero** tests -> false ``RESOLVED_NO``.
+
+    An empty result (e.g. the test_patch touched only data files) means "run the
+    whole suite" — which the official harness also does; the parser then extracts
+    the F2P/P2P statuses from the full output.  By construction every F2P/P2P test
+    lies within this selection (that is how the benchmark measured them).
+    """
+    repo = instance.get("repo", "")
+    # seq2seq repos use a fixed test file.
+    if repo == "swe-bench/humaneval":
+        return ["test.py"]
+    directives = _DIFF_PAT.findall(instance.get("test_patch") or "")
+    directives = [d for d in directives
+                  if not any(d.endswith(ext) for ext in _NON_TEST_EXTS)]
+    # Django: tests/foo/bar.py -> foo.bar (strip ext + "tests/" prefix, / -> .).
+    if repo == "django/django":
+        transformed = []
+        for d in directives:
+            if d.endswith(".py"):
+                d = d[: -len(".py")]
+            if d.startswith("tests/"):
+                d = d[len("tests/"):]
+            transformed.append(d.replace("/", "."))
+        directives = transformed
+    return directives
+
+
 def build_eval_command(spec_test_cmd: str, test_ids: list[str]) -> str:
-    """``<spec test_cmd> <quoted test ids>`` — the faithful SWE-bench eval line."""
+    """``<spec test_cmd> <quoted directives>`` — the faithful SWE-bench eval line.
+
+    ``test_ids`` are the :func:`eval_directives` (test files/modules), not
+    method-ids.  An empty list yields the bare ``spec_test_cmd`` (run the whole
+    suite), matching the official harness."""
     ids = " ".join(shlex.quote(t) for t in test_ids)
     return f"{spec_test_cmd} {ids}".strip()
 
@@ -109,7 +162,13 @@ def run_eval_in_container(
          "bash", "-ls"],
         check=False, timeout=timeout, input_bytes=script.encode(),
     )
-    log = (proc.stdout or b"").decode("utf-8", "replace")
+    # Combine stdout + stderr: pytest writes results to stdout, but unittest-based
+    # runners (django ``runtests.py``) write per-test results to STDERR. The
+    # official parsers consume the combined log, so capturing stdout alone loses
+    # every django result -> all F2P/P2P appear missing -> false RESOLVED_NO (#335).
+    out = (proc.stdout or b"").decode("utf-8", "replace")
+    err = (proc.stderr or b"").decode("utf-8", "replace")
+    log = out + err
     with open(log_dest, "w") as f:
         f.write(log)
     return log
@@ -137,9 +196,8 @@ def gold_patch_gate(
     if not apply_patch_in_container(handle, instance["test_patch"]):
         raise InContainerTestError("held-out test patch did not apply cleanly")
 
-    test_ids = _coerce_ids(instance.get("FAIL_TO_PASS")) + _coerce_ids(instance.get("PASS_TO_PASS"))
     log = run_eval_in_container(
-        handle, spec_test_cmd=spec_test_cmd, test_ids=test_ids,
+        handle, spec_test_cmd=spec_test_cmd, test_ids=eval_directives(instance),
         eval_env=eval_env, log_dest=log_dest, timeout=timeout,
     )
     return official_grade.grade(instance, log)
@@ -156,7 +214,7 @@ def grade_agent_run(
     timeout: float = 1800,
 ) -> dict:
     """Grade an arm: the agent has already edited ``/testbed``; apply the held-out
-    test patch, run the eval over FAIL_TO_PASS + PASS_TO_PASS, and grade.
+    test patch, run the eval over the test_patch's directives, and grade.
 
     The agent-side counterpart to :func:`gold_patch_gate` (no gold patch — the
     agent's own diff is the change under test).  When ``verify_no_leak`` (C4b),
@@ -169,19 +227,8 @@ def grade_agent_run(
     if not apply_patch_in_container(handle, instance["test_patch"]):
         raise InContainerTestError("held-out test patch did not apply cleanly")
 
-    test_ids = _coerce_ids(instance.get("FAIL_TO_PASS")) + _coerce_ids(instance.get("PASS_TO_PASS"))
     log = run_eval_in_container(
-        handle, spec_test_cmd=spec_test_cmd, test_ids=test_ids,
+        handle, spec_test_cmd=spec_test_cmd, test_ids=eval_directives(instance),
         eval_env=eval_env, log_dest=log_dest, timeout=timeout,
     )
     return official_grade.grade(instance, log)
-
-
-def _coerce_ids(v) -> list[str]:
-    import json
-    if isinstance(v, str):
-        try:
-            return json.loads(v)
-        except Exception:
-            return [v]
-    return list(v or [])

--- a/tests/test_container_test.py
+++ b/tests/test_container_test.py
@@ -33,6 +33,59 @@ def test_build_eval_command_quotes_node_ids() -> None:
     assert "b.py::test_y" in cmd
 
 
+def test_build_eval_command_empty_directives_runs_whole_suite() -> None:
+    # no directives (test_patch touched only data files) -> bare test_cmd.
+    assert ct.build_eval_command("pytest -rA", []) == "pytest -rA"
+
+
+def test_eval_directives_pytest_file_passthrough() -> None:
+    inst = {"repo": "psf/requests",
+            "test_patch": "diff --git a/test_requests.py b/test_requests.py\n"
+                          "--- a/test_requests.py\n+++ b/test_requests.py\n@@ -1 +1 @@\n"}
+    # pytest repos: the test FILE is the directive (not the F2P/P2P method-ids).
+    assert ct.eval_directives(inst) == ["test_requests.py"]
+
+
+def test_eval_directives_django_transform() -> None:
+    inst = {"repo": "django/django",
+            "test_patch": "diff --git a/tests/auth_tests/test_validators.py "
+                          "b/tests/auth_tests/test_validators.py\n@@ -1 +1 @@\n"}
+    # tests/foo/bar.py -> foo.bar (django runtests label), the #335 fix.
+    assert ct.eval_directives(inst) == ["auth_tests.test_validators"]
+
+
+def test_eval_directives_filters_non_test_files_to_empty() -> None:
+    # django-10097's real shape: test_patch touches only data files -> [] -> full suite.
+    inst = {"repo": "django/django",
+            "test_patch": "diff --git a/tests/validators/invalid_urls.txt "
+                          "b/tests/validators/invalid_urls.txt\n@@ -1 +1 @@\n"
+                          "diff --git a/tests/validators/valid_urls.txt "
+                          "b/tests/validators/valid_urls.txt\n@@ -1 +1 @@\n"}
+    assert ct.eval_directives(inst) == []
+
+
+def test_eval_directives_humaneval_fixed() -> None:
+    assert ct.eval_directives({"repo": "swe-bench/humaneval", "test_patch": ""}) == ["test.py"]
+
+
+def test_gold_patch_gate_feeds_directives_not_method_ids(monkeypatch, tmp_path) -> None:
+    inst = {"repo": "django/django", "patch": "P", "version": "2.2",
+            "FAIL_TO_PASS": ["test_x (auth_tests.test_validators.T)"],
+            "PASS_TO_PASS": ["test_y (auth_tests.test_validators.T)"],
+            "test_patch": "diff --git a/tests/auth_tests/test_validators.py "
+                          "b/tests/auth_tests/test_validators.py\n@@ -1 +1 @@\n"}
+    seen = {}
+    monkeypatch.setattr(ct, "apply_patch_in_container", lambda h, p: True)
+    monkeypatch.setattr(ct, "run_eval_in_container",
+                        lambda h, **kw: seen.update(test_ids=kw["test_ids"]) or "log")
+    monkeypatch.setattr(ct.official_grade, "grade",
+                        lambda instance, log, **kw: {"resolution": "RESOLVED_FULL"})
+    ct.gold_patch_gate(container.ContainerHandle("i", "c", "s"), inst,
+                       spec_test_cmd="./tests/runtests.py", log_dest=str(tmp_path / "l"))
+    # directive (transformed file), NOT the unittest-format method-ids.
+    assert seen["test_ids"] == ["auth_tests.test_validators"]
+
+
 def test_patch_targets_parses_plus_paths() -> None:
     patch = (
         "diff --git a/src/m.py b/src/m.py\n--- a/src/m.py\n+++ b/src/m.py\n@@ -1 +1 @@\n"
@@ -79,6 +132,25 @@ def test_run_eval_writes_log_and_activates_testbed(monkeypatch, tmp_path) -> Non
     assert "activate" in captured["script"] and "testbed" in captured["script"]
     assert "export LANG=" in captured["script"]
     assert "pytest -rA a.py::test_x" in captured["script"]
+
+
+def test_run_eval_merges_stderr_for_unittest_runners(monkeypatch, tmp_path) -> None:
+    # django/unittest writes per-test results to stderr; the combined log must
+    # include them or the parser sees no results -> false RESOLVED_NO (#335).
+    def _fake(args, **kw):
+        return types.SimpleNamespace(
+            returncode=1, stdout=b"Creating test database...\n",
+            stderr=b"test_x (auth_tests.T) ... ok\nRan 1 test in 0.1s\n")
+    monkeypatch.setattr(container, "_docker", _fake)
+    dest = tmp_path / "eval.log"
+    log = ct.run_eval_in_container(
+        container.ContainerHandle("i", "c", "s"),
+        spec_test_cmd="./tests/runtests.py", test_ids=["auth_tests.test_x"],
+        eval_env={}, log_dest=str(dest),
+    )
+    assert "Creating test database" in log  # stdout
+    assert "test_x (auth_tests.T) ... ok" in log and "Ran 1 test" in log  # stderr
+    assert dest.read_text() == log
 
 
 def test_run_eval_large_id_list_stays_under_max_arg_strlen(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Closes #335.

Two eval-fidelity gaps made the image-runtime grader non-faithful for **non-pytest** runners. Both are in `container_test.py`.

## 1. Test selection — directives, not method-ids
The eval re-implemented selection by appending the raw `FAIL_TO_PASS`/`PASS_TO_PASS` **method-ids** to the test command. pytest accepts node-ids (so the 5 pytest repos gold-gated FULL), but django's `runtests.py` (unittest format `test_x (mod.Cls)`) and other non-pytest runners reject that → **zero tests selected** → false `RESOLVED_NO`.

Added `eval_directives(instance)`, ported verbatim from `swebench.harness.test_spec.python.get_test_directives` (swebench==4.1.0, the package pinned in `official_grade`). It derives the test **files** from the `test_patch` diff (django transform `tests/foo/bar.py` → `foo.bar`), so selection matches the grader **by construction**. Empty directives → bare `test_cmd` (full suite), as upstream. `gold_patch_gate` + `grade_agent_run` now select by directives; dead `_coerce_ids` removed.

## 2. Output capture — combined stdout+stderr
`run_eval_in_container` captured only `proc.stdout`. pytest writes results to stdout, but unittest-based runners (django) write per-test results to **stderr**, so django logs had zero parseable results. Now captures combined stdout+stderr (what the official parsers expect).

## Verification (gold gate, image path)
- `eval_directives` is byte-identical to the official `get_test_directives` on **all 8** local instances.
- **sympy-11618**: `RESOLVED_NO` → **RESOLVED_FULL** ✅
- **sphinx-10449**: `RESOLVED_NO` → **RESOLVED_FULL** ✅ (was selection/ordering, not env-drift)
- **requests-1142**: **RESOLVED_FULL** (no regression)
- **django-10097**: results now parse; **all 438 FAIL_TO_PASS pass**. Still `RESOLVED_NO` due to 5 PASS_TO_PASS failures from a full-suite SQLite shared-cache **test-isolation** cascade — a separate, narrower issue tracked in **#337** (only the rare empty-directive/full-suite instance hits it; the common django instance runs one isolated module).

## Tests
- `eval_directives`: django transform, NON_TEST_EXTS→empty, pytest passthrough, humaneval, and a gate test asserting directives (not method-ids) flow through.
- `run_eval_in_container`: combined stdout+stderr capture.
- Full local `tests/ -m "not integration"` suite green; change-surface files (container_test, official_grade, image_run, container_agent, container_strip) 44 passed.

*(Note: a bare local `pytest` hits unrelated collection errors from gitignored `data/fixtures*/` legacy checkouts not present in CI; scope to `tests/`.)*

Follow-up to #319 (epic #314); siblings #333 (merged), #334 (baseline tool surface), #337 (django full-suite isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)