### PR TITLE
WS-334(#334): pin baseline tool surface to canonical coding allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,14 @@ The cached venv at `instances/<id>/venv/` (formerly a shared mutable dir) is now
 
 `run_claude()` creates a temp config dir containing only `.credentials.json` + `.claude.json` and sets `CLAUDE_CONFIG_DIR` to it. Always uses `--dangerously-skip-permissions --no-session-persistence`. Never shares state between arms or runs.
 
-### Tool restriction for onlycode / code_only
+### Tool restriction for onlycode / code_only / baseline (Claude surface)
 
-The onlycode arm passes `--tools mcp__codebox__execute_code,mcp__codebox__list_tools` and `--disallowedTools` covering all built-in tools. This is implemented in `runner.py:ClaudeRunner.build_tools_flags`; check there before modifying tool lists.
+Both arms are pinned to an explicit `--tools` allowlist in `runner.py:ClaudeRunner.build_tools_flags` (single-sourced; used by the image, overlay, and artifact paths). Check there before modifying tool lists.
+
+- **onlycode / code_only** → `--tools mcp__codebox__execute_code,mcp__codebox__list_tools` + `--disallowedTools BLOCKED_BUILTINS`.
+- **baseline / tool_rich** → `--tools CODING_ALLOWLIST` (`Bash,Edit,Glob,Grep,Read,Write`) + `--disallowedTools` (BLOCKED_BUILTINS minus the allowlist). This pins the baseline to a canonical "native file-system coding" surface instead of the binary's full default set, which includes agentic-orchestration tools (subagents via `Task`, `Workflow`, `ScheduleWakeup`, `Cron*`, `Monitor`, `RemoteTrigger`, …) and omits `Glob`/`Grep`. Without the pin the baseline could fan out to subagents (not apples-to-apples vs. the code-only arm) and the surface drifted with the binary version (#334).
+
+`BLOCKED_BUILTINS` is the full known built-in surface and must enumerate every orchestration tool the binary ships; adding to it tightens both arms. **Methodology note:** baseline numbers collected before #334 (≤ 2026-06-07) ran on the unrestricted default surface (possible subagent use, no `Glob`/`Grep`) — flag this in any longitudinal comparison. The Codex surface is unaffected (it has no orchestration tools; tools are gated via `config.toml`, not CLI flags).
 
 ### patterns.json is append-only during runs
 

--- a/swebench/runner.py
+++ b/swebench/runner.py
@@ -81,15 +81,33 @@ def generate_isolation_nonce(instance_id: str, arm: str, run_idx: int) -> str:
 
 # Built-in Claude tools blocked for onlycode / code_only arms.
 # Canonical single source of truth — imported by run.py and artifact_run.py.
+#
+# This is the full known built-in surface of the ``claude`` binary. It also
+# seeds the *baseline* disallow list (everything here minus CODING_ALLOWLIST),
+# so any agentic-orchestration tool added to the binary must be mirrored here
+# to keep both arms reproducible across binary versions. ``Task`` (the subagent
+# spawner — distinct from the legacy ``Agent`` alias), ``Workflow`` and
+# ``ScheduleWakeup`` were observed in the binary's default surface (2026-06-06,
+# issue #334) but missing from this list; the onlycode allowlist masked the gap,
+# the unrestricted baseline did not.
 BLOCKED_BUILTINS = (
     "Agent,AskUserQuestion,Bash,CronCreate,CronDelete,CronList,"
     "Edit,EnterPlanMode,EnterWorktree,ExitPlanMode,ExitWorktree,"
     "Glob,Grep,ListMcpResourcesTool,LSP,Monitor,NotebookEdit,"
     "PowerShell,PushNotification,Read,ReadMcpResourceTool,"
-    "RemoteTrigger,SendMessage,Skill,"
-    "TaskCreate,TaskGet,TaskList,TaskOutput,TaskStop,TaskUpdate,"
-    "TeamCreate,TeamDelete,TodoWrite,ToolSearch,WebFetch,WebSearch,Write"
+    "RemoteTrigger,ScheduleWakeup,SendMessage,Skill,"
+    "Task,TaskCreate,TaskGet,TaskList,TaskOutput,TaskStop,TaskUpdate,"
+    "TeamCreate,TeamDelete,TodoWrite,ToolSearch,WebFetch,WebSearch,"
+    "Workflow,Write"
 )
+
+# Canonical "native file-system coding" tool surface for the baseline /
+# tool_rich arms. The baseline is pinned to exactly this allowlist (and
+# everything else in BLOCKED_BUILTINS is disallowed) so it is an apples-to-apples
+# "native tools vs code-only" contrast: no subagents (Task), no automation
+# (Cron*, Workflow, ScheduleWakeup, Monitor, RemoteTrigger), no web access —
+# but with Glob/Grep restored (the binary default omits them). See issue #334.
+CODING_ALLOWLIST = "Bash,Edit,Glob,Grep,Read,Write"
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +227,16 @@ class ClaudeRunner(AgentRunner):
 
     def build_tools_flags(self, arm: str, mcp_config_path: str | None) -> list[str]:
         if arm in ("tool_rich", "baseline"):
-            return []
+            # Pin to the canonical coding allowlist instead of inheriting the
+            # binary's full default surface (which includes subagents and
+            # automation tools, and omits Glob/Grep). #334. ``--tools`` acts as
+            # a true allowlist for this binary; the explicit ``--disallowedTools``
+            # is defense-in-depth against allowlist-semantics drift.
+            allow = set(CODING_ALLOWLIST.split(","))
+            blocked = ",".join(
+                t for t in BLOCKED_BUILTINS.split(",") if t.strip() not in allow
+            )
+            return ["--tools", CODING_ALLOWLIST, "--disallowedTools", blocked]
         if arm in ("code_only", "onlycode"):
             flags: list[str] = []
             if mcp_config_path:

--- a/tests/test_artifact_run.py
+++ b/tests/test_artifact_run.py
@@ -20,7 +20,7 @@ from swebench.artifact_run import (
     run_artifact_arm,
     run_dir_for,
 )
-from swebench.runner import AgentRunner, ClaudeRunner, BLOCKED_BUILTINS
+from swebench.runner import AgentRunner, ClaudeRunner, BLOCKED_BUILTINS, CODING_ALLOWLIST
 
 
 def _make_fixture(task_dir: Path, grader_src: str, budget=(0, 0)) -> Task:
@@ -114,8 +114,13 @@ def test_build_tools_flags_code_only_includes_blocked_builtins():
         assert name in disallowed
 
 
-def test_build_tools_flags_tool_rich_empty():
-    assert ClaudeRunner().build_tools_flags("tool_rich", mcp_config_path="/tmp/mcp.json") == []
+def test_build_tools_flags_tool_rich_pinned_to_coding_allowlist():
+    # tool_rich is pinned to the canonical coding allowlist, not unrestricted (#334).
+    flags = ClaudeRunner().build_tools_flags("tool_rich", mcp_config_path="/tmp/mcp.json")
+    assert flags[flags.index("--tools") + 1] == CODING_ALLOWLIST
+    disallowed = flags[flags.index("--disallowedTools") + 1]
+    assert "Task" in disallowed and "Workflow" in disallowed
+    assert "--mcp-config" not in flags  # no codebox MCP for tool_rich
 
 
 def test_build_tools_flags_rejects_unknown_arm():

--- a/tests/test_container_agent.py
+++ b/tests/test_container_agent.py
@@ -25,7 +25,7 @@ import pytest
 
 from swebench import container, container_agent as ca
 from swebench.container import ContainerHandle
-from swebench.runner import BLOCKED_BUILTINS
+from swebench.runner import BLOCKED_BUILTINS, CODING_ALLOWLIST
 
 
 # --------------------------------------------------------------------------
@@ -79,13 +79,17 @@ def test_build_agent_argv_code_only_restricts_to_codebox() -> None:
     assert argv[argv.index("--model") + 1] == ca.MODEL
 
 
-def test_build_agent_argv_baseline_has_no_tool_restriction() -> None:
+def test_build_agent_argv_baseline_pinned_to_coding_allowlist() -> None:
     argv = ca.build_agent_argv(
         "baseline", prompt="p", system_prompt="s", wall_timeout=0)
     # No timeout prefix when wall_timeout == 0.
     assert argv[0] == ca.CLAUDE_BIN
-    # baseline => native tools; no restriction flags.
-    assert "--tools" not in argv and "--disallowedTools" not in argv
+    # baseline => native coding tools pinned to a canonical allowlist (#334),
+    # not the binary's full default surface.
+    assert argv[argv.index("--tools") + 1] == CODING_ALLOWLIST
+    disallowed = argv[argv.index("--disallowedTools") + 1]
+    assert "Task" in disallowed and "Workflow" in disallowed  # subagents/automation blocked
+    # No codebox MCP for baseline.
     assert "--mcp-config" not in argv
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,6 +12,7 @@ import tomllib
 
 from swebench.runner import (
     BLOCKED_BUILTINS,
+    CODING_ALLOWLIST,
     ClaudeRunner,
     CodexRunner,
     _toml_str,
@@ -108,12 +109,41 @@ def test_harness_generate_mcp_config_missing_file_returns_input():
 # ClaudeRunner — build_tools_flags
 # ---------------------------------------------------------------------------
 
-def test_claude_tools_flags_baseline():
-    assert ClaudeRunner().build_tools_flags("baseline", None) == []
+def _baseline_disallowed(arm: str) -> str:
+    flags = ClaudeRunner().build_tools_flags(arm, None)
+    return flags[flags.index("--disallowedTools") + 1]
 
 
-def test_claude_tools_flags_tool_rich():
-    assert ClaudeRunner().build_tools_flags("tool_rich", None) == []
+@pytest.mark.parametrize("arm", ["baseline", "tool_rich"])
+def test_claude_tools_flags_baseline_pinned_to_coding_allowlist(arm):
+    """baseline/tool_rich is pinned to the canonical coding allowlist (#334),
+    not the binary's full default surface."""
+    flags = ClaudeRunner().build_tools_flags(arm, None)
+    assert flags[flags.index("--tools") + 1] == CODING_ALLOWLIST
+    allowed = set(CODING_ALLOWLIST.split(","))
+    # Canonical coding tools present, incl. Glob/Grep (binary default omits them).
+    assert {"Bash", "Edit", "Read", "Write", "Glob", "Grep"} <= allowed
+
+
+@pytest.mark.parametrize("arm", ["baseline", "tool_rich"])
+def test_claude_tools_flags_baseline_excludes_orchestration(arm):
+    """Subagents and automation tools must be disallowed for the baseline so it
+    is an apples-to-apples contrast with the code-only arm (#334)."""
+    disallowed = _baseline_disallowed(arm)
+    for tool in ("Task", "Agent", "Workflow", "ScheduleWakeup",
+                 "CronCreate", "Monitor", "RemoteTrigger", "WebFetch", "WebSearch"):
+        assert tool in disallowed, f"{tool} must be disallowed for {arm}"
+    # Allowlisted coding tools must NOT also appear in the disallow list.
+    for tool in CODING_ALLOWLIST.split(","):
+        assert tool not in disallowed.split(","), f"{tool} wrongly disallowed for {arm}"
+
+
+def test_blocked_builtins_covers_orchestration_surface():
+    """Regression for the #334 gap: BLOCKED_BUILTINS must enumerate the
+    agentic-orchestration tools observed in the binary's default surface."""
+    builtins = set(BLOCKED_BUILTINS.split(","))
+    for tool in ("Task", "Workflow", "ScheduleWakeup"):
+        assert tool in builtins, f"{tool} missing from BLOCKED_BUILTINS"
 
 
 def test_claude_tools_flags_onlycode_with_mcp():


### PR DESCRIPTION
## Summary

The **baseline**/`tool_rich` Claude arm returned `[]` from `build_tools_flags`, inheriting the `claude` binary's **full default tool surface**. An image parity-sweep transcript (`runs/swebench/parity-sweep/`, 2026-06-06) confirms that surface:

- **includes agentic-orchestration tools** — subagents (`Task`), `Workflow`, `ScheduleWakeup`, `Cron*`, `Monitor`, `RemoteTrigger`, `Skill`, `EnterWorktree`, … — and
- **omits `Glob`/`Grep`** (canonical search).

2 of 5 baseline runs spawned `Explore` subagents via `Task`. Subagent actions aren't written to the saved transcript (so `num_turns` undercounts and the behavioral record is incomplete), and the code-only arm **cannot** spawn subagents — so the contrast wasn't apples-to-apples. The surface also **drifted with the binary version** (new orchestration tools silently join on upgrade).

## Fix

Single-sourced in `runner.py:ClaudeRunner.build_tools_flags` (used by the image, overlay, and artifact paths):

- Pin baseline/tool_rich to `CODING_ALLOWLIST = "Bash,Edit,Glob,Grep,Read,Write"` via `--tools`, plus `--disallowedTools` = `BLOCKED_BUILTINS` minus the allowlist (mirrors the existing `bash_only` subtraction pattern). Restores `Glob`/`Grep`, excludes subagents and automation.
- **Closed a `BLOCKED_BUILTINS` gap found while investigating:** it was missing `Task`, `Workflow`, `ScheduleWakeup` (it had the legacy `Agent` alias but not the binary's actual `Task` subagent tool). The onlycode `--tools` allowlist masked the gap (onlycode got exactly the 2 codebox tools — verified in transcript); the unrestricted baseline did not. Adding them tightens both arms.

## Verification

- `onlycode` init tools (transcript): `mcp__codebox__execute_code, mcp__codebox__list_tools` only → `--tools` is a true allowlist for this binary; the explicit `--disallowedTools` is defense-in-depth.
- Full suite: **938 passed** (`-m "not integration"`).

## Tests
- Parametrized baseline/tool_rich: allowlist present, orchestration (`Task`/`Workflow`/`ScheduleWakeup`/`Cron*`/`Monitor`/`RemoteTrigger`/web) disallowed, allowlisted tools not double-listed.
- `BLOCKED_BUILTINS` coverage regression for the three missing tools.
- Updated the two tests that encoded the old "baseline = unrestricted" behavior.

## Methodology note
Baseline numbers collected before this pin (≤ 2026-06-07) ran on the unrestricted default surface (possible subagent use, no `Glob`/`Grep`) — flagged in `CLAUDE.md` for longitudinal comparison. Codex surface unaffected (no orchestration tools; gated via `config.toml`).

Closes #334. Follow-up to #319; sibling of #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)