### PR TITLE
Verbatim grading follow-ups: claude smoke fixes (model routing, empty-patch, dup-loader) + data (#354)

### DIFF
--- a/sets/sample-1per-repo.txt
+++ b/sets/sample-1per-repo.txt
@@ -1,0 +1,14 @@
+# Tier-1 codex-smoke sample: 1 buildable instance per repo (#354 e2e).
+# 12 repos; flaky instances excluded for a clean smoke.
+astropy__astropy-12907
+django__django-10554
+matplotlib__matplotlib-13989
+mwaskom__seaborn-3069
+pallets__flask-5014
+psf__requests-1142
+pydata__xarray-2905
+pylint-dev__pylint-4551
+pytest-dev__pytest-10051
+scikit-learn__scikit-learn-10297
+sphinx-doc__sphinx-10323
+sympy__sympy-11618

--- a/sets/verified-flaky.txt
+++ b/sets/verified-flaky.txt
@@ -1,0 +1,6 @@
+# Known-flaky Verified instances (#354): gold resolves intermittently under verbatim
+# run_evaluation. KEPT in verified-buildable.txt — grade with retry-on-not-resolved.
+# Root causes + evidence: docs/VERIFIED_EXCLUSIONS.md.
+psf__requests-1921      # httpbin.org intermittent 503 (SWE-bench issue #484); 3/3 on a quiet host
+django__django-13089    # timing cache tests (test_touch/test_expiration) regress a different subset each run
+django__django-13344    # same flaky cache-timing signature

--- a/swebench/grading_official.py
+++ b/swebench/grading_official.py
@@ -287,6 +287,16 @@ def grade_predictions(
     )
 
     reports = _collect_reports(work, run_id, model_name, ids)
+    # An empty model_patch makes run_evaluation skip the instance (it lists the id
+    # under empty_patch_instances and writes no per-instance report.json). That is a
+    # legitimate *not resolved* — the agent produced no diff — NOT a grading error.
+    # Mark it resolved=False WITHOUT an "error" key so callers score it FAIL, not ERROR.
+    empty_ids = {p["instance_id"] for p in preds if not (p["model_patch"] or "").strip()}
+    for iid in empty_ids:
+        r = reports.get(iid)
+        if r is None or "error" in r:
+            reports[iid] = {"resolved": False, "patch_successfully_applied": False,
+                            "empty_patch": True}
     any_report = any("error" not in r for r in reports.values())
     if proc.returncode != 0 and not any_report:
         tail = (proc.stderr or proc.stdout or "")[-1500:]

--- a/swebench/image_run.py
+++ b/swebench/image_run.py
@@ -164,12 +164,16 @@ def run_one_arm(
     transcript = os.path.join(tempfile.mkdtemp(prefix="img-arm-"), "transcript.jsonl")
     model_patch = ""
     cost, turns = None, None
+    # ``codex_model`` is codex-specific (default "gpt-5.5"). Only pass it to the
+    # codex surface; for claude_code, model=None lets the runner use its pinned
+    # claude model (passing gpt-5.5 to claude is a 404). #354.
+    model = codex_model if agent_surface == "codex_cli" else None
     try:
-        container_agent.stage_arm(handle, surface=agent_surface, arm=arm, model=codex_model)
+        container_agent.stage_arm(handle, surface=agent_surface, arm=arm, model=model)
         rc = container_agent.run_agent(
             handle, arm=arm, prompt=_build_prompt(problem, arm),
             result_path=transcript, wall_timeout=wall_timeout,
-            surface=agent_surface, model=codex_model,
+            surface=agent_surface, model=model,
         )
         diff_dest = os.path.join(os.path.dirname(transcript), "model_patch.diff")
         # Empty-diff case (agent made no change) yields an empty string — fine.

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -828,11 +828,27 @@ def _cleanup_stale_overlays(
 DEPRECATED_PROBLEM_SETS = {"swebench-verified-mini"}
 
 
+#: When the same instance_id (YAML stem) appears in more than one set, this set's
+#: copy wins — it is the canonical Verified-500 spine (correct version/spec/image).
+CANONICAL_PROBLEM_SET = "swebench-verified"
+
+
 def _discover_problem_yamls(problems_dir: Path) -> list[Path]:
-    """All ``*.yaml`` under ``problems_dir``, minus any path component naming a
-    set in :data:`DEPRECATED_PROBLEM_SETS`. Sorted for deterministic ordering."""
-    return [f for f in sorted(problems_dir.rglob("*.yaml"))
-            if not (set(f.relative_to(problems_dir).parts) & DEPRECATED_PROBLEM_SETS)]
+    """All ``*.yaml`` under ``problems_dir``, minus any path component naming a set
+    in :data:`DEPRECATED_PROBLEM_SETS`, **deduplicated by instance_id** (the YAML
+    stem). When an id exists in several sets — e.g. a ``swebench-datasci-mini`` copy
+    (38 unique + 12 that duplicate Verified) and the canonical ``swebench-verified``
+    copy — the Verified copy wins; otherwise discovery globs the id twice and the
+    run double-executes it per arm/seed (#354). Sorted for deterministic ordering."""
+    candidates = [f for f in sorted(problems_dir.rglob("*.yaml"))
+                  if not (set(f.relative_to(problems_dir).parts) & DEPRECATED_PROBLEM_SETS)]
+    by_id: dict[str, Path] = {}
+    for f in candidates:
+        prev = by_id.get(f.stem)
+        if prev is None or (CANONICAL_PROBLEM_SET in f.parts
+                            and CANONICAL_PROBLEM_SET not in prev.parts):
+            by_id[f.stem] = f
+    return sorted(by_id.values())
 
 
 def _parse_filter_ids(filter_spec: str) -> set[str]:

--- a/tests/test_grading_official.py
+++ b/tests/test_grading_official.py
@@ -79,6 +79,37 @@ def test_collect_reports_flat_shape(tmp_path: Path) -> None:
 
 
 # --------------------------------------------------------------------------
+# grade_predictions — empty-patch handling (FAIL, not ERROR)
+# --------------------------------------------------------------------------
+
+def test_grade_predictions_empty_patch_is_fail_not_error(monkeypatch) -> None:
+    """An empty model_patch => run_evaluation writes no report. That is a
+    legitimate not-resolved (agent produced no diff), NOT a grading error: the
+    report must lack an ``error`` key (so callers score FAIL), while a non-empty
+    patch with a genuinely missing report stays an error (#354)."""
+    monkeypatch.setattr(g, "ensure_official_venv", lambda **k: "/bin/true")
+
+    class _Proc:
+        returncode, stderr, stdout = 0, "", ""
+
+    monkeypatch.setattr(g.subprocess, "run", lambda *a, **k: _Proc())
+    # both ids come back report-less (run_evaluation skipped the empty one)
+    monkeypatch.setattr(
+        g, "_collect_reports",
+        lambda *a, **k: {i: {"resolved": False, "error": "no report.json"} for i in a[3]},
+    )
+    out = g.grade_predictions(
+        [{"instance_id": "x__y-1", "model_patch": "   "},          # empty/whitespace
+         {"instance_id": "x__y-2", "model_patch": "diff --git a b"}],  # real, but no report
+        run_id="t", instance_ids=["x__y-1", "x__y-2"],
+    )
+    assert out["x__y-1"] == {"resolved": False, "patch_successfully_applied": False,
+                             "empty_patch": True}
+    assert "error" not in out["x__y-1"]          # -> FAIL
+    assert "error" in out["x__y-2"]              # real patch, missing report -> ERROR
+
+
+# --------------------------------------------------------------------------
 # ensure_official_venv — readiness / atomic-build logic (no real venv)
 # --------------------------------------------------------------------------
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -63,6 +63,25 @@ def test_discover_keeps_everything_when_no_deprecated_dirs(tmp_path):
     assert [p.name for p in found] == ["a__b-1.yaml"]
 
 
+def test_discover_dedups_by_id_prefers_verified(tmp_path):
+    """An id in BOTH a non-deprecated set (e.g. datasci-mini) and the canonical
+    Verified set must resolve to the Verified copy once — not double-run (#354)."""
+    swe = tmp_path
+    (swe / "swebench-verified").mkdir(parents=True)
+    (swe / "swebench-datasci-mini").mkdir(parents=True)
+    # shared id in both sets
+    (swe / "swebench-verified" / "mwaskom__seaborn-3069.yaml").write_text("v: ver\n")
+    (swe / "swebench-datasci-mini" / "mwaskom__seaborn-3069.yaml").write_text("v: mini\n")
+    # an id UNIQUE to datasci-mini must still be discovered
+    (swe / "swebench-datasci-mini" / "sympy__sympy-11232.yaml").write_text("v: mini\n")
+
+    found = {p.relative_to(swe).as_posix() for p in _discover_problem_yamls(swe)}
+    assert found == {
+        "swebench-verified/mwaskom__seaborn-3069.yaml",      # verified wins the dup
+        "swebench-datasci-mini/sympy__sympy-11232.yaml",     # unique kept
+    }
+
+
 # --- runtime backend default (image-only, ADR-0004 / #314) ------------------
 
 def test_runtime_defaults_to_image():


### PR DESCRIPTION
## What

Follow-ups from the #354 verbatim-grading e2e validation — the Tier-1 baseline smoke + two bug fixes it surfaced + data artifacts.

## Bug fixes

- **image runtime fed the codex model to Claude** (`aed63f3`): `run_one_arm` passed `codex_model` (default `gpt-5.5`) to *both* surfaces, so the `claude_code` runner did `--model gpt-5.5` → 404 / empty patches. Now `codex_model` only goes to `codex_cli`; `claude_code` uses its pinned model. Pre-existing; surfaced by the first image+claude run.
- **empty-patch graded as ERROR instead of FAIL** (`d1cd9e3`): an empty `model_patch` makes `run_evaluation` skip the instance (no `report.json`); the adapter mapped "no report" to ERROR. An empty patch is a legitimate *not solved* → now `{resolved: False, empty_patch: True}` (no `error` key) → **FAIL**. A non-empty patch with a genuinely missing report still errors.
- **duplicate problem discovery** (`d1cd9e3`): `mwaskom__seaborn-3069` / `pydata__xarray-2905` exist in both `swebench-datasci-mini` and `swebench-verified`, so `_discover_problem_yamls` globbed them twice and the run double-executed them per arm. Now deduped by instance_id, preferring the canonical `swebench-verified` copy; datasci-mini's 38 unique ids are still discovered.

## Data artifacts (`9257430`)

- `sets/sample-1per-repo.txt` — Tier-1 smoke sample (1 buildable instance per repo, flaky excluded).
- `sets/verified-flaky.txt` — the 3 flaky-but-kept instances with causes (see `docs/VERIFIED_EXCLUSIONS.md`).

## Validation (Tier-1 e2e, claude_code surface)

Codex was quota-blocked, so the smoke ran on `claude_code` — same pipeline, real agent. 12 instances, `--arms baseline`: **9 PASS / 2 FAIL / 1 empty (75%)** — sane band; the pytest instance graded cleanly through the Bug-C-fixed path. Proves the full **agent → extract_agent_diff → two-pass → verbatim run_evaluation** path on main with a live agent.

## Tests

Regression tests for empty-patch→FAIL and dedup-prefers-verified. Full fast suite: 940 passed.

Refs #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
