### PR TITLE
WS-C4-Codex(#325): Codex CLI surface on the image runtime

### DIFF
--- a/swebench/container_agent.py
+++ b/swebench/container_agent.py
@@ -51,7 +51,7 @@ from pathlib import Path
 
 from swebench import container
 from swebench.container import ContainerHandle
-from swebench.runner import ClaudeRunner
+from swebench.runner import ClaudeRunner, DEFAULT_CODEX_MODEL, _apply_arm_directive, _write_codex_config
 
 
 # --------------------------------------------------------------------------
@@ -73,9 +73,27 @@ RESULT_IN_CONTAINER = f"{CFG_DIR}/transcript.jsonl"
 
 #: Pinned model — mirrors ``ClaudeRunner.invoke`` on the host path.
 MODEL = "claude-sonnet-4-6"
+#: Codex default model (mirrors ``runner.DEFAULT_CODEX_MODEL``).
+CODEX_MODEL = DEFAULT_CODEX_MODEL
 
 #: The SWE-bench image's project conda env (repo installed editable here).
 TESTBED_ENV = "/opt/miniconda3/envs/testbed"
+
+#: PATH for the in-container codebox kernel — testbed conda env first so executed
+#: code imports the package under test (shared by the Claude mcp-config and the
+#: Codex config.toml MCP env).
+_TESTBED_PATH = (
+    f"{TESTBED_ENV}/bin:/opt/miniconda3/bin:"
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+)
+
+# --- Codex surface (#325): native static-musl binary staged in the RO volume ---
+CODEX_VENDOR_DIR = f"{AGENT_MOUNT}/codex"          # vendor dir on the runtime volume
+CODEX_BIN = f"{CODEX_VENDOR_DIR}/bin/codex"        # native binary (no node needed for codex itself)
+CODEX_PATH_DIR = f"{CODEX_VENDOR_DIR}/codex-path"  # bundled rg etc. — must be on PATH
+CODEX_HOME_IN_CFG = f"{CFG_DIR}/codex_home"        # per-arm CODEX_HOME (auth.json + config.toml)
+#: The platform triple whose vendor dir we stage (x86_64 images).
+_CODEX_TARGET = "x86_64-unknown-linux-musl"
 
 #: MCP init timeout (ms).  The exec-server's persistent python kernel cold-starts
 #: slower under the in-container conda env than Claude Code's default MCP timeout,
@@ -206,6 +224,75 @@ def ensure_agent_runtime(
     return RUNTIME_VOLUME
 
 
+def _find_codex_vendor() -> str:
+    """Resolve the host codex install's platform vendor dir (#325).
+
+    ``codex`` is an npm node shim that dispatches to a static-musl native binary
+    under ``@openai/codex-linux-x64/vendor/<target>``; that whole dir (binary +
+    bundled ``rg``/``bwrap``) is what we stage. Returns its absolute path.
+    """
+    codex = shutil.which("codex")
+    if not codex:
+        raise AgentRuntimeError(
+            "host `codex` not found on PATH — install with `npm install -g @openai/codex` "
+            "(needs sudo; the global prefix is root-owned)."
+        )
+    # which -> .../@openai/codex/bin/codex.js ; pkg root is two dirs up.
+    pkg_root = os.path.dirname(os.path.dirname(os.path.realpath(codex)))
+    vendor = os.path.join(
+        pkg_root, "node_modules", "@openai", "codex-linux-x64", "vendor", _CODEX_TARGET
+    )
+    if not os.path.isdir(vendor):
+        raise AgentRuntimeError(
+            f"codex platform vendor dir not found at {vendor} — reinstall codex."
+        )
+    return vendor
+
+
+def ensure_codex_runtime(
+    codex_vendor: str | None = None,
+    *,
+    helper_image: str = "busybox:latest",
+    force: bool = False,
+) -> str:
+    """Populate the shared runtime volume with ``node`` + the codex vendor dir (#325).
+
+    Idempotent on the presence of the staged codex binary (independent of the
+    Claude sentinel, so both surfaces can coexist in the one volume). ``node`` is
+    (re)staged too so the codebox MCP bundle works even if the Claude path never
+    populated the volume. Returns the volume name.
+    """
+    if not force and _volume_exists(RUNTIME_VOLUME):
+        probe = container._docker(
+            ["run", "--rm", "-v", f"{RUNTIME_VOLUME}:{AGENT_MOUNT}:ro",
+             helper_image, "test", "-f", CODEX_BIN],
+            check=False,
+        )
+        if probe.returncode == 0:
+            return RUNTIME_VOLUME
+
+    vendor = codex_vendor or _find_codex_vendor()
+    node = _find_node()
+    container.pull_image(helper_image)
+    container._docker(["volume", "create", RUNTIME_VOLUME], check=False)
+
+    helper = ""
+    try:
+        helper = container._decode(container._docker(
+            ["run", "-d", "-v", f"{RUNTIME_VOLUME}:/stage", helper_image, "sleep", "86400"]
+        ))
+        container._docker(["cp", node, f"{helper}:/stage/node"])
+        container._docker(["exec", helper, "chmod", "0755", "/stage/node"])
+        container._docker(["exec", helper, "mkdir", "-p", "/stage/codex"])
+        # copy vendor *contents* into /stage/codex
+        container._docker(["cp", f"{vendor}/.", f"{helper}:/stage/codex"])
+        container._docker(["exec", helper, "chmod", "-R", "a+rX", "/stage/codex"])
+    finally:
+        if helper:
+            container._rm_force(helper)
+    return RUNTIME_VOLUME
+
+
 # --------------------------------------------------------------------------
 # Per-arm staging: exec-server bundle + mcp-config + credentials -> /opt/cfg
 # --------------------------------------------------------------------------
@@ -214,10 +301,7 @@ def _incontainer_mcp_config(*, persistent_kernel: bool = True) -> dict:
     # Prepend the testbed env's bin so the exec-server's python kernel runs in the
     # *project* conda env (where the repo is installed editable) — not the base
     # env — so executed code can import the package under test.
-    path = (
-        f"{TESTBED_ENV}/bin:/opt/miniconda3/bin:"
-        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-    )
+    path = _TESTBED_PATH
     return {
         "mcpServers": {
             "codebox": {
@@ -234,21 +318,8 @@ def _incontainer_mcp_config(*, persistent_kernel: bool = True) -> dict:
     }
 
 
-def stage_arm(
-    handle: ContainerHandle,
-    *,
-    creds_src: str | None = None,
-    persistent_kernel: bool = True,
-) -> None:
-    """Stage the per-arm config into ``/opt/cfg`` of a running arm container.
-
-    Copies the exec-server bundle + helpers, writes the in-container
-    ``mcp-config.json``, and ``docker cp``'s the Claude credentials
-    (``.credentials.json`` + ``.claude.json``) from ``creds_src`` (default
-    ``~/.claude``).  Everything is chowned to the agent user.  None of this is
-    ever committed — arm containers are torn down, not snapshotted.
-    """
-    creds_src = creds_src or os.path.expanduser("~/.claude")
+def _stage_exec_server(cid: str) -> None:
+    """Copy the full exec-server file set into ``/opt/cfg/exec_server`` (both surfaces)."""
     dist = _exec_server_dist()
     for fname in _EXEC_SERVER_FILES:
         if not (dist / fname).is_file():
@@ -256,11 +327,35 @@ def stage_arm(
                 f"exec-server file missing: {dist / fname} — run `npm run build` "
                 "in exec_server/ first."
             )
-
-    cid = handle.container_id
     container._docker(["exec", cid, "mkdir", "-p", f"{CFG_DIR}/exec_server"])
     for fname in _EXEC_SERVER_FILES:
         container._docker(["cp", str(dist / fname), f"{cid}:{CFG_DIR}/exec_server/{fname}"])
+
+
+def stage_arm(
+    handle: ContainerHandle,
+    *,
+    surface: str = "claude_code",
+    arm: str = "onlycode",
+    model: str | None = None,
+    creds_src: str | None = None,
+    persistent_kernel: bool = True,
+) -> None:
+    """Stage the per-arm config into ``/opt/cfg`` of a running arm container.
+
+    Surface-aware (#325): the Claude path writes ``mcp-config.json`` + Claude
+    credentials; the Codex path writes a ``CODEX_HOME`` (auth.json + config.toml).
+    Both stage the exec-server bundle + helpers and chown ``/opt/cfg`` to the
+    agent user.  Nothing is ever committed — arm containers are torn down.
+    """
+    if surface == "codex_cli":
+        _stage_arm_codex(handle, arm=arm, model=model, creds_src=creds_src,
+                         persistent_kernel=persistent_kernel)
+        return
+
+    creds_src = creds_src or os.path.expanduser("~/.claude")
+    cid = handle.container_id
+    _stage_exec_server(cid)
 
     # In-container mcp-config.
     tmp = tempfile.mkdtemp(prefix="arm-cfg-")
@@ -281,6 +376,100 @@ def stage_arm(
     container._docker(["exec", cid, "chown", "-R", f"{AGENT_USER}:{AGENT_USER}", CFG_DIR])
 
 
+#: Minimum access-token life required at stage time. The codex auth is copied
+#: into the container and discarded; if it expires mid-run codex refreshes there
+#: and writes the rotated (one-time) token to the throwaway copy, leaving the host
+#: token dead and breaking every subsequent run. ChatGPT access tokens last ~10
+#: days, so a fresh ``codex login`` clears this by a wide margin; we just refuse
+#: to start with a token that won't outlive the run.
+_CODEX_TOKEN_MIN_REMAINING_SEC = 3600
+
+
+def _assert_codex_token_fresh(auth_path: str, *, _now: float | None = None) -> None:
+    """Raise if the codex access token is expired / expiring within the margin.
+
+    Fails loudly so a stale token (needing an in-container refresh that would
+    consume the one-time refresh token and break the rest of a sweep) surfaces as
+    a clear 're-login' error instead. API-key auth (no ``tokens`` block) is
+    exempt. Decoding is best-effort — an undecodable token is allowed through
+    rather than blocking on a parser quirk."""
+    import base64
+    import time as _time
+    try:
+        data = json.loads(Path(auth_path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return
+    if data.get("OPENAI_API_KEY"):
+        return  # API key never expires/rotates
+    tok = (data.get("tokens") or {}).get("access_token")
+    if not tok or tok.count(".") < 2:
+        return
+    try:
+        payload = tok.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        exp = json.loads(base64.urlsafe_b64decode(payload)).get("exp")
+    except Exception:  # noqa: BLE001 — undecodable token: don't block
+        return
+    if exp is None:
+        return
+    now = _now if _now is not None else _time.time()
+    if exp <= now + _CODEX_TOKEN_MIN_REMAINING_SEC:
+        raise AgentRuntimeError(
+            f"codex access token at {auth_path} expires too soon "
+            f"({int((exp - now) / 60)} min left) — run `codex login` to refresh. "
+            "Staging a near-expiry OAuth token risks an in-container refresh that "
+            "consumes the one-time refresh token and breaks subsequent runs."
+        )
+
+
+def _stage_arm_codex(
+    handle: ContainerHandle,
+    *,
+    arm: str,
+    model: str | None,
+    creds_src: str | None,
+    persistent_kernel: bool,
+) -> None:
+    """Codex staging: exec-server set + a ``CODEX_HOME`` (auth.json + config.toml).
+
+    ``config.toml`` reuses ``runner._write_codex_config`` (single-sourced
+    tool-restriction profile) but with in-container paths — the codebox MCP
+    ``command`` is the staged node and its env carries the testbed ``PATH`` so the
+    kernel runs in the project conda env.
+    """
+    creds_src = creds_src or os.path.expanduser("~/.codex")
+    cid = handle.container_id
+    _stage_exec_server(cid)
+    container._docker(["exec", cid, "mkdir", "-p", CODEX_HOME_IN_CFG])
+
+    auth = os.path.join(creds_src, "auth.json")
+    if not os.path.isfile(auth):
+        raise AgentRuntimeError(
+            f"codex auth not found at {auth} — Codex CLI requires a valid auth token."
+        )
+    _assert_codex_token_fresh(auth)
+
+    tmp = tempfile.mkdtemp(prefix="arm-codex-")
+    try:
+        _write_codex_config(
+            tmp,
+            bundle_path=BUNDLE_IN_CFG,
+            cwd="/testbed",
+            persistent_kernel="1" if persistent_kernel else "0",
+            arm=arm,
+            model=model or CODEX_MODEL,
+            mcp_command=NODE_BIN,
+            mcp_env_extra={"PATH": _TESTBED_PATH},
+        )
+        container._docker(["cp", os.path.join(tmp, "config.toml"),
+                           f"{cid}:{CODEX_HOME_IN_CFG}/config.toml"])
+        container._docker(["cp", auth, f"{cid}:{CODEX_HOME_IN_CFG}/auth.json"])
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    container._docker(["exec", cid, "chown", "-R", f"{AGENT_USER}:{AGENT_USER}", CFG_DIR])
+
+
 # --------------------------------------------------------------------------
 # Invocation
 # --------------------------------------------------------------------------
@@ -290,27 +479,50 @@ def build_agent_argv(
     *,
     prompt: str,
     system_prompt: str,
-    model: str = MODEL,
+    model: str | None = None,
     wall_timeout: int = 3600,
+    surface: str = "claude_code",
 ) -> list[str]:
-    """The in-container claude argv for an arm (no docker wrapper).
+    """The in-container agent argv for an arm (no docker wrapper).
 
-    Tool flags come from ``ClaudeRunner.build_tools_flags`` (single-sourced with
-    the host path); only the mcp-config path is in-container.  A ``timeout``
-    prefix bounds wall time *inside* the container so the agent is killed even if
-    the host ``docker exec`` client is interrupted.
+    Surface-aware (#325). Claude: tool flags from ``ClaudeRunner.build_tools_flags``
+    (single-sourced with the host path); only the mcp-config path is in-container.
+    Codex: ``codex exec`` against the native binary (restriction lives in
+    config.toml from :func:`_stage_arm_codex`). A ``timeout`` prefix bounds wall
+    time *inside* the container so the agent is killed even if the host
+    ``docker exec`` client is interrupted.
     """
+    if surface == "codex_cli":
+        return _build_codex_argv(arm, prompt=prompt, model=model or CODEX_MODEL,
+                                 wall_timeout=wall_timeout)
     tools_flags = ClaudeRunner().build_tools_flags(arm, MCP_CONFIG_IN_CFG)
     argv = [
         CLAUDE_BIN,
         "-p", prompt,
-        "--model", model,
+        "--model", model or MODEL,
         "--system-prompt", system_prompt,
         *tools_flags,
         "--dangerously-skip-permissions",
         "--no-session-persistence",
         "--output-format", "stream-json",
         "--verbose",
+    ]
+    if wall_timeout and wall_timeout > 0:
+        argv = ["timeout", f"{wall_timeout}s", *argv]
+    return argv
+
+
+def _build_codex_argv(arm: str, *, prompt: str, model: str, wall_timeout: int) -> list[str]:
+    """``codex exec`` argv (native binary). Restriction is in config.toml; the soft
+    arm directive is prepended to the prompt (codex can't hard-disable apply_patch)."""
+    effective_prompt = _apply_arm_directive(prompt, arm)
+    argv = [
+        CODEX_BIN, "exec",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--json",
+        "-m", model,
+        "-C", "/testbed",
+        effective_prompt,
     ]
     if wall_timeout and wall_timeout > 0:
         argv = ["timeout", f"{wall_timeout}s", *argv]
@@ -328,22 +540,34 @@ def _codebox_was_used(result_path: str) -> bool:
         text = Path(result_path).read_text()
     except OSError:
         return False
-    # Cheap + robust: the tool name appears in the assistant's tool_use blocks.
-    return "mcp__codebox__" in text
+    # Claude stream-json names the tool ``mcp__codebox__*``; Codex ``--json``
+    # emits ``mcp_tool_call`` items with ``"server":"codebox"``. Match either.
+    return "mcp__codebox__" in text or '"server":"codebox"' in text or '"server": "codebox"' in text
 
 
 def _invoke_once(
     handle: ContainerHandle, agent_argv: list[str], result_path: str,
-    host_timeout: int | None,
+    host_timeout: int | None, *, surface: str = "claude_code",
 ) -> int:
+    if surface == "codex_cli":
+        env_flags = [
+            "-e", f"CODEX_HOME={CODEX_HOME_IN_CFG}",
+            "-e", f"HOME={AGENT_HOME}",
+            # codex-path (rg) + staged node (codebox MCP) + testbed env on PATH.
+            "-e", f"PATH={CODEX_PATH_DIR}:{AGENT_MOUNT}:{_TESTBED_PATH}",
+        ]
+    else:
+        env_flags = [
+            "-e", f"CLAUDE_CONFIG_DIR={CFG_DIR}",
+            "-e", f"HOME={AGENT_HOME}",
+            "-e", "FORCE_PROMPT_CACHING_5M=1",
+            "-e", f"MCP_TIMEOUT={MCP_TIMEOUT_MS}",
+        ]
     docker_argv = [
         container._docker_bin(), "exec",
         "-u", AGENT_USER,
         "-w", "/testbed",
-        "-e", f"CLAUDE_CONFIG_DIR={CFG_DIR}",
-        "-e", f"HOME={AGENT_HOME}",
-        "-e", "FORCE_PROMPT_CACHING_5M=1",
-        "-e", f"MCP_TIMEOUT={MCP_TIMEOUT_MS}",
+        *env_flags,
         handle.container_id,
         *agent_argv,
     ]
@@ -369,10 +593,11 @@ def run_agent(
     prompt: str,
     system_prompt: str = "You are a helpful assistant.",
     result_path: str,
-    model: str = MODEL,
+    model: str | None = None,
     wall_timeout: int = 3600,
     mcp_required: bool | None = None,
     max_attempts: int = 4,
+    surface: str = "claude_code",
 ) -> int:
     """Run one Claude turn inside the arm container, streaming the JSONL
     transcript to ``result_path`` on the host.
@@ -399,13 +624,13 @@ def run_agent(
         mcp_required = arm in _MCP_REQUIRED_ARMS
     agent_argv = build_agent_argv(
         arm, prompt=prompt, system_prompt=system_prompt,
-        model=model, wall_timeout=wall_timeout,
+        model=model, wall_timeout=wall_timeout, surface=surface,
     )
     host_timeout = (wall_timeout + 120) if wall_timeout and wall_timeout > 0 else None
 
     rc = 0
     for attempt in range(1, max_attempts + 1):
-        rc = _invoke_once(handle, agent_argv, result_path, host_timeout)
+        rc = _invoke_once(handle, agent_argv, result_path, host_timeout, surface=surface)
         if not mcp_required or _codebox_was_used(result_path):
             return rc
         if attempt < max_attempts:

--- a/swebench/image_run.py
+++ b/swebench/image_run.py
@@ -86,7 +86,22 @@ def _read_test_patch(problem: Problem, root: Path) -> str:
     return p.read_text() if p.is_file() else ""
 
 
-def _extract_cost_turns(transcript_path: str) -> tuple[float | None, int | None]:
+def _extract_cost_turns(transcript_path: str, *, agent_surface: str = "claude_code",
+                        codex_model: str | None = None) -> tuple[float | None, int | None]:
+    """(cost_usd, num_turns) from the transcript. Codex uses the runner's
+    token-based estimator (its ``--json`` shape differs from Claude's); its cost
+    needs a ``meta`` line naming the model to hit the price table, which the raw
+    ``codex exec`` stdout lacks — so we prepend one before estimating."""
+    if agent_surface == "codex_cli":
+        from swebench.runner import CodexRunner
+        try:
+            lines = Path(transcript_path).read_text().splitlines()
+            meta = json.dumps({"type": "meta", "model": codex_model or "gpt-5.5"})
+            primed = transcript_path + ".priced.jsonl"
+            Path(primed).write_text(meta + "\n" + "\n".join(lines) + "\n")
+            return CodexRunner().extract_metadata(Path(primed))
+        except Exception:  # noqa: BLE001 — cost is best-effort
+            return (None, None)
     cost = turns = None
     try:
         for line in Path(transcript_path).read_text().splitlines():
@@ -114,6 +129,7 @@ def run_one_arm(
     eval_env: dict,
     results_dir: str,
     agent_surface: str = "claude_code",
+    codex_model: str | None = None,
     wall_timeout: int = 1800,
     _now=None,
 ) -> str:
@@ -122,10 +138,11 @@ def run_one_arm(
     transcript = os.path.join(tempfile.mkdtemp(prefix="img-arm-"), "transcript.jsonl")
     verdict, resolution, cost, turns = "ERROR", None, None, None
     try:
-        container_agent.stage_arm(handle)
+        container_agent.stage_arm(handle, surface=agent_surface, arm=arm, model=codex_model)
         rc = container_agent.run_agent(
             handle, arm=arm, prompt=_build_prompt(problem, arm),
             result_path=transcript, wall_timeout=wall_timeout,
+            surface=agent_surface, model=codex_model,
         )
         log_dest = os.path.join(os.path.dirname(transcript), "eval.txt")
         grade = container_test.grade_agent_run(
@@ -134,7 +151,8 @@ def run_one_arm(
         )
         resolution = grade.get("resolution")
         verdict = "PASS" if official_grade.is_resolved(grade) else "FAIL"
-        cost, turns = _extract_cost_turns(transcript)
+        cost, turns = _extract_cost_turns(transcript, agent_surface=agent_surface,
+                                          codex_model=codex_model)
         logging.info("image_run %s %s run%d: rc=%s resolution=%s -> %s",
                      problem.instance_id, arm, run_idx, rc, resolution, verdict)
     finally:
@@ -177,6 +195,8 @@ def run_image_arms(
     num_runs: int,
     results_dir: str,
     agent_binary: str,
+    agent_surface: str = "claude_code",
+    codex_model: str | None = None,
     cap_gb: float | None = None,
     wall_timeout: int = 1800,
     echo=print,
@@ -184,7 +204,11 @@ def run_image_arms(
     """Run ``arms`` over ``problems`` on the image runtime. Returns
     ``(instance_id, arm, verdict)`` triples."""
     image_store.registry_login()
-    container_agent.ensure_agent_runtime(agent_binary)
+    # Populate the shared runtime volume for the chosen surface (#325).
+    if agent_surface == "codex_cli":
+        container_agent.ensure_codex_runtime()
+    else:
+        container_agent.ensure_agent_runtime(agent_binary)
     root = Path(os.environ.get("ONLYCODES_REPO_ROOT", ".")).resolve()
 
     order = {iid: i for i, iid in enumerate(
@@ -215,6 +239,7 @@ def run_image_arms(
                     digest_info=digest_info, grading_instance=gi,
                     spec_test_cmd=spec["test_cmd"], eval_env=eval_env,
                     results_dir=results_dir, wall_timeout=wall_timeout,
+                    agent_surface=agent_surface, codex_model=codex_model,
                 )
                 echo(f"  [{arm} run {run_idx}] {verdict}")
                 results.append((problem.instance_id, arm, verdict))

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -858,6 +858,8 @@ def _run_image_runtime(
     agent_binary: str,
     num_runs: int,
     max_wall_seconds: int,
+    agent_surface: str = "claude_code",
+    codex_model: str | None = None,
 ) -> None:
     """Handle ``--runtime image`` (C5 #319): Docker preflight, then dispatch to
     the dedicated image-runtime orchestrator (``swebench.image_run``)."""
@@ -881,6 +883,7 @@ def _run_image_runtime(
     results = image_run.run_image_arms(
         problems, arms=arm_list, num_runs=num_runs,
         results_dir=results_dir, agent_binary=agent_binary,
+        agent_surface=agent_surface, codex_model=codex_model,
         wall_timeout=wall, echo=click.echo,
     )
     n_pass = sum(1 for _, _, v in results if v == "PASS")
@@ -1130,27 +1133,16 @@ def run_command(
     if arms in ("bash_only", "all"):
         arm_list.append("bash_only")
 
-    # The image runtime's in-container agent staging is Claude-specific (C4);
-    # the Codex surface on images is a follow-up (#325). Fail clearly rather than
-    # letting the image path try to stage a codex binary it can't drive.
-    if runtime == "image" and agent_surface != "claude_code":
-        click.echo(
-            f"ERROR: --runtime image currently supports only --agent-surface claude_code "
-            f"(got {agent_surface!r}). Codex-on-image is tracked in #325; "
-            f"use --runtime overlay for the codex surface.",
-            err=True,
-        )
-        raise SystemExit(1)
-
     # --- Image runtime: dispatch to the dedicated orchestrator (C5 #319) -------
     # Runs on the official prebuilt images (pull-by-digest + LRU + in-container
-    # agent + official-parser grading). Deliberately separate from the overlay
-    # serial/parallel loop below.
+    # agent + official-parser grading), Claude or Codex surface (#325).
+    # Deliberately separate from the overlay serial/parallel loop below.
     if runtime == "image":
         _run_image_runtime(
             problems, arm_list,
             results_dir=str(results_dir), agent_binary=agent_binary,
             num_runs=num_runs, max_wall_seconds=max_wall_seconds,
+            agent_surface=agent_surface, codex_model=codex_model,
         )
         return
 

--- a/swebench/runner.py
+++ b/swebench/runner.py
@@ -910,6 +910,8 @@ def _write_codex_config(
     model: str = DEFAULT_CODEX_MODEL,
     isolation_nonce: str | None = None,
     iso_server_path: str | None = None,
+    mcp_command: str = "node",
+    mcp_env_extra: dict[str, str] | None = None,
 ) -> None:
     """Write config.toml into cfg_dir for a Codex run.
 
@@ -978,14 +980,21 @@ def _write_codex_config(
     )
 
     if _arm_uses_codebox(arm):
+        # mcp_command/mcp_env_extra let the in-container image path (#325) point
+        # the codebox server at the staged node binary and inject the testbed
+        # PATH so the kernel uses the project conda env. Host path keeps the
+        # defaults ("node" on PATH, no extra env).
+        env_lines = f'ONLYCODES_PERSISTENT_KERNEL = "{_toml_str(persistent_kernel)}"\n'
+        for k, v in (mcp_env_extra or {}).items():
+            env_lines += f'{k} = "{_toml_str(v)}"\n'
         toml += (
             "\n"
             "[mcp_servers.codebox]\n"
-            'command = "node"\n'
+            f'command = "{_toml_str(mcp_command)}"\n'
             f'args = ["{_toml_str(bundle_path)}"]\n'
             "\n"
             "[mcp_servers.codebox.env]\n"
-            f'ONLYCODES_PERSISTENT_KERNEL = "{_toml_str(persistent_kernel)}"\n'
+            + env_lines +
             "\n"
             "[mcp_servers.codebox.options]\n"
             'enabled_tools = ["execute_code", "execute_code_and_wait"]\n'

--- a/tests/test_container_agent.py
+++ b/tests/test_container_agent.py
@@ -162,13 +162,128 @@ def test_stage_arm_raises_if_exec_server_unbuilt(monkeypatch, tmp_path) -> None:
         ca.stage_arm(ContainerHandle("i", "c", "s"))
 
 
+# --- Codex surface (#325) ---------------------------------------------------
+
+def test_build_agent_argv_codex_onlycode() -> None:
+    argv = ca.build_agent_argv(
+        "onlycode", prompt="fix the bug", system_prompt="x",
+        surface="codex_cli", model="gpt-5.5", wall_timeout=900,
+    )
+    assert argv[:2] == ["timeout", "900s"]
+    assert argv[2] == ca.CODEX_BIN and argv[3] == "exec"
+    assert "--dangerously-bypass-approvals-and-sandbox" in argv and "--json" in argv
+    assert argv[argv.index("-m") + 1] == "gpt-5.5"
+    assert argv[argv.index("-C") + 1] == "/testbed"
+    # the soft tool-restriction directive is prepended to the prompt (last arg)
+    assert "execute_code" in argv[-1] and "fix the bug" in argv[-1]
+
+
+def test_codebox_was_used_detects_codex_and_claude(tmp_path) -> None:
+    codex = tmp_path / "codex.jsonl"
+    codex.write_text('{"type":"item.started","item":{"type":"mcp_tool_call","server":"codebox","tool":"execute_code"}}\n')
+    claude = tmp_path / "claude.jsonl"
+    claude.write_text('{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__codebox__execute_code"}]}}\n')
+    none = tmp_path / "none.jsonl"
+    none.write_text('{"type":"item.completed","item":{"type":"command_execution"}}\n')
+    assert ca._codebox_was_used(str(codex)) is True
+    assert ca._codebox_was_used(str(claude)) is True
+    assert ca._codebox_was_used(str(none)) is False
+
+
+def test_stage_arm_codex_writes_codex_home_and_chowns(monkeypatch, tmp_path) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(container, "_docker",
+                        lambda args, **kw: calls.append(args) or types.SimpleNamespace(
+                            returncode=0, stdout=b"", stderr=b""))
+    dist = tmp_path / "dist"; dist.mkdir()
+    for fname in ca._EXEC_SERVER_FILES:
+        (dist / fname).write_text("x")
+    monkeypatch.setattr(ca, "_exec_server_dist", lambda: dist)
+    creds = tmp_path / "codex"; creds.mkdir()
+    (creds / "auth.json").write_text("{}")
+
+    ca.stage_arm(ContainerHandle("i", "cidZ", "snap"), surface="codex_cli",
+                 arm="onlycode", model="gpt-5.5", creds_src=str(creds))
+
+    joined = [" ".join(a) for a in calls]
+    assert any("exec-server.bundle.mjs" in s for s in joined)            # bundle staged
+    assert any(f"{ca.CODEX_HOME_IN_CFG}/config.toml" in s for s in joined)  # config written
+    assert any(f"{ca.CODEX_HOME_IN_CFG}/auth.json" in s for s in joined)    # auth cp'd
+    assert calls[-1] == ["exec", "cidZ", "chown", "-R",
+                         f"{ca.AGENT_USER}:{ca.AGENT_USER}", ca.CFG_DIR]
+
+
+def test_stage_arm_codex_raises_without_auth(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(container, "_docker",
+                        lambda args, **kw: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""))
+    dist = tmp_path / "dist"; dist.mkdir()
+    for fname in ca._EXEC_SERVER_FILES:
+        (dist / fname).write_text("x")
+    monkeypatch.setattr(ca, "_exec_server_dist", lambda: dist)
+    with pytest.raises(ca.AgentRuntimeError, match="codex auth not found"):
+        ca.stage_arm(ContainerHandle("i", "c", "s"), surface="codex_cli",
+                     arm="onlycode", creds_src=str(tmp_path / "empty"))
+
+
+def test_find_codex_vendor_resolves_platform_dir(monkeypatch, tmp_path) -> None:
+    # mimic the npm layout: .../@openai/codex/bin/codex.js -> vendor/<target>
+    pkg = tmp_path / "lib" / "node_modules" / "@openai" / "codex"
+    (pkg / "bin").mkdir(parents=True)
+    shim = pkg / "bin" / "codex.js"; shim.write_text("//shim")
+    vendor = pkg / "node_modules" / "@openai" / "codex-linux-x64" / "vendor" / ca._CODEX_TARGET
+    vendor.mkdir(parents=True)
+    monkeypatch.setattr(ca.shutil, "which", lambda _: str(shim))
+    assert ca._find_codex_vendor() == str(vendor)
+
+
+def test_find_codex_vendor_raises_if_codex_absent(monkeypatch) -> None:
+    monkeypatch.setattr(ca.shutil, "which", lambda _: None)
+    with pytest.raises(ca.AgentRuntimeError, match="host `codex` not found"):
+        ca._find_codex_vendor()
+
+
+def _fake_codex_auth(tmp_path, exp_offset_sec: float | None, *, api_key=False):
+    import base64, json as _json, time
+    if api_key:
+        body = {"OPENAI_API_KEY": "sk-x", "tokens": None}
+    else:
+        claims = {"exp": int(time.time() + exp_offset_sec)} if exp_offset_sec is not None else {}
+        payload = base64.urlsafe_b64encode(_json.dumps(claims).encode()).rstrip(b"=").decode()
+        body = {"auth_mode": "chatgpt", "tokens": {"access_token": f"h.{payload}.sig"}}
+    p = tmp_path / "auth.json"; p.write_text(_json.dumps(body))
+    return str(p)
+
+
+def test_assert_codex_token_fresh_accepts_long_lived(tmp_path) -> None:
+    ca._assert_codex_token_fresh(_fake_codex_auth(tmp_path, 10 * 86400))  # 10 days -> ok
+
+
+def test_assert_codex_token_fresh_rejects_near_expiry(tmp_path) -> None:
+    with pytest.raises(ca.AgentRuntimeError, match="codex login"):
+        ca._assert_codex_token_fresh(_fake_codex_auth(tmp_path, 600))  # 10 min left -> reject
+
+
+def test_assert_codex_token_fresh_exempts_api_key(tmp_path) -> None:
+    ca._assert_codex_token_fresh(_fake_codex_auth(tmp_path, None, api_key=True))  # no raise
+
+
+def test_ensure_codex_runtime_idempotent_when_codex_present(monkeypatch) -> None:
+    monkeypatch.setattr(ca, "_volume_exists", lambda name: True)
+    monkeypatch.setattr(container, "_docker",
+                        lambda args, **kw: types.SimpleNamespace(returncode=0, stdout=b"", stderr=b""))
+    # codex bin present in volume -> returns without re-staging (no _find_codex_vendor needed)
+    monkeypatch.setattr(ca, "_find_codex_vendor",
+                        lambda: (_ for _ in ()).throw(AssertionError("should not re-stage")))
+    assert ca.ensure_codex_runtime() == ca.RUNTIME_VOLUME
+
+
 def test_run_agent_retries_code_only_until_codebox_connects(monkeypatch, tmp_path) -> None:
     # Simulate the MCP startup race: first two invocations produce a transcript
     # with no codebox use; the third connects.
     result = tmp_path / "r.jsonl"
     calls = {"n": 0}
 
-    def _fake_invoke(handle, argv, path, host_timeout):
+    def _fake_invoke(handle, argv, path, host_timeout, **kw):
         calls["n"] += 1
         if calls["n"] < 3:
             Path(path).write_text('{"type":"assistant"}\n')  # no codebox tool
@@ -188,7 +303,7 @@ def test_run_agent_baseline_never_retries(monkeypatch, tmp_path) -> None:
     result = tmp_path / "b.jsonl"
     calls = {"n": 0}
 
-    def _fake_invoke(handle, argv, path, host_timeout):
+    def _fake_invoke(handle, argv, path, host_timeout, **kw):
         calls["n"] += 1
         Path(path).write_text('{"type":"assistant"}\n')  # no codebox — irrelevant for baseline
         return 0
@@ -203,7 +318,7 @@ def test_run_agent_gives_up_after_max_attempts(monkeypatch, tmp_path) -> None:
     result = tmp_path / "g.jsonl"
     calls = {"n": 0}
 
-    def _fake_invoke(handle, argv, path, host_timeout):
+    def _fake_invoke(handle, argv, path, host_timeout, **kw):
         calls["n"] += 1
         Path(path).write_text('{"type":"assistant"}\n')  # never connects
         return 0

--- a/tests/test_image_run.py
+++ b/tests/test_image_run.py
@@ -98,6 +98,40 @@ def test_run_one_arm_pass_path(monkeypatch, tmp_path) -> None:
     assert meta["verdict"] == "PASS" and meta["total_cost_usd"] == 0.2
 
 
+def test_run_image_arms_codex_surface_uses_codex_runtime(monkeypatch, tmp_path) -> None:
+    calls = {}
+    monkeypatch.setattr(image_run.image_store, "registry_login", lambda: False)
+    monkeypatch.setattr(image_run.container_agent, "ensure_codex_runtime",
+                        lambda **k: calls.setdefault("codex_rt", True) or "vol")
+    monkeypatch.setattr(image_run.container_agent, "ensure_agent_runtime",
+                        lambda *a, **k: calls.setdefault("claude_rt", True))
+    monkeypatch.setattr(image_run, "run_one_arm",
+                        lambda *a, **k: (calls.update(surface=k["agent_surface"],
+                                                      model=k["codex_model"]), "PASS")[1])
+    monkeypatch.setattr(image_run.image_store, "ensure_image",
+                        lambda iid, **k: {"digest": "sha256:x", "arch": "amd64"})
+    monkeypatch.setattr(image_run.container, "prepare_instance",
+                        lambda iid, **k: PreparedImage(iid, "b", "s"))
+    monkeypatch.setattr(image_run.specs, "spec_for", lambda r, v: {"test_cmd": "pytest -rA"})
+    monkeypatch.setattr(image_run.specs, "eval_env", lambda s: {})
+
+    out = image_run.run_image_arms([_problem()], arms=["onlycode"], num_runs=1,
+                                   results_dir=str(tmp_path), agent_binary="codex",
+                                   agent_surface="codex_cli", codex_model="gpt-5.4",
+                                   echo=lambda *a: None)
+    assert out == [("psf__requests-1142", "onlycode", "PASS")]
+    assert calls.get("codex_rt") and "claude_rt" not in calls   # codex runtime, not claude
+    assert calls["surface"] == "codex_cli" and calls["model"] == "gpt-5.4"
+
+
+def test_extract_cost_turns_codex_counts_turns(tmp_path) -> None:
+    f = tmp_path / "t.jsonl"
+    f.write_text('{"type":"turn.started"}\n'
+                 '{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5}}\n')
+    _cost, turns = image_run._extract_cost_turns(str(f), agent_surface="codex_cli", codex_model="gpt-5.5")
+    assert turns == 1
+
+
 def test_run_image_arms_skips_without_grading_data(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(image_run.image_store, "registry_login", lambda: False)
     monkeypatch.setattr(image_run.container_agent, "ensure_agent_runtime", lambda b, **k: "vol")

--- a/tests/test_integration_codex_onlycode_arm.py
+++ b/tests/test_integration_codex_onlycode_arm.py
@@ -171,28 +171,6 @@ def test_codex_run_onlycode_preflight_invoked(runner, monkeypatch, tmp_path):
     )
 
 
-def test_codex_run_image_runtime_rejected(runner, monkeypatch, tmp_path):
-    """codex_cli + --runtime image must error clearly (codex-on-image is #325),
-    not fall into the Claude-only image path."""
-    monkeypatch.setattr("swebench.runner.CodexRunner.find_binary", lambda self: "/usr/bin/codex")
-    monkeypatch.setattr("swebench.runner.CodexRunner.verify_auth", lambda self: None)
-    monkeypatch.setattr("swebench.runner.CodexRunner.get_version", lambda self, _: "test")
-    _make_minimal_swe_problem(tmp_path / "problems" / "swe")
-    monkeypatch.setattr("swebench.run.repo_root", lambda: tmp_path)
-
-    result = runner.invoke(
-        cli,
-        ["run", "--agent-surface", "codex_cli", "--arms", "onlycode",
-         "--runtime", "image", "--output-dir", str(tmp_path / "out")],
-        catch_exceptions=False,
-    )
-    assert result.exit_code != 0
-    out = result.output or ""
-    assert "claude_code" in out and "#325" in out, (
-        f"Expected a clear codex-on-image rejection mentioning #325, got:\n{out!r}"
-    )
-
-
 def test_codex_run_onlycode_preflight_ok_proceeds_past_preflight(runner, monkeypatch, tmp_path):
     """codex_cli + onlycode arm proceeds past preflight when it succeeds.
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -201,6 +201,23 @@ def test_write_codex_config_persistent_kernel_flag(tmp_path):
     assert 'ONLYCODES_PERSISTENT_KERNEL = "1"' in content
 
 
+def test_write_codex_config_incontainer_command_and_env(tmp_path):
+    """In-container image path (#325): codebox MCP command + extra env (PATH)."""
+    _write_codex_config(
+        str(tmp_path), "/opt/cfg/exec_server/exec-server.bundle.mjs", "/testbed", "1",
+        arm="code_only", mcp_command="/opt/agent/node",
+        mcp_env_extra={"PATH": "/opt/miniconda3/envs/testbed/bin:/usr/bin"},
+    )
+    content = (tmp_path / "config.toml").read_text()
+    assert 'command = "/opt/agent/node"' in content              # staged node, not "node"
+    assert 'PATH = "/opt/miniconda3/envs/testbed/bin:/usr/bin"' in content
+    assert 'args = ["/opt/cfg/exec_server/exec-server.bundle.mjs"]' in content
+    # default host behaviour unchanged when params omitted
+    other = tmp_path / "host"; other.mkdir()
+    _write_codex_config(str(other), "/b.mjs", "/s", "1", arm="code_only")
+    assert 'command = "node"' in (other / "config.toml").read_text()
+
+
 # ---------------------------------------------------------------------------
 # CodexRunner — model pinning (Issue #253)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #325. Extends the in-container agent (C4) to the **Codex CLI** surface, so `--runtime image --agent-surface codex_cli` works, reusing the same container / exec-server / no-leak / official-grading plumbing.

De-risked first by an in-container spike (codex auths, codebox MCP registers, tool restriction holds, kernel binds the testbed env), then built surface-aware.

## Changes
**`container_agent.py` (surface-aware):**
- `ensure_codex_runtime` + `_find_codex_vendor` — stage codex's **static-musl native binary** (vendor dir ~224 MB) + node into the shared RO runtime volume. codex is a node shim → native binary; we invoke the **native binary directly** (no node for codex itself; node still runs the codebox MCP bundle).
- `_stage_arm_codex` — writes a `CODEX_HOME` (auth.json + config.toml) instead of Claude creds/mcp-config. config.toml is **single-sourced** via `runner._write_codex_config` (new `mcp_command` + `mcp_env_extra` args) with in-container paths: codebox MCP `command`=staged node, env `PATH`=testbed conda bin.
- `_build_codex_argv` — `codex exec --dangerously-bypass-approvals-and-sandbox --json -m <model> -C /testbed` + soft arm directive.
- `_invoke_once` — codex env (`CODEX_HOME` + `PATH`); `_codebox_was_used` matches both Claude (`mcp__codebox__`) and Codex (`"server":"codebox"`) transcripts.
- **Token-freshness guard** — refuse to stage an OAuth token expiring within 1 h. ChatGPT access tokens last ~10 days, so cp-forward never refreshes in-container; an in-container refresh would consume the one-time refresh token and break the rest of a sweep, so a stale token now fails loudly with a `codex login` hint. API-key auth exempt.

**`image_run.py`** — dispatch staging/argv/runtime/cost by `agent_surface`; codex cost via `CodexRunner.extract_metadata`. **`run.py`** — drop the codex+image guard (now supported); thread `agent_surface`/`codex_model`. **`runner.py`** — `_write_codex_config` gains `mcp_command`/`mcp_env_extra` (host behaviour unchanged when omitted).

## Validation
- **Hermetic**: 935 passed (`tests/ -m "not integration"`), incl. new codex argv/staging/guard/dispatch/config tests.
- **Live (image path, requests-1142)**: codex ran **restricted to codebox (30 calls, 0 shell)**, edited `/testbed`, was official-graded honestly. n=1 `RESOLVED_NO` on both runs — codex consistently makes a **GET-only** fix that misses the held-out test's HEAD assertion (a model-behaviour miss, *not* a harness defect; Claude solved the same instance). The full pipeline — auth → restricted run → grade → record (cost/turns/resolution) — is validated.

## Auth note (for codex sweeps)
cp-forward the host `~/.codex/auth.json`; with a ~10-day access token it never refreshes in-container, so a single `codex login` covers a full sweep. The freshness guard makes a stale token fail loudly instead of silently consuming the one-time refresh token. For parallel codex sweeps, `OPENAI_API_KEY` (no rotation) is the robust path — the staging already exempts it from the guard; wiring key-based staging end-to-end is a small follow-up if needed.

Follow-up to #318/#319 (epic #314). Not committed here: the 38-sweep grading-data (digest manifest + extra `problems/` YAMLs) — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)