### PR TITLE
WS-C6(#320): image-only runtime (default), overlay deprecated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,18 @@ Shared infrastructure:
 
 **Full CLI reference:** see README.md. **Task schema:** see docs/SCHEMA_ARTIFACT.md.
 
+### SWE-bench runtime backend: image-only (ADR-0004, epic #314)
+
+`run` has two backends via `--runtime`: **`image` (default)** runs inside the official
+prebuilt SWE-bench Docker images (pull-by-digest → stripped snapshot → fresh container
+per arm → official-parser grading; modules `container*.py`, `image_*.py`, `official_grade.py`),
+and **`overlay` (DEPRECATED)** is the legacy host clone + OverlayFS + venv path
+(`cache.py`, `harness.py`, the overlay branch of `run.py`). All 500 Verified instances have
+published official images (100% coverage, verified 2026-06-07), so image is the supported
+path; overlay emits a deprecation warning and is **slated for removal** — do not collect
+benchmark numbers on it. The overlay invariants below remain documented only because the
+code still exists pending that cleanup.
+
 ---
 
 ## Module Map

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ python -m swebench run --arms bash_only          # bash_only arm only
 python -m swebench run --arms both               # baseline+onlycode (excludes bash_only)
 python -m swebench run --filter django__django-16379
 python -m swebench run --runs 3                  # multiple runs per arm
-python -m swebench run --no-cache                # skip OverlayFS cache
+python -m swebench run --runtime image           # default: official prebuilt Docker images
+python -m swebench run --runtime overlay         # DEPRECATED legacy host OverlayFS path
+python -m swebench run --no-cache                # (overlay only) skip OverlayFS cache
 
 # Analyze results
 python -m swebench analyze summary
@@ -106,6 +108,11 @@ This resolves `node`, the bundle path, and the repo root automatically. Re-run
 after any container rebuild or workspace move.
 
 ### OverlayFS Cache
+
+> **DEPRECATED (ADR-0004 / #314).** The OverlayFS cache belongs to the legacy `--runtime overlay`
+> backend. The default `--runtime image` backend runs on the official prebuilt Docker images
+> (100% Verified coverage) and does not use this cache. Overlay is kept only as a general-purpose
+> fallback and is slated for removal.
 
 For large-scale or repeated runs, the harness supports an OverlayFS-backed instance cache that skips clone + venv setup on subsequent runs.
 

--- a/docs/adr-0004-verified-docker-images.md
+++ b/docs/adr-0004-verified-docker-images.md
@@ -1,10 +1,30 @@
 # ADR 0004 — Run SWE-bench Verified from Official Prebuilt Docker Images
 
-**Status:** Accepted. C2 de-risk spike complete — **GO** (`docs/spike-c2-docker-images.md`,
-#316). C3 reset strategy decided (see below).
+**Status:** Accepted. C1–C5 complete; C6 in progress. C2 de-risk spike — **GO**
+(`docs/spike-c2-docker-images.md`, #316). C3 reset strategy decided (see below).
+**Amended 2026-06-07 → image-only** (see "Update" below).
 **Date:** 2026-06-04.
 **Tracking issue:** [#314](https://github.com/hyang0129/onlycodes/issues/314).
-**Supersedes:** the *build half* of [#311](https://github.com/hyang0129/onlycodes/issues/311) / PR [#313](https://github.com/hyang0129/onlycodes/pull/313) (conda-native build) for Verified. Conda is retained as a fallback.
+**Supersedes:** the *build half* of [#311](https://github.com/hyang0129/onlycodes/issues/311) / PR [#313](https://github.com/hyang0129/onlycodes/pull/313) (conda-native build) for Verified. Conda/overlay is **deprecated** (see Update).
+
+## Update (2026-06-07) — image-only; conda/overlay deprecated
+
+The original plan kept a **dual-backend** `image-if-published-else-conda` selection rule
+and a C6 image-vs-conda parity table. A coverage check across **all 500** Verified
+instances (Docker Hub repo API) returned **500/500 published, 0 missing** — so the
+`else-conda` branch never fires for Verified. Combined with the C5 gold gate giving
+*absolute* fidelity against the official parsers (a stronger check than any conda
+comparison), the conda/overlay path is **dead code for the benchmark** (overlay is
+SWE-bench-only; artifact mode uses its own materialize path).
+
+**Revised decision:** the harness is **image-only** for Verified. `run.py` defaults to
+`--runtime image`; `--runtime overlay` is retained but emits a deprecation warning and is
+slated for removal in a separate cleanup. Consequences: the C6 **parity table is dropped**
+(nothing faithful to compare against), the standalone **conda gold gate (#322) is
+unnecessary**, and the selection rule reduces to "image, else error loudly" (digest
+pinning, #319, covers reproducibility; availability is the only residual risk). C5's
+gold-fidelity sample stands at 12/12 RESOLVED_FULL across 7 repos. The lone empty-directive
+instance in all of Verified is django-10097 (1/500; full-suite isolation residual, #337).
 
 ## Context
 
@@ -232,7 +252,8 @@ kill-switch, not an irreversible migration.
 
 - [x] C2 spike confirms a real pull + in-container agent turn + parsed test (go/no-go).
 - [x] Container runtime with in-container git-strip and fresh-container per-arm reset (C3).
-- [ ] Both arms run in-container with correct tool restriction + transcript capture (C4).
-- [ ] Official-parser grading + gold-patch fidelity gate + digest pinning (C5).
-- [ ] Image-vs-conda parity table + image-else-conda selection rule + docs updated (C6).
+- [x] Both arms run in-container with correct tool restriction + transcript capture (C4/C4b).
+- [x] Official-parser grading + gold-patch fidelity gate + digest pinning (C5).
+- [ ] ~~Image-vs-conda parity table + image-else-conda selection rule~~ → **image-only**
+  (100% image coverage; see Update 2026-06-07): image default + overlay deprecated + docs (C6).
 - [ ] This ADR's status flipped once the spike confirms (or rolled back per Reversibility).

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -1050,17 +1050,17 @@ def _run_image_runtime(
 @click.option(
     "--runtime",
     "runtime",
-    type=click.Choice(["overlay", "image"]),
-    default="overlay",
+    type=click.Choice(["image", "overlay"]),
+    default="image",
     show_default=True,
     help=(
-        "Environment backend. 'overlay' (default): clone + cache + per-arm "
-        "fuse-overlayfs on the host (the established path). 'image': run inside "
-        "the official prebuilt SWE-bench Docker images, resetting per arm from a "
-        "stripped snapshot container (ADR-0004, epic #314). The 'image' runtime "
-        "container layer is C3 (#317); pull/disk policy is C3b (#323) and agent + "
-        "test execution are C4/C5 (#318/#319), so selecting it today reports "
-        "readiness and exits rather than running a full arm."
+        "Environment backend. 'image' (default): run inside the official prebuilt "
+        "SWE-bench Docker images, resetting per arm from a stripped snapshot "
+        "container, graded by the official parsers (ADR-0004, epic #314). All 500 "
+        "Verified instances have published images (100% coverage), so this is the "
+        "supported path. 'overlay' (DEPRECATED): the legacy clone + cache + per-arm "
+        "fuse-overlayfs host build; kept only as a general-purpose fallback for "
+        "instances without a published image and slated for removal."
     ),
 )
 def run_command(
@@ -1141,6 +1141,17 @@ def run_command(
             num_runs=num_runs, max_wall_seconds=max_wall_seconds,
         )
         return
+
+    # Overlay is deprecated (ADR-0004 / epic #314): all 500 Verified instances have
+    # published official images, so the image runtime is the supported path. The
+    # overlay/conda backend is kept only as a general-purpose fallback and is slated
+    # for removal — warn loudly so nobody collects benchmark numbers on it by accident.
+    click.echo(
+        "WARNING: --runtime overlay is DEPRECATED. The image runtime (default) is the "
+        "supported backend for SWE-bench Verified (100% official-image coverage); "
+        "overlay is a legacy fallback slated for removal. See ADR-0004 / #314.",
+        err=True,
+    )
 
     # Codex exec-server pre-flight: only needed for arms that use the MCP exec-server.
     # baseline and bash_only run on Codex's native shell/apply_patch surface

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -1130,6 +1130,18 @@ def run_command(
     if arms in ("bash_only", "all"):
         arm_list.append("bash_only")
 
+    # The image runtime's in-container agent staging is Claude-specific (C4);
+    # the Codex surface on images is a follow-up (#325). Fail clearly rather than
+    # letting the image path try to stage a codex binary it can't drive.
+    if runtime == "image" and agent_surface != "claude_code":
+        click.echo(
+            f"ERROR: --runtime image currently supports only --agent-surface claude_code "
+            f"(got {agent_surface!r}). Codex-on-image is tracked in #325; "
+            f"use --runtime overlay for the codex surface.",
+            err=True,
+        )
+        raise SystemExit(1)
+
     # --- Image runtime: dispatch to the dedicated orchestrator (C5 #319) -------
     # Runs on the official prebuilt images (pull-by-digest + LRU + in-container
     # agent + official-parser grading). Deliberately separate from the overlay

--- a/tests/test_integration_codex_onlycode_arm.py
+++ b/tests/test_integration_codex_onlycode_arm.py
@@ -117,6 +117,7 @@ def test_codex_run_onlycode_calls_preflight_not_rejection(runner, monkeypatch, t
             "run",
             "--agent-surface", "codex_cli",
             "--arms", "onlycode",
+            "--runtime", "overlay",  # codex surface is overlay-only (image+codex is #325)
             "--output-dir", str(tmp_path / "out"),
         ],
         catch_exceptions=False,
@@ -159,6 +160,7 @@ def test_codex_run_onlycode_preflight_invoked(runner, monkeypatch, tmp_path):
     runner.invoke(
         cli,
         ["run", "--agent-surface", "codex_cli", "--arms", "onlycode",
+         "--runtime", "overlay",  # codex surface is overlay-only (image+codex is #325)
          "--output-dir", str(tmp_path / "out")],
         catch_exceptions=False,
     )
@@ -166,6 +168,28 @@ def test_codex_run_onlycode_preflight_invoked(runner, monkeypatch, tmp_path):
     assert preflight_called, (
         "CodexRunner.preflight() was never called for codex_cli + onlycode arm. "
         "The rejection guard may have been left in place."
+    )
+
+
+def test_codex_run_image_runtime_rejected(runner, monkeypatch, tmp_path):
+    """codex_cli + --runtime image must error clearly (codex-on-image is #325),
+    not fall into the Claude-only image path."""
+    monkeypatch.setattr("swebench.runner.CodexRunner.find_binary", lambda self: "/usr/bin/codex")
+    monkeypatch.setattr("swebench.runner.CodexRunner.verify_auth", lambda self: None)
+    monkeypatch.setattr("swebench.runner.CodexRunner.get_version", lambda self, _: "test")
+    _make_minimal_swe_problem(tmp_path / "problems" / "swe")
+    monkeypatch.setattr("swebench.run.repo_root", lambda: tmp_path)
+
+    result = runner.invoke(
+        cli,
+        ["run", "--agent-surface", "codex_cli", "--arms", "onlycode",
+         "--runtime", "image", "--output-dir", str(tmp_path / "out")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    out = result.output or ""
+    assert "claude_code" in out and "#325" in out, (
+        f"Expected a clear codex-on-image rejection mentioning #325, got:\n{out!r}"
     )
 
 
@@ -195,6 +219,7 @@ def test_codex_run_onlycode_preflight_ok_proceeds_past_preflight(runner, monkeyp
             "run",
             "--agent-surface", "codex_cli",
             "--arms", "onlycode",
+            "--runtime", "overlay",  # codex surface is overlay-only (image+codex is #325)
             "--output-dir", str(tmp_path / "out"),
         ],
         catch_exceptions=True,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from swebench.run import _is_triple_complete, _parse_filter_ids
+from swebench.run import _is_triple_complete, _parse_filter_ids, run_command
 
 
 INSTANCE = "django__django-16379"
@@ -26,6 +26,17 @@ def _paths(tmp_path):
     jsonl = tmp_path / f"{INSTANCE}_{ARM}_run{RUN_IDX}.jsonl"
     test_txt = tmp_path / f"{INSTANCE}_{ARM}_run{RUN_IDX}_test.txt"
     return jsonl, test_txt
+
+
+# --- runtime backend default (image-only, ADR-0004 / #314) ------------------
+
+def test_runtime_defaults_to_image():
+    """Image is the default/supported backend (100% Verified image coverage);
+    overlay is the deprecated legacy fallback (#320)."""
+    opt = next(p for p in run_command.params if p.name == "runtime")
+    assert opt.default == "image"
+    # image listed first; overlay retained but deprecated.
+    assert list(opt.type.choices) == ["image", "overlay"]
 
 
 # --- missing files ----------------------------------------------------------


### PR DESCRIPTION
Reframes C6 (#320) given **100% official-image coverage** and moves the harness to an image-only runtime.

## Why (supersedes the original C6 plan)
A coverage check across **all 500** Verified instances (Docker Hub repo API): **500/500 published, 0 missing.** So the `image-if-published-else-conda` rule's fallback never fires, and the conda/overlay path is dead code for the benchmark (overlay is SWE-bench-only; artifact mode uses its own materialize path). The C5 gold gate gives *absolute* fidelity vs the official parsers — stronger than any conda comparison — so the parity table is moot.

## Changes
- **`run.py`**: `--runtime` defaults to **`image`** (was `overlay`); selecting `overlay` prints a deprecation warning (legacy fallback, slated for removal). Stale help text refreshed (image is the real graded path now, not "reports readiness and exits").
- **ADR-0004**: dated amendment (2026-06-07) recording the image-only decision + 100% coverage; C4/C5 acceptance boxes flipped; dual-backend/parity plan superseded.
- **CLAUDE.md / README**: image documented as the default/supported backend; overlay marked DEPRECATED (OverlayFS cache section flagged).
- **test_run.py**: asserts `--runtime` default is `image`.

## Scope decisions (per discussion)
- **Parity table — dropped** (nothing faithful to compare against).
- **#322 (conda gold gate) — unnecessary**; closing.
- **Overlay/conda code — deprecate now, delete later** (separate cleanup PR; the overlay invariants stay documented because the code still exists).
- Gold-fidelity evidence: C5's 12/12 RESOLVED_FULL across 7 repos (optionally extendable to the #313 38-instance sample, image-only).

## Tests
`tests/test_run.py` + `tests/test_image_run.py` green (24 passed). Full `tests/ -m "not integration"` suite unaffected.

Closes the epic-capstone build for #320 (final close pending the docs/issue admin + overlay-removal cleanup). Follow-up to #319 (epic #314).

🤖 Generated with [Claude Code](https://claude.com/claude-code)