### PR TITLE
fix(#307): power analysis → N* for SWE-bench/Claude NS anchor

### DIFF
--- a/scripts/power_analysis.py
+++ b/scripts/power_analysis.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python3
+"""Power analysis → N* for the SWE-bench/Claude NS anchor (WS-A.1, #307).
+
+Calibration gate: reproduces the +14.4%, p≈0.12 headline contrast from
+``runs/swebench/full_run_seed_{1,2,3}`` using the same arithmetic effect size
+and Wilcoxon test as the paper's headline cell (``headline_unanimous.csv``).
+The paper's ``cost_usd_adjusted`` uses a **cache-floor** adjustment sourced
+from ``scripts/collect_results._apply_cache_floor_adjustment``: for each
+(seed, arm) group, cold-start tasks (first_call_cache_read = 0) are given
+credit for the median warm cache read, lowering their cost. This is
+implemented here from raw JSONL without reading paper/ data files.
+
+Power analysis: resampling power on the log-scale estimand (the issue's
+canonical estimand, d_i = log c_onlycode,i − log c_baseline,i, averaged
+across seeds) at a grid of N values, with proportional repo-stratified
+sampling. N* is the smallest N with power ≥ 0.90 at α = 0.05 two-sided.
+
+Usage:
+  scripts/power_analysis.py \\
+      --runs runs/swebench/full_run_seed_1 \\
+             runs/swebench/full_run_seed_2 \\
+             runs/swebench/full_run_seed_3 \\
+      [--treatment onlycode] [--reference baseline] \\
+      [--n-boot 10000] [--power-sims 2000] [--alpha 0.05] \\
+      [--n-min 20] [--n-max 500] [--n-step 10] \\
+      [--out-prefix runs/swebench/_analysis/power/ws-a] \\
+      [--seed 0]
+
+Outputs:
+  <out_prefix>.json  — full report (calibration + power curve + N* + go/no-go)
+  <out_prefix>.csv   — power curve table (n, power_bootstrap, power_wilcoxon)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from scipy.stats import wilcoxon as scipy_wilcoxon
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from swebench.contrast_stats import paired_cost_contrast  # noqa: E402
+
+# Claude pricing constants (same as parse_run.py / cost_first_call_adjust.py).
+# The cache-floor adjustment gap = input_rate − cache_read_rate per token.
+_CLAUDE_INPUT_RATE = 3.00   # USD / 1M tokens
+_CLAUDE_CR_RATE = 0.30      # USD / 1M tokens — cache_read
+_CLAUDE_GAP = (_CLAUDE_INPUT_RATE - _CLAUDE_CR_RATE) / 1_000_000  # per token
+
+# Regex for SWE-bench JSONL filenames: {instance_id}_{arm}_run{N}.jsonl
+_STEM_RE = re.compile(r"^(.+)_(baseline|onlycode|bash_only)_run(\d+)$")
+
+
+# ---------------------------------------------------------------------------
+# Raw JSONL parsing (extract cost + first-call cache_read per instance/arm)
+# ---------------------------------------------------------------------------
+
+
+def _parse_claude_jsonl(jsonl_path: Path) -> dict | None:
+    """Extract (cost_usd, first_call_input, first_call_cache_read, model) from one JSONL.
+
+    Returns None if the file has no result line or is unreadable.
+    """
+    seen_ids: set[str] = set()
+    first_call_usage: dict | None = None
+    result_line: dict | None = None
+    model: str | None = None
+
+    try:
+        with open(jsonl_path) as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                t = obj.get("type")
+                if t == "assistant":
+                    msg = obj.get("message") or {}
+                    msg_id = msg.get("id")
+                    if msg_id and msg_id in seen_ids:
+                        continue
+                    seen_ids.add(msg_id or f"_pos_{len(seen_ids)}")
+                    if model is None:
+                        model = msg.get("model")
+                    if first_call_usage is None:
+                        u = msg.get("usage")
+                        if isinstance(u, dict):
+                            first_call_usage = u
+                elif t == "result":
+                    result_line = obj
+    except OSError:
+        return None
+
+    if result_line is None:
+        return None
+
+    cost = result_line.get("total_cost_usd")
+    if not isinstance(cost, (int, float)):
+        return None
+    cost = float(cost)
+
+    first_input = first_cache_read = None
+    if isinstance(first_call_usage, dict):
+        fi = int(first_call_usage.get("input_tokens") or 0)
+        fcr = int(first_call_usage.get("cache_read_input_tokens") or 0)
+        fcc = int(first_call_usage.get("cache_creation_input_tokens") or 0)
+        first_input = fi + fcr + fcc
+        first_cache_read = fcr
+
+    return {
+        "cost_usd": cost,
+        "first_call_input": first_input,
+        "first_call_cache_read": first_cache_read,
+        "model": model,
+    }
+
+
+def _walk_swebench_run_dir(run_dir: Path):
+    """Yield (instance_id, arm, run_idx, jsonl_path) for each JSONL in a SWE-bench run dir."""
+    for jsonl in sorted(run_dir.glob("*.jsonl")):
+        m = _STEM_RE.match(jsonl.stem)
+        if not m:
+            continue
+        yield m.group(1), m.group(2), int(m.group(3)), jsonl
+
+
+def _load_run_dir(run_dir: Path) -> list[dict]:
+    """Parse one run dir into a flat list of row dicts.
+
+    Each row: {instance_id, arm, run, seed (from dir name), cost_usd,
+               first_call_input, first_call_cache_read, model}
+    """
+    # Infer seed from directory name (e.g. full_run_seed_2 → seed=2).
+    # If not parseable, fall back to a placeholder.
+    m = re.search(r"seed_(\d+)", run_dir.name)
+    seed_str = m.group(1) if m else run_dir.name
+
+    rows = []
+    for iid, arm, run_idx, jsonl in _walk_swebench_run_dir(run_dir):
+        parsed = _parse_claude_jsonl(jsonl)
+        if parsed is None:
+            continue
+        rows.append({
+            "instance_id": iid,
+            "arm": arm,
+            "run": run_idx,
+            "seed": seed_str,
+            "cost_usd": parsed["cost_usd"],
+            "first_call_input": parsed["first_call_input"],
+            "first_call_cache_read": parsed["first_call_cache_read"],
+            "model": parsed["model"],
+        })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Cache-floor adjustment (mirrors collect_results._apply_cache_floor_adjustment)
+# ---------------------------------------------------------------------------
+
+
+def apply_cache_floor_adjustment(rows: list[dict]) -> None:
+    """Per-(seed, arm) median floor on first-call cache_read; mutates rows in place.
+
+    Logic from ``scripts/collect_results._apply_cache_floor_adjustment``:
+    - Group by (seed, arm).
+    - For each group, compute median(first_call_cache_read) over the warm
+      subset (rows where first_call_cache_read > 0).
+    - For each row: adj_cached = max(first_cr, min(median, first_input)).
+      moved = adj_cached − first_cr. Δ = −moved × gap.
+      cost_adj = cost_usd + Δ  (Δ ≤ 0, so adj ≤ orig).
+
+    Rows where cost_usd, first_call_input, or first_call_cache_read is None
+    get cost_adj = cost_usd (no adjustment possible).
+    """
+    groups: dict[tuple, list[dict]] = defaultdict(list)
+    for row in rows:
+        groups[(row["seed"], row["arm"])].append(row)
+
+    for _key, grp in groups.items():
+        warm = [
+            r["first_call_cache_read"]
+            for r in grp
+            if isinstance(r["first_call_cache_read"], int) and r["first_call_cache_read"] > 0
+        ]
+        median = int(statistics.median(warm)) if warm else 0
+
+        for row in grp:
+            cost = row["cost_usd"]
+            first_input = row["first_call_input"]
+            first_cr = row["first_call_cache_read"]
+            if not isinstance(cost, (int, float)) or first_input is None or first_cr is None:
+                row["cost_adj"] = cost
+                continue
+            adj_cached = max(first_cr, min(median, first_input))
+            moved = adj_cached - first_cr
+            if moved == 0:
+                row["cost_adj"] = cost
+            else:
+                row["cost_adj"] = cost - moved * _CLAUDE_GAP
+
+
+# ---------------------------------------------------------------------------
+# Data loading with cache-floor adjustment + per-instance seed averaging
+# ---------------------------------------------------------------------------
+
+
+def load_paired_costs(
+    run_dirs: list[Path],
+    *,
+    treatment: str = "onlycode",
+    reference: str = "baseline",
+) -> dict[str, tuple[float, float]]:
+    """Load per-instance (treatment_cost, reference_cost), averaged across seeds.
+
+    Uses the cache-floor-adjusted cost (same methodology as the paper's
+    ``cost_usd_adjusted`` column in ``all_results.csv``). Returns only
+    instances present with positive cost in **both** arms across all seeds.
+    """
+    all_rows: list[dict] = []
+    for rd in run_dirs:
+        rd = Path(rd)
+        if not rd.is_dir():
+            sys.exit(f"ERROR: run dir not found: {rd}")
+        rows = _load_run_dir(rd)
+        apply_cache_floor_adjustment(rows)
+        all_rows.extend(rows)
+
+    # Group by (arm, instance_id) and collect costs across seeds
+    costs: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for row in all_rows:
+        c = row.get("cost_adj") or row.get("cost_usd")
+        if c is not None and isinstance(c, float) and math.isfinite(c) and c > 0:
+            costs[row["arm"]][row["instance_id"]].append(c)
+
+    mean_arm: dict[str, dict[str, float]] = {
+        arm: {iid: sum(v) / len(v) for iid, v in inst.items() if v}
+        for arm, inst in costs.items()
+    }
+
+    t_map = mean_arm.get(treatment, {})
+    r_map = mean_arm.get(reference, {})
+    common = sorted(set(t_map) & set(r_map))
+    return {iid: (t_map[iid], r_map[iid]) for iid in common}
+
+
+# ---------------------------------------------------------------------------
+# Calibration gate (arithmetic delta + Wilcoxon — matches paper headline)
+# ---------------------------------------------------------------------------
+
+
+def calibration_check(
+    paired: dict[str, tuple[float, float]],
+) -> dict:
+    """Reproduce the paper's +14.4%, p≈0.12 arithmetic-scale headline.
+
+    The paper reports:
+      - effect  = mean_delta / mean_reference × 100  (arithmetic ratio)
+      - p-value = Wilcoxon signed-rank on arithmetic per-instance deltas
+        (treatment − reference, with cache-floor-adjusted costs)
+
+    This is distinct from the log-scale estimand used in the power analysis.
+    Gate passes if effect ∈ [+13.4%, +15.4%] and p ∈ [0.07, 0.17].
+    """
+    ids = sorted(paired)
+    deltas = [paired[iid][0] - paired[iid][1] for iid in ids]
+    mean_delta = sum(deltas) / len(deltas)
+    mean_ref = sum(paired[iid][1] for iid in ids) / len(ids)
+    pct_effect = mean_delta / mean_ref * 100
+
+    p_wilcoxon: float | None = None
+    nonzero = [d for d in deltas if d != 0.0]
+    if nonzero:
+        try:
+            p_wilcoxon = float(scipy_wilcoxon(nonzero).pvalue)
+        except Exception:
+            pass
+
+    # Tolerance window: paper headline = +14.4375%, p=0.1202
+    gate_passes = (
+        pct_effect is not None
+        and 13.0 <= pct_effect <= 16.0
+        and p_wilcoxon is not None
+        and 0.07 <= p_wilcoxon <= 0.20
+    )
+    return {
+        "n": len(ids),
+        "mean_delta": mean_delta,
+        "mean_reference": mean_ref,
+        "pct_effect_arithmetic": pct_effect,
+        "p_wilcoxon_arithmetic": p_wilcoxon,
+        "gate_passes": gate_passes,
+        # Paper reference values
+        "paper_pct_effect": 14.4375,
+        "paper_p_wilcoxon": 0.1202,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Log-scale effect + Cohen dz (the power analysis estimand)
+# ---------------------------------------------------------------------------
+
+
+def log_scale_effect(
+    paired: dict[str, tuple[float, float]],
+) -> tuple[np.ndarray, list[str]]:
+    """Compute per-instance log-differences d_i = log(treatment) - log(reference).
+
+    Returns ``(d, ids)`` where ``d[i]`` corresponds to ``ids[i]``.
+    """
+    ids = sorted(paired)
+    d_list: list[float] = []
+    ids_kept: list[str] = []
+    for iid in ids:
+        t, r = paired[iid]
+        if t > 0 and r > 0 and math.isfinite(t) and math.isfinite(r):
+            d_list.append(math.log(t) - math.log(r))
+            ids_kept.append(iid)
+    return np.asarray(d_list, dtype=float), ids_kept
+
+
+# ---------------------------------------------------------------------------
+# Repo stratification
+# ---------------------------------------------------------------------------
+
+
+def _repo_from_id(instance_id: str) -> str:
+    """Extract repo from SWE-bench instance ID (e.g. 'django__django-1234' → 'django')."""
+    return instance_id.split("__")[0]
+
+
+def _stratified_sample(
+    d: np.ndarray,
+    ids: list[str],
+    n: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Draw n instances with proportional repo stratification.
+
+    For each repo, allocate ``round(n * repo_frac)`` slots; the last repo
+    absorbs the rounding residual to ensure exactly n are drawn total.
+    Within each repo the draw is with replacement (resampling power convention).
+    Returns a 1-D array of n log-differences.
+    """
+    repo_idx: dict[str, list[int]] = defaultdict(list)
+    for i, iid in enumerate(ids):
+        repo_idx[_repo_from_id(iid)].append(i)
+
+    total = len(ids)
+    repos = sorted(repo_idx)
+    alloc: dict[str, int] = {}
+    allocated = 0
+    for repo in repos[:-1]:
+        k = round(n * len(repo_idx[repo]) / total)
+        alloc[repo] = k
+        allocated += k
+    alloc[repos[-1]] = n - allocated  # absorb rounding residual
+
+    sample_idx: list[int] = []
+    for repo in repos:
+        k = alloc[repo]
+        if k <= 0:
+            continue
+        pool = repo_idx[repo]
+        sample_idx.extend(rng.choice(pool, size=k, replace=True).tolist())
+
+    return d[sample_idx]
+
+
+# ---------------------------------------------------------------------------
+# Resampling power
+# ---------------------------------------------------------------------------
+
+
+def resampling_power(
+    d: np.ndarray,
+    ids: list[str],
+    *,
+    n_grid: list[int],
+    n_boot: int = 10000,
+    power_sims: int = 2000,
+    alpha: float = 0.05,
+    seed: int = 0,
+) -> list[dict]:
+    """Compute empirical power at each N in n_grid.
+
+    For each N:
+      1. Draw ``power_sims`` stratified resamples of size N from the empirical
+         per-instance log-difference distribution (with replacement within repo).
+      2. For each resample, run: paired bootstrap (n_boot resamples) → p_boot,
+         Wilcoxon signed-rank on log-diffs → p_wil.
+      3. Power = fraction of simulations where p < alpha.
+
+    Returns a list of dicts (one per N): {n, power_bootstrap, power_wilcoxon}.
+    """
+    rng = np.random.default_rng(seed)
+    results: list[dict] = []
+
+    for N in n_grid:
+        boot_rejections = 0
+        wil_rejections = 0
+
+        for _ in range(power_sims):
+            sample = _stratified_sample(d, ids, N, rng)
+            p_boot = _bootstrap_pvalue(sample, n_boot=n_boot, rng=rng)
+            if p_boot < alpha:
+                boot_rejections += 1
+            p_wil = _wilcoxon_pvalue(sample)
+            if p_wil is not None and p_wil < alpha:
+                wil_rejections += 1
+
+        results.append({
+            "n": N,
+            "power_bootstrap": boot_rejections / power_sims,
+            "power_wilcoxon": wil_rejections / power_sims,
+        })
+
+    return results
+
+
+def _bootstrap_pvalue(d: np.ndarray, n_boot: int, rng: np.random.Generator) -> float:
+    """Two-sided bootstrap p-value for H0: mean(d) = 0.
+
+    CI-inversion: 2 * min(P(boot>=0), P(boot<=0)).
+    """
+    n = len(d)
+    if n == 0:
+        return 1.0
+    idx = rng.integers(0, n, size=(n_boot, n))
+    boot_means = d[idx].mean(axis=1)
+    p_left = float(np.mean(boot_means >= 0.0))
+    p_right = float(np.mean(boot_means <= 0.0))
+    return min(1.0, 2.0 * min(p_left, p_right))
+
+
+def _wilcoxon_pvalue(d: np.ndarray) -> float | None:
+    """Two-sided Wilcoxon signed-rank p-value; None if undefined."""
+    nz = d[d != 0.0]
+    if len(nz) < 1:
+        return None
+    try:
+        return float(scipy_wilcoxon(nz).pvalue)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# N* detection
+# ---------------------------------------------------------------------------
+
+
+def find_n_star(
+    curve: list[dict],
+    power_threshold: float,
+    key: str = "power_bootstrap",
+) -> int | None:
+    """Return smallest N with power >= power_threshold, or None if not reached."""
+    for row in curve:
+        if row[key] >= power_threshold:
+            return row["n"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Go/no-go recommendation
+# ---------------------------------------------------------------------------
+
+
+def go_nogo_recommendation(
+    n_star_90: int | None,
+    n_star_80: int | None,
+    n_available: int,
+) -> dict:
+    """Produce a go/no-go recommendation for #299 (modification spine N).
+
+    Three verdicts:
+    - "powered_subset": N* ≤ n_available → run N* instances in the spine.
+    - "full_pool": N* ≤ 500 but exceeds n_available → run full available pool.
+    - "null_branch": N* > 500 → effect too small; plan TOST at full buildable pool.
+    """
+    if n_star_90 is not None and n_star_90 <= n_available:
+        return {
+            "verdict": "powered_subset",
+            "recommendation": (
+                f"Run {n_star_90} instances in the modification spine (#299). "
+                f"This is N* for 0.90 power at the observed effect size. "
+                f"Powered subset sizing for the deconfound cut (#301) should also use N={n_star_90}."
+            ),
+            "n_star_90": n_star_90,
+            "n_star_80": n_star_80,
+            "null_branch": False,
+        }
+    if n_star_90 is not None and n_star_90 > n_available:
+        return {
+            "verdict": "full_pool",
+            "recommendation": (
+                f"N* ({n_star_90}) exceeds available paired instances ({n_available}). "
+                f"Run the full available pool in the spine (#299). "
+                f"Consider accepting 0.80 power (N*={n_star_80}) if n_available < N*(0.90)."
+            ),
+            "n_star_90": n_star_90,
+            "n_star_80": n_star_80,
+            "null_branch": False,
+        }
+    return {
+        "verdict": "null_branch",
+        "recommendation": (
+            "N* for 0.90 power exceeds the grid maximum (500). "
+            "The observed effect is too small to power under the current n=100 data. "
+            "Pre-register a minimum meaningful effect (±10% cost) and plan a TOST "
+            "equivalence test at the full buildable pool. "
+            "A CI excluding ±10% would be a clean null — retire the 'lone exception' framing."
+        ),
+        "n_star_90": None,
+        "n_star_80": n_star_80,
+        "null_branch": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report assembly and I/O
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    run_dirs: list[Path],
+    *,
+    treatment: str = "onlycode",
+    reference: str = "baseline",
+    n_boot: int = 10000,
+    power_sims: int = 2000,
+    alpha: float = 0.05,
+    n_min: int = 20,
+    n_max: int = 500,
+    n_step: int = 10,
+    seed: int = 0,
+) -> dict:
+    """Run the full power analysis pipeline and return the report dict."""
+    paired = load_paired_costs(run_dirs, treatment=treatment, reference=reference)
+    if not paired:
+        sys.exit("ERROR: no paired instances found. Check run dirs and arm names.")
+
+    # Calibration gate (arithmetic + Wilcoxon, cache-floor-adj — matches paper headline)
+    calib = calibration_check(paired)
+
+    # Log-scale effect (power analysis estimand)
+    d, ids = log_scale_effect(paired)
+    n_paired = len(d)
+    if n_paired == 0:
+        sys.exit("ERROR: zero valid paired log-differences after filtering.")
+
+    mean_log = float(d.mean())
+    std_log = float(d.std(ddof=0))
+    dz = mean_log / std_log if std_log > 0 else float("nan")
+    pct_effect_log = 100.0 * (math.exp(mean_log) - 1.0)
+
+    # Full-sample log-scale contrast
+    full_contrast = paired_cost_contrast(
+        {iid: paired[iid][0] for iid in paired},
+        {iid: paired[iid][1] for iid in paired},
+        n_boot=n_boot,
+        alpha=alpha,
+        seed=seed,
+    )
+
+    # Repo distribution
+    repo_counts: dict[str, int] = defaultdict(int)
+    for iid in ids:
+        repo_counts[_repo_from_id(iid)] += 1
+
+    # Power curve
+    n_grid = list(range(n_min, n_max + 1, n_step))
+    curve = resampling_power(
+        d, ids,
+        n_grid=n_grid,
+        n_boot=n_boot,
+        power_sims=power_sims,
+        alpha=alpha,
+        seed=seed,
+    )
+
+    n_star_90 = find_n_star(curve, 0.90, "power_bootstrap")
+    n_star_80 = find_n_star(curve, 0.80, "power_bootstrap")
+    rec = go_nogo_recommendation(n_star_90, n_star_80, n_paired)
+
+    return {
+        "treatment": treatment,
+        "reference": reference,
+        "run_dirs": [str(r) for r in run_dirs],
+        "n_paired": n_paired,
+        "repo_distribution": dict(sorted(repo_counts.items())),
+        "calibration": calib,
+        "log_scale_effect": {
+            "mean_log_diff": mean_log,
+            "std_log_diff": std_log,
+            "dz": dz,
+            "pct_effect_log": pct_effect_log,
+            "full_contrast": full_contrast.as_dict(),
+        },
+        "power_analysis": {
+            "n_grid": n_grid,
+            "n_boot": n_boot,
+            "power_sims": power_sims,
+            "alpha": alpha,
+            "seed": seed,
+            "n_star_80": n_star_80,
+            "n_star_90": n_star_90,
+            "curve": curve,
+        },
+        "go_nogo": rec,
+    }
+
+
+def _print_report(rep: dict) -> None:
+    calib = rep["calibration"]
+    log_eff = rep["log_scale_effect"]
+    pa = rep["power_analysis"]
+    rec = rep["go_nogo"]
+
+    print("=" * 96)
+    print("Power Analysis — WS-A.1 (#307)")
+    print(f"  treatment={rep['treatment']}  reference={rep['reference']}  n={rep['n_paired']}")
+    print(f"  run_dirs: {rep['run_dirs']}")
+    print("=" * 96)
+
+    print("\n--- Calibration gate (arithmetic effect, cache-floor-adjusted cost) ---")
+    gate_status = "PASS" if calib["gate_passes"] else "FAIL"
+    print(f"  Status   : {gate_status}")
+    print(f"  Effect   : {calib['pct_effect_arithmetic']:+.4f}%  "
+          f"(paper headline: +{calib['paper_pct_effect']:.4f}%)")
+    print(f"  Wilcoxon : p={calib['p_wilcoxon_arithmetic']:.4g}  "
+          f"(paper: p≈{calib['paper_p_wilcoxon']:.4f})")
+    print(f"  n        : {calib['n']}")
+
+    print("\n--- Log-scale effect (power analysis estimand: d_i = log(treat) - log(ref)) ---")
+    fc = log_eff["full_contrast"]
+    print(f"  exp(mean_d)-1 : {log_eff['pct_effect_log']:+.2f}%")
+    print(f"  Cohen dz      : {log_eff['dz']:.4f}")
+    print(f"  Bootstrap p   : {fc['p_bootstrap']:.4g}  "
+          f"CI: [{fc['ci_pct_lo']:+.1f}%, {fc['ci_pct_hi']:+.1f}%]")
+    wil = fc.get("p_wilcoxon")
+    print(f"  Wilcoxon p    : {wil:.4g}" if wil is not None else "  Wilcoxon p    : N/A")
+
+    print("\n--- Power curve (resampling bootstrap, repo-stratified) ---")
+    n_grid = pa["n_grid"]
+    step = n_grid[1] - n_grid[0] if len(n_grid) > 1 else pa.get("n_step", 10)
+    print(f"  N grid: {n_grid[0]}–{n_grid[-1]}, step={step}")
+    print(f"  power_sims={pa['power_sims']}  n_boot={pa['n_boot']}  alpha={pa['alpha']}")
+    print(f"\n  {'N':>5}  {'power_boot':>12}  {'power_wil':>12}")
+    for row in pa["curve"]:
+        marker = " ← N*(0.90)" if row["n"] == pa["n_star_90"] else (
+                 " ← N*(0.80)" if row["n"] == pa["n_star_80"] else "")
+        print(f"  {row['n']:>5}  {row['power_bootstrap']:>12.3f}  "
+              f"{row['power_wilcoxon']:>12.3f}{marker}")
+
+    print(f"\n  N* (0.80 power): {pa['n_star_80']}")
+    print(f"  N* (0.90 power): {pa['n_star_90']}")
+
+    print("\n--- Go/no-go for #299 ---")
+    print(f"  Verdict: {rec['verdict'].upper()}")
+    print(f"  {rec['recommendation']}")
+    if rep.get("repo_distribution"):
+        print(f"\n  Repo distribution (stratification): {rep['repo_distribution']}")
+
+
+def _write_outputs(rep: dict, out_prefix: str) -> None:
+    out = Path(out_prefix)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    json_path = out.with_suffix(".json")
+    json_path.write_text(json.dumps(rep, indent=2))
+
+    csv_path = out.with_suffix(".csv")
+    with open(csv_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["n", "power_bootstrap", "power_wilcoxon"])
+        w.writeheader()
+        for row in rep["power_analysis"]["curve"]:
+            w.writerow(row)
+
+    print(f"\nWrote {json_path} and {csv_path}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--runs", nargs="+", required=True, type=Path,
+        help="Seed run dirs (e.g. full_run_seed_1 full_run_seed_2 full_run_seed_3).",
+    )
+    ap.add_argument("--treatment", default="onlycode")
+    ap.add_argument("--reference", default="baseline")
+    ap.add_argument(
+        "--n-boot", type=int, default=10000,
+        help="Bootstrap resamples for the per-simulation test (default: 10000).",
+    )
+    ap.add_argument(
+        "--power-sims", type=int, default=2000,
+        help="Number of power simulations per N (default: 2000).",
+    )
+    ap.add_argument("--alpha", type=float, default=0.05)
+    ap.add_argument("--n-min", type=int, default=20)
+    ap.add_argument("--n-max", type=int, default=500)
+    ap.add_argument("--n-step", type=int, default=10)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument(
+        "--out-prefix", default=None,
+        help="Write <prefix>.json + <prefix>.csv "
+             "(default: runs/swebench/_analysis/power/ws-a).",
+    )
+    args = ap.parse_args(argv)
+
+    rep = build_report(
+        args.runs,
+        treatment=args.treatment,
+        reference=args.reference,
+        n_boot=args.n_boot,
+        power_sims=args.power_sims,
+        alpha=args.alpha,
+        n_min=args.n_min,
+        n_max=args.n_max,
+        n_step=args.n_step,
+        seed=args.seed,
+    )
+    _print_report(rep)
+    out_prefix = args.out_prefix or str(
+        REPO_ROOT / "runs" / "swebench" / "_analysis" / "power" / "ws-a"
+    )
+    _write_outputs(rep, out_prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/power_analysis.py
+++ b/scripts/power_analysis.py
@@ -50,7 +50,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 sys.path.insert(0, str(REPO_ROOT))
 
-from swebench.contrast_stats import paired_cost_contrast  # noqa: E402
+from swebench.contrast_stats import (  # noqa: E402
+    paired_cost_contrast,
+    wilcoxon_pvalue as _wilcoxon_pvalue,
+)
 
 # Claude pricing constants (same as parse_run.py / cost_first_call_adjust.py).
 # The cache-floor adjustment gap = input_rate − cache_read_rate per token.
@@ -273,7 +276,8 @@ def calibration_check(
         (treatment − reference, with cache-floor-adjusted costs)
 
     This is distinct from the log-scale estimand used in the power analysis.
-    Gate passes if effect ∈ [+13.4%, +15.4%] and p ∈ [0.07, 0.17].
+    Gate passes if effect ∈ [+13.0%, +16.0%] and p ∈ [0.07, 0.20]
+    (the tolerance window applied in the code below).
     """
     ids = sorted(paired)
     deltas = [paired[iid][0] - paired[iid][1] for iid in ids]
@@ -446,17 +450,6 @@ def _bootstrap_pvalue(d: np.ndarray, n_boot: int, rng: np.random.Generator) -> f
     return min(1.0, 2.0 * min(p_left, p_right))
 
 
-def _wilcoxon_pvalue(d: np.ndarray) -> float | None:
-    """Two-sided Wilcoxon signed-rank p-value; None if undefined."""
-    nz = d[d != 0.0]
-    if len(nz) < 1:
-        return None
-    try:
-        return float(scipy_wilcoxon(nz).pvalue)
-    except Exception:
-        return None
-
-
 # ---------------------------------------------------------------------------
 # N* detection
 # ---------------------------------------------------------------------------
@@ -483,13 +476,14 @@ def go_nogo_recommendation(
     n_star_90: int | None,
     n_star_80: int | None,
     n_available: int,
+    n_max: int = 500,
 ) -> dict:
     """Produce a go/no-go recommendation for #299 (modification spine N).
 
     Three verdicts:
     - "powered_subset": N* ≤ n_available → run N* instances in the spine.
-    - "full_pool": N* ≤ 500 but exceeds n_available → run full available pool.
-    - "null_branch": N* > 500 → effect too small; plan TOST at full buildable pool.
+    - "full_pool": N* ≤ n_max but exceeds n_available → run full available pool.
+    - "null_branch": N* > n_max → effect too small; plan TOST at full buildable pool.
     """
     if n_star_90 is not None and n_star_90 <= n_available:
         return {
@@ -518,8 +512,8 @@ def go_nogo_recommendation(
     return {
         "verdict": "null_branch",
         "recommendation": (
-            "N* for 0.90 power exceeds the grid maximum (500). "
-            "The observed effect is too small to power under the current n=100 data. "
+            f"N* for 0.90 power exceeds the grid maximum ({n_max}). "
+            f"The observed effect is too small to power under the current n={n_available} data. "
             "Pre-register a minimum meaningful effect (±10% cost) and plan a TOST "
             "equivalence test at the full buildable pool. "
             "A CI excluding ±10% would be a clean null — retire the 'lone exception' framing."
@@ -563,7 +557,7 @@ def build_report(
         sys.exit("ERROR: zero valid paired log-differences after filtering.")
 
     mean_log = float(d.mean())
-    std_log = float(d.std(ddof=0))
+    std_log = float(d.std(ddof=1))  # sample std (conventional Cohen's dz)
     dz = mean_log / std_log if std_log > 0 else float("nan")
     pct_effect_log = 100.0 * (math.exp(mean_log) - 1.0)
 
@@ -594,7 +588,7 @@ def build_report(
 
     n_star_90 = find_n_star(curve, 0.90, "power_bootstrap")
     n_star_80 = find_n_star(curve, 0.80, "power_bootstrap")
-    rec = go_nogo_recommendation(n_star_90, n_star_80, n_paired)
+    rec = go_nogo_recommendation(n_star_90, n_star_80, n_paired, n_max=n_max)
 
     return {
         "treatment": treatment,

--- a/tests/test_integration_power_analysis_artifact.py
+++ b/tests/test_integration_power_analysis_artifact.py
@@ -1,0 +1,471 @@
+"""Integration tests for scripts/power_analysis.py — artifact tier.
+
+Scenario: slice-power-analysis-cli
+Tier: artifact
+
+Verifies exact output correctness of the power-analysis CLI against committed
+synthetic fixtures with known expected values.
+
+These tests verify:
+  - JSON output content: all required sub-sections are present with correct
+    types; n_paired matches the number of instances supplied; treatment/reference
+    fields echo the CLI arguments.
+  - CSV output content: row count equals the n_grid length derived from
+    --n-min / --n-max / --n-step; n column values match the grid; power values
+    are in [0, 1]; rows are ordered by increasing n.
+  - Calibration section: pct_effect_arithmetic reflects the known synthetic
+    cost ratio; paper_pct_effect and paper_p_wilcoxon reference constants are
+    present.
+  - Log-scale effect section: mean_log_diff, std_log_diff, dz, pct_effect_log
+    are all present; full_contrast sub-section has CI and p-value fields.
+  - Power-analysis section: curve list length matches n_grid length; n_star_80
+    / n_star_90 are either int or null; go_nogo section has the correct fields.
+  - Default --out-prefix routing: when --out-prefix is omitted, the script
+    writes to runs/swebench/_analysis/power/ws-a.{json,csv}.
+
+Run with:
+    pytest tests/test_integration_power_analysis_artifact.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers (independent copy — each tier file must be independently executable)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "power_analysis.py"
+PYTHON = sys.executable
+
+
+def _write_claude_jsonl(
+    path: Path,
+    *,
+    instance: str,
+    arm: str,
+    cost: float,
+    first_call_cache_read: int = 100,
+) -> None:
+    """Write a minimal CLAUDE-format JSONL that power_analysis.py can parse."""
+    input_tokens = 500
+    lines = [
+        json.dumps({"type": "meta", "instance_id": instance, "arm": arm,
+                    "agent_surface": "claude_code"}),
+        json.dumps({"type": "assistant", "message": {
+            "id": f"msg_{instance}_{arm}",
+            "model": "claude-sonnet-4-6",
+            "usage": {
+                "input_tokens": input_tokens,
+                "cache_read_input_tokens": first_call_cache_read,
+                "cache_creation_input_tokens": 50,
+                "output_tokens": 20,
+            }}}),
+        json.dumps({"type": "result", "total_cost_usd": cost, "num_turns": 3,
+                    "usage": {"input_tokens": input_tokens, "output_tokens": 20}}),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _make_run_dir(
+    run_dir: Path,
+    *,
+    instances: list[str],
+    treatment_cost: float = 1.2,
+    reference_cost: float = 1.0,
+    treatment_arm: str = "onlycode",
+    reference_arm: str = "baseline",
+) -> None:
+    """Write a minimal SWE-bench run-dir with two arms per instance."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for iid in instances:
+        stem_t = f"{iid}_{treatment_arm}_run1"
+        stem_r = f"{iid}_{reference_arm}_run1"
+        _write_claude_jsonl(
+            run_dir / f"{stem_t}.jsonl",
+            instance=iid, arm=treatment_arm, cost=treatment_cost,
+        )
+        (run_dir / f"{stem_t}_test.txt").write_text("ran tests\nPASS\n")
+        _write_claude_jsonl(
+            run_dir / f"{stem_r}.jsonl",
+            instance=iid, arm=reference_arm, cost=reference_cost,
+        )
+        (run_dir / f"{stem_r}_test.txt").write_text("ran tests\nPASS\n")
+
+
+def _standard_instances(n: int = 12) -> list[str]:
+    """Generate n instance IDs spread across four repos for stratification."""
+    repos = ["django", "sklearn", "sympy", "mpl"]
+    return [f"{repos[i % len(repos)]}__issue-{i:04d}" for i in range(n)]
+
+
+def _run_cli_with_standard_fixture(
+    tmp_path: Path,
+    *,
+    n_instances: int = 12,
+    treatment_cost: float = 1.3,
+    reference_cost: float = 1.0,
+    n_min: int = 5,
+    n_max: int = 10,
+    n_step: int = 5,
+    extra_args: list[str] | None = None,
+) -> tuple[subprocess.CompletedProcess, Path]:
+    """Run the CLI against a single-seed synthetic fixture and return (result, out_dir)."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_standard_instances(n_instances),
+                  treatment_cost=treatment_cost, reference_cost=reference_cost)
+    out_dir = tmp_path / "out"
+    out_prefix = str(out_dir / "ws-a")
+
+    cmd = [
+        "--runs", str(run_dir),
+        "--n-boot", "200",
+        "--power-sims", "50",
+        "--n-min", str(n_min),
+        "--n-max", str(n_max),
+        "--n-step", str(n_step),
+        "--seed", "42",
+        "--out-prefix", out_prefix,
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    result = subprocess.run(
+        [PYTHON, str(SCRIPT)] + cmd,
+        capture_output=True, text=True, timeout=60,
+    )
+    return result, out_dir
+
+
+# ---------------------------------------------------------------------------
+# 1 — n_paired reflects exact instance count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_n_paired_matches_instance_count(tmp_path: Path):
+    """``n_paired`` must equal the number of instances written to the run dir."""
+    n_instances = 12
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, n_instances=n_instances,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads((out_dir / "ws-a.json").read_text())
+    assert data["n_paired"] == n_instances
+
+
+@pytest.mark.integration
+def test_treatment_and_reference_echoed_in_json(tmp_path: Path):
+    """``treatment`` and ``reference`` in JSON must reflect the CLI arguments."""
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, extra_args=["--treatment", "onlycode", "--reference", "baseline"],
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads((out_dir / "ws-a.json").read_text())
+    assert data["treatment"] == "onlycode"
+    assert data["reference"] == "baseline"
+
+
+@pytest.mark.integration
+def test_run_dirs_field_contains_supplied_path(tmp_path: Path):
+    """``run_dirs`` in JSON must include the path we supplied via --runs."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_standard_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    result = subprocess.run(
+        [PYTHON, str(SCRIPT),
+         "--runs", str(run_dir),
+         "--n-boot", "100", "--power-sims", "20",
+         "--n-min", "5", "--n-max", "5", "--n-step", "5",
+         "--seed", "0", "--out-prefix", out_prefix],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads((tmp_path / "out" / "ws-a.json").read_text())
+    assert any(str(run_dir) in rd for rd in data.get("run_dirs", []))
+
+
+# ---------------------------------------------------------------------------
+# 2 — Calibration section content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_calibration_section_has_required_fields(tmp_path: Path):
+    """Calibration section must contain all required numeric/bool fields."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    calib = json.loads((out_dir / "ws-a.json").read_text())["calibration"]
+
+    required_fields = [
+        "n", "mean_delta", "mean_reference",
+        "pct_effect_arithmetic", "gate_passes",
+        "paper_pct_effect", "paper_p_wilcoxon",
+    ]
+    for f in required_fields:
+        assert f in calib, f"Missing calibration field: {f!r}"
+
+
+@pytest.mark.integration
+def test_calibration_paper_reference_constants(tmp_path: Path):
+    """Calibration paper reference constants must match documented values."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    calib = json.loads((out_dir / "ws-a.json").read_text())["calibration"]
+    # These constants are hardcoded in power_analysis.py — verify they survive.
+    assert calib["paper_pct_effect"] == pytest.approx(14.4375, abs=0.001)
+    assert calib["paper_p_wilcoxon"] == pytest.approx(0.1202, abs=0.001)
+
+
+@pytest.mark.integration
+def test_calibration_effect_direction_positive(tmp_path: Path):
+    """With treatment_cost > reference_cost, pct_effect_arithmetic must be positive."""
+    # treatment=1.3, reference=1.0 → 30% positive effect
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, treatment_cost=1.3, reference_cost=1.0,
+    )
+    assert result.returncode == 0, result.stderr
+    calib = json.loads((out_dir / "ws-a.json").read_text())["calibration"]
+    assert calib["pct_effect_arithmetic"] > 0
+
+
+@pytest.mark.integration
+def test_calibration_n_matches_n_paired(tmp_path: Path):
+    """``calibration.n`` must equal ``n_paired``."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path, n_instances=10)
+    assert result.returncode == 0, result.stderr
+    data = json.loads((out_dir / "ws-a.json").read_text())
+    assert data["calibration"]["n"] == data["n_paired"]
+
+
+# ---------------------------------------------------------------------------
+# 3 — Log-scale effect section content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_log_scale_effect_section_has_required_fields(tmp_path: Path):
+    """log_scale_effect section must contain required numeric fields."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    lse = json.loads((out_dir / "ws-a.json").read_text())["log_scale_effect"]
+
+    for f in ("mean_log_diff", "std_log_diff", "dz", "pct_effect_log"):
+        assert f in lse, f"Missing log_scale_effect field: {f!r}"
+        assert isinstance(lse[f], (int, float)), f"{f!r} must be numeric"
+
+
+@pytest.mark.integration
+def test_log_scale_full_contrast_section(tmp_path: Path):
+    """log_scale_effect.full_contrast must contain CI and p-value fields."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    fc = json.loads((out_dir / "ws-a.json").read_text())["log_scale_effect"]["full_contrast"]
+
+    for f in ("n", "n_dropped", "mean_log_diff", "ci_pct_lo", "ci_pct_hi",
+              "p_bootstrap", "n_boot", "alpha"):
+        assert f in fc, f"Missing full_contrast field: {f!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4 — Power-analysis section: curve rows and N* values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_power_curve_row_count_matches_n_grid(tmp_path: Path):
+    """Power curve row count must equal len(range(n_min, n_max+1, n_step))."""
+    n_min, n_max, n_step = 5, 15, 5
+    expected_rows = len(range(n_min, n_max + 1, n_step))  # [5, 10, 15] → 3
+
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, n_min=n_min, n_max=n_max, n_step=n_step,
+    )
+    assert result.returncode == 0, result.stderr
+    pa_section = json.loads((out_dir / "ws-a.json").read_text())["power_analysis"]
+    assert len(pa_section["curve"]) == expected_rows
+
+
+@pytest.mark.integration
+def test_csv_row_count_matches_n_grid(tmp_path: Path):
+    """CSV row count must match the power-curve n_grid length."""
+    n_min, n_max, n_step = 5, 15, 5
+    expected_rows = len(range(n_min, n_max + 1, n_step))
+
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, n_min=n_min, n_max=n_max, n_step=n_step,
+    )
+    assert result.returncode == 0, result.stderr
+    csv_path = out_dir / "ws-a.csv"
+    with open(csv_path) as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == expected_rows
+
+
+@pytest.mark.integration
+def test_csv_n_values_match_n_grid(tmp_path: Path):
+    """CSV ``n`` column values must exactly match the expected n_grid values."""
+    n_min, n_max, n_step = 5, 15, 5
+    expected_ns = list(range(n_min, n_max + 1, n_step))
+
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, n_min=n_min, n_max=n_max, n_step=n_step,
+    )
+    assert result.returncode == 0, result.stderr
+    csv_path = out_dir / "ws-a.csv"
+    with open(csv_path) as f:
+        rows = list(csv.DictReader(f))
+    actual_ns = [int(r["n"]) for r in rows]
+    assert actual_ns == expected_ns
+
+
+@pytest.mark.integration
+def test_csv_rows_ordered_by_n_ascending(tmp_path: Path):
+    """CSV rows must be ordered by n ascending."""
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, n_min=5, n_max=15, n_step=5,
+    )
+    assert result.returncode == 0, result.stderr
+    csv_path = out_dir / "ws-a.csv"
+    with open(csv_path) as f:
+        rows = list(csv.DictReader(f))
+    ns = [int(r["n"]) for r in rows]
+    assert ns == sorted(ns), "CSV rows must be ordered by n ascending"
+
+
+@pytest.mark.integration
+def test_power_values_in_unit_interval(tmp_path: Path):
+    """All power values in JSON curve and CSV must be in [0, 1]."""
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, n_min=5, n_max=10, n_step=5,
+    )
+    assert result.returncode == 0, result.stderr
+
+    # Check JSON curve
+    curve = json.loads((out_dir / "ws-a.json").read_text())["power_analysis"]["curve"]
+    for row in curve:
+        assert 0.0 <= row["power_bootstrap"] <= 1.0, (
+            f"power_bootstrap out of range: {row}")
+        assert 0.0 <= row["power_wilcoxon"] <= 1.0, (
+            f"power_wilcoxon out of range: {row}")
+
+    # Check CSV
+    csv_path = out_dir / "ws-a.csv"
+    with open(csv_path) as f:
+        csv_rows = list(csv.DictReader(f))
+    for row in csv_rows:
+        pb = float(row["power_bootstrap"])
+        pw = float(row["power_wilcoxon"])
+        assert 0.0 <= pb <= 1.0, f"CSV power_bootstrap out of range: {pb}"
+        assert 0.0 <= pw <= 1.0, f"CSV power_wilcoxon out of range: {pw}"
+
+
+@pytest.mark.integration
+def test_n_star_fields_are_int_or_none(tmp_path: Path):
+    """n_star_80 and n_star_90 in power_analysis section must be int or null."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    pa_section = json.loads((out_dir / "ws-a.json").read_text())["power_analysis"]
+    for field in ("n_star_80", "n_star_90"):
+        val = pa_section[field]
+        assert val is None or isinstance(val, int), (
+            f"{field} must be int or null; got {type(val).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# 5 — Go/no-go section content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_gonogo_section_has_required_fields(tmp_path: Path):
+    """go_nogo section must contain all documented fields."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    rec = json.loads((out_dir / "ws-a.json").read_text())["go_nogo"]
+
+    for f in ("verdict", "recommendation", "n_star_90", "n_star_80", "null_branch"):
+        assert f in rec, f"Missing go_nogo field: {f!r}"
+
+
+@pytest.mark.integration
+def test_gonogo_null_branch_is_bool(tmp_path: Path):
+    """go_nogo.null_branch must be a boolean."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    rec = json.loads((out_dir / "ws-a.json").read_text())["go_nogo"]
+    assert isinstance(rec["null_branch"], bool)
+
+
+@pytest.mark.integration
+def test_gonogo_recommendation_is_non_empty_string(tmp_path: Path):
+    """go_nogo.recommendation must be a non-empty string."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path)
+    assert result.returncode == 0, result.stderr
+    rec = json.loads((out_dir / "ws-a.json").read_text())["go_nogo"]
+    assert isinstance(rec["recommendation"], str)
+    assert len(rec["recommendation"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# 6 — Repo distribution section
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_repo_distribution_reflects_instance_repos(tmp_path: Path):
+    """repo_distribution dict must contain the repos used in instance IDs."""
+    # _standard_instances uses "django", "sklearn", "sympy", "mpl"
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path, n_instances=12)
+    assert result.returncode == 0, result.stderr
+    data = json.loads((out_dir / "ws-a.json").read_text())
+    repo_dist = data.get("repo_distribution", {})
+    assert isinstance(repo_dist, dict)
+    # At minimum, the first repo used should appear
+    assert "django" in repo_dist
+
+
+@pytest.mark.integration
+def test_repo_distribution_counts_sum_to_n_paired(tmp_path: Path):
+    """Sum of repo_distribution values must equal n_paired."""
+    result, out_dir = _run_cli_with_standard_fixture(tmp_path, n_instances=12)
+    assert result.returncode == 0, result.stderr
+    data = json.loads((out_dir / "ws-a.json").read_text())
+    assert sum(data["repo_distribution"].values()) == data["n_paired"]
+
+
+# ---------------------------------------------------------------------------
+# 7 — JSON and CSV consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_json_and_csv_curve_data_are_consistent(tmp_path: Path):
+    """JSON power curve and CSV must contain the same n and power values."""
+    result, out_dir = _run_cli_with_standard_fixture(
+        tmp_path, n_min=5, n_max=10, n_step=5,
+    )
+    assert result.returncode == 0, result.stderr
+
+    json_curve = json.loads((out_dir / "ws-a.json").read_text())["power_analysis"]["curve"]
+    csv_path = out_dir / "ws-a.csv"
+    with open(csv_path) as f:
+        csv_rows = list(csv.DictReader(f))
+
+    assert len(json_curve) == len(csv_rows)
+    for jrow, crow in zip(json_curve, csv_rows):
+        assert jrow["n"] == int(crow["n"])
+        assert jrow["power_bootstrap"] == pytest.approx(
+            float(crow["power_bootstrap"]), abs=1e-9
+        )
+        assert jrow["power_wilcoxon"] == pytest.approx(
+            float(crow["power_wilcoxon"]), abs=1e-9
+        )

--- a/tests/test_integration_power_analysis_wiring.py
+++ b/tests/test_integration_power_analysis_wiring.py
@@ -1,0 +1,548 @@
+"""Integration tests for scripts/power_analysis.py — wiring tier.
+
+Scenario: slice-power-analysis-cli
+Tier: wiring
+
+Exercises the full vertical slice of the power-analysis CLI:
+
+  - Subprocess boundary: ``python scripts/power_analysis.py --runs <dir> ...``
+    exits 0, produces the two artifact files, and prints expected output.
+  - Argument parsing wiring: ``--help`` resolves, required ``--runs`` flag is
+    enforced, missing run-dir is rejected.
+  - Run-directory discovery: the CLI discovers and reads JSONL + _test.txt
+    files from the supplied run directories without crashing.
+  - Output file creation: both ``<prefix>.json`` and ``<prefix>.csv`` are
+    created and parseable (schema structure, not exact values).
+
+These tests exercise the subprocess / argparse boundary — a layer the unit
+tests in ``test_power_analysis.py`` do not cover (those call ``pa.main([...])``
+in-process). The integration tier catches wiring breaks such as incorrect
+import paths, argparse mis-registration, or output-directory creation failures.
+
+Per-test budget: each test completes in well under 60 s. No network, no
+Docker, no external services — all fixtures are synthetic tmp_path trees.
+
+Run with:
+    pytest tests/test_integration_power_analysis_wiring.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers shared with the artifact tier (inline to keep files independent)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "power_analysis.py"
+PYTHON = sys.executable
+
+
+def _write_claude_jsonl(
+    path: Path,
+    *,
+    instance: str,
+    arm: str,
+    cost: float,
+    first_call_cache_read: int = 100,
+) -> None:
+    """Write a minimal CLAUDE-format JSONL that power_analysis.py can parse."""
+    input_tokens = 500
+    lines = [
+        json.dumps({"type": "meta", "instance_id": instance, "arm": arm,
+                    "agent_surface": "claude_code"}),
+        json.dumps({"type": "assistant", "message": {
+            "id": f"msg_{instance}_{arm}",
+            "model": "claude-sonnet-4-6",
+            "usage": {
+                "input_tokens": input_tokens,
+                "cache_read_input_tokens": first_call_cache_read,
+                "cache_creation_input_tokens": 50,
+                "output_tokens": 20,
+            }}}),
+        json.dumps({"type": "result", "total_cost_usd": cost, "num_turns": 3,
+                    "usage": {"input_tokens": input_tokens, "output_tokens": 20}}),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _make_run_dir(
+    run_dir: Path,
+    *,
+    instances: list[str],
+    treatment_cost: float = 1.2,
+    reference_cost: float = 1.0,
+    treatment_arm: str = "onlycode",
+    reference_arm: str = "baseline",
+) -> None:
+    """Write a minimal SWE-bench run-dir with two arms per instance."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for iid in instances:
+        stem_t = f"{iid}_{treatment_arm}_run1"
+        stem_r = f"{iid}_{reference_arm}_run1"
+        _write_claude_jsonl(
+            run_dir / f"{stem_t}.jsonl",
+            instance=iid, arm=treatment_arm, cost=treatment_cost,
+        )
+        (run_dir / f"{stem_t}_test.txt").write_text("ran tests\nPASS\n")
+        _write_claude_jsonl(
+            run_dir / f"{stem_r}.jsonl",
+            instance=iid, arm=reference_arm, cost=reference_cost,
+        )
+        (run_dir / f"{stem_r}_test.txt").write_text("ran tests\nPASS\n")
+
+
+def _minimal_instances(n: int = 10) -> list[str]:
+    """Generate n instance IDs spread across two repos for stratification."""
+    repos = ["django", "sklearn"]
+    return [f"{repos[i % len(repos)]}__issue-{i:04d}" for i in range(n)]
+
+
+def _run_cli(args: list[str], *, timeout: int = 60) -> subprocess.CompletedProcess:
+    """Invoke the power_analysis CLI as a subprocess using the repo venv Python."""
+    return subprocess.run(
+        [PYTHON, str(SCRIPT)] + args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1 — CLI Schema Wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_help_exits_zero():
+    """``power_analysis.py --help`` must exit 0 and show usage."""
+    result = _run_cli(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "usage" in result.stdout.lower() or "Usage" in result.stdout
+
+
+@pytest.mark.integration
+def test_help_documents_runs_flag():
+    """``--runs`` must appear in --help output (it is the only required argument)."""
+    result = _run_cli(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "--runs" in result.stdout
+
+
+@pytest.mark.integration
+def test_help_documents_out_prefix():
+    """``--out-prefix`` must appear in --help (output path is configurable)."""
+    result = _run_cli(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "--out-prefix" in result.stdout
+
+
+@pytest.mark.integration
+def test_help_documents_treatment_and_reference_flags():
+    """``--treatment`` and ``--reference`` flags must be advertised in --help."""
+    result = _run_cli(["--help"])
+    assert result.returncode == 0, result.stderr
+    assert "--treatment" in result.stdout
+    assert "--reference" in result.stdout
+
+
+@pytest.mark.integration
+def test_missing_runs_flag_fails():
+    """Invoking without ``--runs`` must exit non-zero (required argument)."""
+    result = _run_cli([])
+    assert result.returncode != 0
+
+
+@pytest.mark.integration
+def test_nonexistent_run_dir_fails(tmp_path: Path):
+    """``--runs`` pointing to a non-existent directory must exit non-zero."""
+    missing = tmp_path / "no_such_dir"
+    out_prefix = str(tmp_path / "out" / "ws-a")
+    result = _run_cli(["--runs", str(missing), "--out-prefix", out_prefix,
+                       "--n-boot", "100", "--power-sims", "20",
+                       "--n-min", "5", "--n-max", "5", "--n-step", "5"])
+    assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# 2 — Run-directory discovery and basic output creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_cli_exits_zero_on_valid_run_dir(tmp_path: Path):
+    """CLI exits 0 when given a valid synthetic run directory."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    result = _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.integration
+def test_cli_creates_json_output(tmp_path: Path):
+    """CLI creates ``<prefix>.json`` output file."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert (tmp_path / "out" / "ws-a.json").exists()
+
+
+@pytest.mark.integration
+def test_cli_creates_csv_output(tmp_path: Path):
+    """CLI creates ``<prefix>.csv`` output file."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert (tmp_path / "out" / "ws-a.csv").exists()
+
+
+@pytest.mark.integration
+def test_cli_stdout_contains_calibration_gate(tmp_path: Path):
+    """CLI stdout must include ``Calibration gate`` header from _print_report."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    result = _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert result.returncode == 0, result.stderr
+    assert "Calibration gate" in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_stdout_contains_power_curve_section(tmp_path: Path):
+    """CLI stdout must include the power curve section header."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    result = _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert result.returncode == 0, result.stderr
+    assert "Power curve" in result.stdout
+
+
+@pytest.mark.integration
+def test_cli_stdout_contains_gonogo_section(tmp_path: Path):
+    """CLI stdout must include the Go/no-go section header."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    result = _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert result.returncode == 0, result.stderr
+    assert "Go/no-go" in result.stdout or "go/no-go" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3 — JSON output schema structure (no exact values)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_json_output_is_valid_json(tmp_path: Path):
+    """JSON output file must be valid JSON."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    data = json.loads((tmp_path / "out" / "ws-a.json").read_text())
+    assert isinstance(data, dict)
+
+
+@pytest.mark.integration
+def test_json_output_has_required_top_level_keys(tmp_path: Path):
+    """JSON output must contain calibration, log_scale_effect, power_analysis, go_nogo."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    data = json.loads((tmp_path / "out" / "ws-a.json").read_text())
+    assert "calibration" in data
+    assert "log_scale_effect" in data
+    assert "power_analysis" in data
+    assert "go_nogo" in data
+
+
+@pytest.mark.integration
+def test_json_output_n_paired_is_integer(tmp_path: Path):
+    """``n_paired`` in JSON output must be a positive integer."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    data = json.loads((tmp_path / "out" / "ws-a.json").read_text())
+    assert isinstance(data.get("n_paired"), int)
+    assert data["n_paired"] > 0
+
+
+@pytest.mark.integration
+def test_json_output_gonogo_verdict_is_valid(tmp_path: Path):
+    """``go_nogo.verdict`` must be one of the three documented values."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    data = json.loads((tmp_path / "out" / "ws-a.json").read_text())
+    assert data["go_nogo"]["verdict"] in ("powered_subset", "full_pool", "null_branch")
+
+
+# ---------------------------------------------------------------------------
+# 4 — CSV output schema structure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_csv_output_has_required_columns(tmp_path: Path):
+    """CSV must have columns: n, power_bootstrap, power_wilcoxon."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    csv_path = tmp_path / "out" / "ws-a.csv"
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames
+    assert fieldnames is not None
+    assert "n" in fieldnames
+    assert "power_bootstrap" in fieldnames
+    assert "power_wilcoxon" in fieldnames
+
+
+@pytest.mark.integration
+def test_csv_output_has_at_least_one_row(tmp_path: Path):
+    """CSV must contain at least one data row."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    csv_path = tmp_path / "out" / "ws-a.csv"
+    with open(csv_path) as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) >= 1
+
+
+@pytest.mark.integration
+def test_csv_n_column_is_numeric(tmp_path: Path):
+    """CSV ``n`` column must be parseable as int in every row."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "10",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    csv_path = tmp_path / "out" / "ws-a.csv"
+    with open(csv_path) as f:
+        rows = list(csv.DictReader(f))
+    for row in rows:
+        int(row["n"])  # must not raise
+
+
+@pytest.mark.integration
+def test_csv_power_columns_are_floats(tmp_path: Path):
+    """CSV power columns must be parseable as float in every row."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(8))
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    csv_path = tmp_path / "out" / "ws-a.csv"
+    with open(csv_path) as f:
+        rows = list(csv.DictReader(f))
+    for row in rows:
+        float(row["power_bootstrap"])  # must not raise
+        float(row["power_wilcoxon"])  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 5 — Multi-seed run-directory discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_cli_accepts_multiple_run_dirs(tmp_path: Path):
+    """CLI must accept and combine multiple --runs arguments."""
+    instances = _minimal_instances(8)
+    d1 = tmp_path / "full_run_seed_1"
+    d2 = tmp_path / "full_run_seed_2"
+    _make_run_dir(d1, instances=instances)
+    _make_run_dir(d2, instances=instances)
+    out_prefix = str(tmp_path / "out" / "ws-a")
+
+    result = _run_cli([
+        "--runs", str(d1), str(d2),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "out" / "ws-a.json").exists()
+
+
+@pytest.mark.integration
+def test_cli_creates_output_parent_dirs(tmp_path: Path):
+    """CLI must create the output parent directory hierarchy if it does not exist."""
+    run_dir = tmp_path / "full_run_seed_1"
+    _make_run_dir(run_dir, instances=_minimal_instances(6))
+    # Deeply nested output path that does not yet exist
+    out_prefix = str(tmp_path / "deep" / "nested" / "dir" / "ws-a")
+
+    result = _run_cli([
+        "--runs", str(run_dir),
+        "--n-boot", "100",
+        "--power-sims", "20",
+        "--n-min", "5",
+        "--n-max", "5",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "deep" / "nested" / "dir" / "ws-a.json").exists()
+    assert (tmp_path / "deep" / "nested" / "dir" / "ws-a.csv").exists()

--- a/tests/test_power_analysis.py
+++ b/tests/test_power_analysis.py
@@ -1,0 +1,507 @@
+"""Unit tests for scripts/power_analysis.py (WS-A.1 power analysis, #307).
+
+Hermetic and fast: synthesizes tiny SWE-bench-layout run dirs (JSONL + _test.txt)
+with known costs and asserts:
+- calibration gate recovers known arithmetic effect + p-value sign
+- log-scale dz is consistent with the input data
+- power curve is monotone increasing and N* detection is correct
+- go/no-go verdict matches expected outcome
+- JSON + CSV outputs are written with the correct schema
+
+No real run dirs, no network.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+import power_analysis as pa  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers to synthesize run dirs
+# ---------------------------------------------------------------------------
+
+
+def _write_claude_jsonl(
+    path: Path,
+    *,
+    instance: str,
+    arm: str,
+    cost: float,
+    first_call_cache_read: int = 0,
+) -> None:
+    """Write a minimal claude-format JSONL file.
+
+    ``first_call_cache_read=0`` means cold first call → cache-floor adjustment
+    may increase the credited cache (reducing cost) when other instances are warm.
+    We set it to a fixed value so adj_cost == cost in tests where all instances
+    have the same first_call_cache_read (median = that value → moved = 0).
+    """
+    input_tokens = 500
+    lines = [
+        json.dumps({"type": "meta", "instance_id": instance, "arm": arm,
+                    "agent_surface": "claude_code"}),
+        json.dumps({"type": "assistant", "message": {
+            "id": f"msg_{instance}_{arm}",
+            "model": "claude-sonnet-4-6",
+            "usage": {
+                "input_tokens": input_tokens,
+                "cache_read_input_tokens": first_call_cache_read,
+                "cache_creation_input_tokens": 50,
+                "output_tokens": 20,
+            }}}),
+        json.dumps({"type": "result", "total_cost_usd": cost, "num_turns": 3,
+                    "usage": {"input_tokens": input_tokens, "output_tokens": 20}}),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _make_run_dir(
+    run_dir: Path,
+    *,
+    instances: list[str],
+    treatment_cost_fn,
+    reference_cost_fn,
+    treatment_arm: str = "onlycode",
+    reference_arm: str = "baseline",
+    treatment_cr: int = 100,  # uniform warm first_call_cache_read → no cache-floor adjustment
+    reference_cr: int = 100,
+) -> None:
+    """Write a complete SWE-bench run dir with treatment and reference arms.
+
+    By setting ``treatment_cr = reference_cr = 100`` (all warm with the same
+    value), the cache-floor median equals that value, adj_cached = first_cr
+    for every row, moved = 0 → cost_adj == cost_usd. This makes the tests
+    deterministic without modelling the cache-floor mechanics.
+    """
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for iid in instances:
+        stem_t = f"{iid}_{treatment_arm}_run1"
+        stem_r = f"{iid}_{reference_arm}_run1"
+        _write_claude_jsonl(
+            run_dir / f"{stem_t}.jsonl",
+            instance=iid, arm=treatment_arm, cost=treatment_cost_fn(iid),
+            first_call_cache_read=treatment_cr,
+        )
+        (run_dir / f"{stem_t}_test.txt").write_text("ran tests\nPASS\n")
+        _write_claude_jsonl(
+            run_dir / f"{stem_r}.jsonl",
+            instance=iid, arm=reference_arm, cost=reference_cost_fn(iid),
+            first_call_cache_read=reference_cr,
+        )
+        (run_dir / f"{stem_r}_test.txt").write_text("ran tests\nPASS\n")
+
+
+def _standard_instances(n: int = 20) -> list[str]:
+    """Generate instance IDs spread across a few repos for stratification."""
+    repos = ["django", "sphinx", "sklearn", "mpl", "sympy"]
+    return [f"{repos[i % len(repos)]}__proj-{i:04d}" for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# apply_cache_floor_adjustment (unit tests)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_floor_no_cold_instances():
+    """When all instances are warm with the same first_call_cache_read, no adjustment."""
+    rows = [
+        {"seed": "1", "arm": "onlycode", "cost_usd": 1.0,
+         "first_call_input": 500, "first_call_cache_read": 100},
+        {"seed": "1", "arm": "onlycode", "cost_usd": 2.0,
+         "first_call_input": 500, "first_call_cache_read": 100},
+    ]
+    pa.apply_cache_floor_adjustment(rows)
+    assert rows[0]["cost_adj"] == pytest.approx(1.0)
+    assert rows[1]["cost_adj"] == pytest.approx(2.0)
+
+
+def test_cache_floor_cold_instance_gets_credit():
+    """Cold instance (first_call_cache_read=0) gets floored up to median of warm instances."""
+    # Warm median = 200 tokens; gap = (3.00 - 0.30) / 1e6 = 2.7e-6 per token
+    gap = (3.00 - 0.30) / 1_000_000
+    rows = [
+        {"seed": "1", "arm": "baseline", "cost_usd": 1.0,
+         "first_call_input": 1000, "first_call_cache_read": 0},    # cold → gets credit
+        {"seed": "1", "arm": "baseline", "cost_usd": 2.0,
+         "first_call_input": 1000, "first_call_cache_read": 200},  # warm
+        {"seed": "1", "arm": "baseline", "cost_usd": 3.0,
+         "first_call_input": 1000, "first_call_cache_read": 200},  # warm
+    ]
+    pa.apply_cache_floor_adjustment(rows)
+    # median(warm) = 200; cold row gets adj_cached=200, moved=200
+    # cost_adj = 1.0 - 200 * gap
+    expected_adj = 1.0 - 200 * gap
+    assert rows[0]["cost_adj"] == pytest.approx(expected_adj, rel=1e-6)
+    # Warm rows: moved=0 → unchanged
+    assert rows[1]["cost_adj"] == pytest.approx(2.0)
+    assert rows[2]["cost_adj"] == pytest.approx(3.0)
+
+
+def test_cache_floor_none_fields_skipped():
+    """Rows with None cost or missing fields are left unadjusted (cost_adj = cost_usd)."""
+    rows = [
+        {"seed": "1", "arm": "onlycode", "cost_usd": None,
+         "first_call_input": 500, "first_call_cache_read": 100},
+        {"seed": "1", "arm": "onlycode", "cost_usd": 1.0,
+         "first_call_input": None, "first_call_cache_read": None},
+    ]
+    pa.apply_cache_floor_adjustment(rows)
+    assert rows[0]["cost_adj"] is None
+    assert rows[1]["cost_adj"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# load_paired_costs
+# ---------------------------------------------------------------------------
+
+
+def test_load_paired_costs_basic(tmp_path):
+    """Costs are loaded and averaged across seeds; adj == cost when all warm."""
+    instances = _standard_instances(10)
+    # Seed 1: onlycode=1.2, baseline=1.0
+    d1 = tmp_path / "full_run_seed_1"
+    _make_run_dir(d1, instances=instances,
+                  treatment_cost_fn=lambda _: 1.2,
+                  reference_cost_fn=lambda _: 1.0)
+    # Seed 2: onlycode=1.4, baseline=1.0 → mean onlycode = 1.3
+    d2 = tmp_path / "full_run_seed_2"
+    _make_run_dir(d2, instances=instances,
+                  treatment_cost_fn=lambda _: 1.4,
+                  reference_cost_fn=lambda _: 1.0)
+
+    paired = pa.load_paired_costs([d1, d2])
+    assert len(paired) == 10
+    for iid in instances:
+        t, r = paired[iid]
+        assert r == pytest.approx(1.0, abs=1e-6)
+        assert t == pytest.approx(1.3, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# calibration_check
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_check_known_effect():
+    """Arithmetic effect = 10% when treatment is uniformly 10% more expensive."""
+    paired = {f"inst{i}": (1.1, 1.0) for i in range(20)}
+    result = pa.calibration_check(paired)
+    assert result["n"] == 20
+    assert result["pct_effect_arithmetic"] == pytest.approx(10.0, abs=1e-6)
+    # Wilcoxon detects uniform positive effect
+    assert result["p_wilcoxon_arithmetic"] is not None
+    assert result["p_wilcoxon_arithmetic"] < 0.05
+
+
+def test_calibration_check_zero_effect():
+    """Zero effect → arithmetic 0%, Wilcoxon p undefined (all zeros)."""
+    paired = {f"inst{i}": (1.0, 1.0) for i in range(20)}
+    result = pa.calibration_check(paired)
+    assert result["pct_effect_arithmetic"] == pytest.approx(0.0, abs=1e-9)
+    assert result["p_wilcoxon_arithmetic"] is None
+
+
+def test_calibration_check_gate_tolerance():
+    """Gate passes when arithmetic effect is near 14.4% (within ±1 pp) and p is near 0.12."""
+    # Construct 100 paired instances where pct ≈ 14.44% and p ≈ noisy positive.
+    # All identical deltas → p will be tiny (p < 0.05), so gate_passes = False
+    # because p is not in [0.07, 0.20]. This is expected: gate only passes with real data.
+    n = 100
+    paired = {f"inst{i}": (1.1444 * (1.0 + 0.01 * i), 1.0 + 0.01 * i) for i in range(n)}
+    result = pa.calibration_check(paired)
+    # Effect is near 14.44%
+    assert result["pct_effect_arithmetic"] == pytest.approx(14.44, abs=0.1)
+    # Gate requires p ∈ [0.07, 0.20]; uniform deltas give p < 0.05 → gate fails
+    assert result["gate_passes"] is False  # uniform deltas → too significant
+    assert result["paper_pct_effect"] == 14.4375
+
+
+# ---------------------------------------------------------------------------
+# log_scale_effect
+# ---------------------------------------------------------------------------
+
+
+def test_log_scale_effect_known_ratio():
+    """exp(mean_d) - 1 recovers the uniform cost ratio."""
+    paired = {f"inst{i}": (1.2, 1.0) for i in range(50)}
+    d, ids = pa.log_scale_effect(paired)
+    assert len(d) == 50
+    assert float(d.mean()) == pytest.approx(math.log(1.2), abs=1e-9)
+
+
+def test_log_scale_effect_drops_nonpositive():
+    """Instances with non-positive costs are dropped."""
+    paired = {"good": (1.2, 1.0), "bad_t": (0.0, 1.0), "bad_r": (1.0, -0.5)}
+    d, ids = pa.log_scale_effect(paired)
+    assert len(d) == 1
+    assert ids == ["good"]
+
+
+# ---------------------------------------------------------------------------
+# Repo stratification
+# ---------------------------------------------------------------------------
+
+
+def test_stratified_sample_size():
+    """_stratified_sample always returns exactly n items."""
+    rng = np.random.default_rng(0)
+    d = np.ones(20)
+    ids = [f"django__proj-{i}" for i in range(10)] + [f"astropy__proj-{i}" for i in range(10)]
+    for n in (5, 10, 15, 20, 25):
+        sample = pa._stratified_sample(d, ids, n, rng)
+        assert len(sample) == n
+
+
+def test_stratified_sample_single_repo():
+    """With a single repo, stratified sampling degenerates to uniform with replacement."""
+    rng = np.random.default_rng(1)
+    d = np.arange(10, dtype=float)
+    ids = [f"django__proj-{i}" for i in range(10)]
+    sample = pa._stratified_sample(d, ids, 30, rng)
+    assert len(sample) == 30
+
+
+# ---------------------------------------------------------------------------
+# Power curve monotonicity
+# ---------------------------------------------------------------------------
+
+
+def test_power_curve_monotone(tmp_path):
+    """Power curve is weakly monotone increasing in N for a clear positive effect."""
+    instances = _standard_instances(30)
+    d1 = tmp_path / "full_run_seed_1"
+    _make_run_dir(d1, instances=instances,
+                  treatment_cost_fn=lambda _: 2.0,
+                  reference_cost_fn=lambda _: 1.0)
+
+    paired = pa.load_paired_costs([d1])
+    d, ids = pa.log_scale_effect(paired)
+    curve = pa.resampling_power(d, ids, n_grid=[5, 10, 15, 20],
+                                n_boot=500, power_sims=200, alpha=0.05, seed=0)
+    powers = [row["power_bootstrap"] for row in curve]
+    for i in range(1, len(powers)):
+        assert powers[i] >= powers[i - 1] - 0.15, f"Power dropped at N={curve[i]['n']}"
+
+
+def test_power_curve_null_effect(tmp_path):
+    """With no effect, power should be near alpha (≈0.05) at any N."""
+    instances = _standard_instances(30)
+    d1 = tmp_path / "full_run_seed_1"
+    _make_run_dir(d1, instances=instances,
+                  treatment_cost_fn=lambda _: 1.0,
+                  reference_cost_fn=lambda _: 1.0)
+
+    paired = pa.load_paired_costs([d1])
+    d, ids = pa.log_scale_effect(paired)
+    curve = pa.resampling_power(d, ids, n_grid=[10, 20],
+                                n_boot=500, power_sims=200, alpha=0.05, seed=0)
+    for row in curve:
+        # Bootstrap p = 1 when d = 0 → all simulations fail to reject → power ≈ 0
+        assert row["power_bootstrap"] < 0.20
+
+
+# ---------------------------------------------------------------------------
+# find_n_star
+# ---------------------------------------------------------------------------
+
+
+def test_find_n_star_exact():
+    """N* is the first N that reaches the threshold."""
+    curve = [
+        {"n": 10, "power_bootstrap": 0.50, "power_wilcoxon": 0.45},
+        {"n": 20, "power_bootstrap": 0.75, "power_wilcoxon": 0.70},
+        {"n": 30, "power_bootstrap": 0.90, "power_wilcoxon": 0.88},
+        {"n": 40, "power_bootstrap": 0.95, "power_wilcoxon": 0.93},
+    ]
+    assert pa.find_n_star(curve, 0.90) == 30
+    # 0.75 < 0.80 at N=20; N=30 (0.90 ≥ 0.80) is the first to cross
+    assert pa.find_n_star(curve, 0.80) == 30
+    assert pa.find_n_star(curve, 0.96) is None  # never reached
+
+
+def test_find_n_star_never_reached():
+    """Returns None when threshold is not met."""
+    curve = [{"n": 10, "power_bootstrap": 0.50, "power_wilcoxon": 0.45}]
+    assert pa.find_n_star(curve, 0.90) is None
+
+
+# ---------------------------------------------------------------------------
+# go_nogo_recommendation
+# ---------------------------------------------------------------------------
+
+
+def test_go_nogo_powered_subset():
+    rec = pa.go_nogo_recommendation(n_star_90=80, n_star_80=60, n_available=100)
+    assert rec["verdict"] == "powered_subset"
+    assert rec["null_branch"] is False
+    assert rec["n_star_90"] == 80
+
+
+def test_go_nogo_full_pool():
+    rec = pa.go_nogo_recommendation(n_star_90=150, n_star_80=100, n_available=100)
+    assert rec["verdict"] == "full_pool"
+    assert rec["null_branch"] is False
+
+
+def test_go_nogo_null_branch():
+    rec = pa.go_nogo_recommendation(n_star_90=None, n_star_80=None, n_available=100)
+    assert rec["verdict"] == "null_branch"
+    assert rec["null_branch"] is True
+
+
+# ---------------------------------------------------------------------------
+# build_report integration (small synthetic data)
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_end_to_end(tmp_path):
+    """build_report runs without error on small synthetic data and returns expected schema."""
+    instances = _standard_instances(20)
+    d1 = tmp_path / "full_run_seed_1"
+    _make_run_dir(d1, instances=instances,
+                  treatment_cost_fn=lambda _: 1.3,
+                  reference_cost_fn=lambda _: 1.0)
+    d2 = tmp_path / "full_run_seed_2"
+    _make_run_dir(d2, instances=instances,
+                  treatment_cost_fn=lambda _: 1.3,
+                  reference_cost_fn=lambda _: 1.0)
+
+    rep = pa.build_report(
+        [d1, d2],
+        n_boot=500,
+        power_sims=100,
+        n_min=5,
+        n_max=20,
+        n_step=5,
+        seed=0,
+    )
+
+    # Schema checks
+    assert "calibration" in rep
+    assert "log_scale_effect" in rep
+    assert "power_analysis" in rep
+    assert "go_nogo" in rep
+    assert rep["n_paired"] == 20
+
+    # Calibration: +30% arithmetic effect
+    calib = rep["calibration"]
+    assert calib["pct_effect_arithmetic"] == pytest.approx(30.0, abs=0.1)
+
+    # Log-scale effect: exp(log(1.3)) - 1 = 30%
+    log_eff = rep["log_scale_effect"]
+    assert log_eff["pct_effect_log"] == pytest.approx(30.0, abs=0.1)
+
+    # Power curve: 4 entries (5, 10, 15, 20)
+    pa_sec = rep["power_analysis"]
+    assert len(pa_sec["curve"]) == 4
+
+    # go_nogo has a verdict
+    assert rep["go_nogo"]["verdict"] in ("powered_subset", "full_pool", "null_branch")
+
+    # repo_distribution should reflect our synthetic instance names
+    assert "django" in rep["repo_distribution"]
+
+
+# ---------------------------------------------------------------------------
+# Output files (JSON + CSV)
+# ---------------------------------------------------------------------------
+
+
+def test_write_outputs_creates_files(tmp_path):
+    """_write_outputs creates both JSON and CSV with correct schema."""
+    rep = {
+        "treatment": "onlycode",
+        "reference": "baseline",
+        "run_dirs": [],
+        "n_paired": 10,
+        "repo_distribution": {"django": 10},
+        "calibration": {
+            "n": 10, "mean_delta": 0.1, "mean_reference": 1.0,
+            "pct_effect_arithmetic": 10.0, "p_wilcoxon_arithmetic": 0.05,
+            "gate_passes": False, "paper_pct_effect": 14.4375, "paper_p_wilcoxon": 0.1202,
+        },
+        "log_scale_effect": {
+            "mean_log_diff": 0.095, "std_log_diff": 0.1, "dz": 0.95,
+            "pct_effect_log": 9.97,
+            "full_contrast": {
+                "n": 10, "n_dropped": 0, "mean_log_diff": 0.095,
+                "pct_effect": 9.97, "ci_pct_lo": 5.0, "ci_pct_hi": 15.0,
+                "p_bootstrap": 0.02, "p_wilcoxon": 0.03,
+                "n_boot": 500, "alpha": 0.05, "significant": True,
+            },
+        },
+        "power_analysis": {
+            "n_grid": [5, 10], "n_boot": 500, "power_sims": 100,
+            "alpha": 0.05, "seed": 0, "n_star_80": 5, "n_star_90": 10,
+            "curve": [
+                {"n": 5, "power_bootstrap": 0.75, "power_wilcoxon": 0.70},
+                {"n": 10, "power_bootstrap": 0.91, "power_wilcoxon": 0.89},
+            ],
+        },
+        "go_nogo": {
+            "verdict": "powered_subset",
+            "recommendation": "Run N=10.",
+            "n_star_90": 10, "n_star_80": 5, "null_branch": False,
+        },
+    }
+
+    out_prefix = str(tmp_path / "ws-a")
+    pa._write_outputs(rep, out_prefix)
+
+    json_path = tmp_path / "ws-a.json"
+    csv_path = tmp_path / "ws-a.csv"
+    assert json_path.exists()
+    assert csv_path.exists()
+
+    loaded = json.loads(json_path.read_text())
+    assert loaded["go_nogo"]["verdict"] == "powered_subset"
+
+    import csv as csv_mod
+    with open(csv_path) as f:
+        rows = list(csv_mod.DictReader(f))
+    assert len(rows) == 2
+    assert rows[0]["n"] == "5"
+    assert float(rows[1]["power_bootstrap"]) == pytest.approx(0.91)
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_cli_main_runs(tmp_path, capsys):
+    """CLI main() writes outputs and prints a report without crashing."""
+    instances = _standard_instances(10)
+    d1 = tmp_path / "full_run_seed_1"
+    _make_run_dir(d1, instances=instances,
+                  treatment_cost_fn=lambda _: 1.15,
+                  reference_cost_fn=lambda _: 1.0)
+
+    out_prefix = str(tmp_path / "out" / "ws-a")
+    pa.main([
+        "--runs", str(d1),
+        "--n-boot", "200",
+        "--power-sims", "50",
+        "--n-min", "5",
+        "--n-max", "10",
+        "--n-step", "5",
+        "--seed", "0",
+        "--out-prefix", out_prefix,
+    ])
+
+    captured = capsys.readouterr()
+    assert "Calibration gate" in captured.out
+    assert (tmp_path / "out" / "ws-a.json").exists()
+    assert (tmp_path / "out" / "ws-a.csv").exists()


### PR DESCRIPTION
Closes #307

## What changed

Issue #307 requires a power analysis on existing SWE-bench/Claude run data to determine N* (the minimum sample size for ≥0.90 power at α=0.05 two-sided), with a calibration gate that reproduces the paper's +14.4%/p≈0.12 headline contrast. This PR adds `scripts/power_analysis.py` with the complete pipeline: cache-floor-adjusted cost loading → arithmetic calibration gate → log-scale resampling power curve with repo-stratified sampling → N* detection → go/no-go recommendation for #299.

The key architectural insight: the paper's +14.4%/p≈0.12 uses a **cache-floor** adjustment (per-arm-per-seed median of warm first-call cache reads, flooring cold-start tasks up to the median), not the first-call recharging approach in `cost_first_call_adjust.py`. The calibration gate re-implements this from raw JSONL without reading `paper/` data files.

## Implementation walkthrough

### New functions in `scripts/power_analysis.py`

- **`_parse_claude_jsonl(path)`** — extracts `(cost_usd, first_call_input, first_call_cache_read, model)` from one JSONL, deduplicating assistant messages by ID to get the true first-call cache_read signal.

- **`apply_cache_floor_adjustment(rows)`** — mirrors `collect_results._apply_cache_floor_adjustment`: groups rows by (seed, arm), computes `median(first_call_cache_read)` over the warm subset, then floors cold-start tasks up to the median. `Δ = −moved × gap` where `gap = (3.00 − 0.30) / 1e6`. Mutates rows in place.

- **`load_paired_costs(run_dirs, ...)`** — walks each seed run dir, applies cache-floor adjustment per seed, then averages per (arm, instance) across seeds. Returns `{instance_id: (mean_treatment_adj_cost, mean_reference_adj_cost)}` over instances present in both arms.

- **`calibration_check(paired)`** — arithmetic effect (`mean_delta / mean_reference × 100`) + Wilcoxon signed-rank on arithmetic deltas. Reproduces the paper headline. Gate window: effect ∈ [13.0%, 16.0%], p ∈ [0.07, 0.20].

- **`log_scale_effect(paired)`** — per-instance `d_i = log(treatment) − log(reference)`. Returns `(d, ids)` for power analysis.

- **`_stratified_sample(d, ids, n, rng)`** — proportional repo-stratified resample: allocates slots by `round(n × repo_frac)`, absorbing rounding residual in the last repo. Draw is with replacement within each repo.

- **`resampling_power(d, ids, ...)`** — for each N in the grid: `power_sims` stratified resamples → paired bootstrap test + Wilcoxon on each → power = fraction of sims where p < alpha.

- **`find_n_star(curve, threshold)`** — first N in the power curve where power ≥ threshold.

- **`go_nogo_recommendation(n_star_90, n_star_80, n_available, n_max)`** — three verdicts: `powered_subset` (N* ≤ n_available), `full_pool` (N* > n_available but ≤ n_max), `null_branch` (N* > n_max → TOST at full buildable pool).

### Calibration and observed results (from full_run_seed_{1,2,3})

- **Calibration gate**: +15.26% arithmetic effect (paper: +14.44%), p=0.118 (paper: 0.120) → **PASS**
- **Log-scale effect** (power analysis estimand): exp(mean_d)−1 ≈ +10.85%, Cohen dz ≈ 0.282 (sample std, ddof=1)
- **N*(0.80)**: 90 instances; **N*(0.90)**: 120 instances
- **Verdict**: `full_pool` — N*(0.90) exceeds the current n=100 paired instances

### Output files

`runs/swebench/_analysis/power/ws-a.json` — full report (calibration, dz, power curve, N*, go/no-go)
`runs/swebench/_analysis/power/ws-a.csv` — power-vs-N table for plotting

(Both are gitignored under `runs/*`; regenerate locally with the invocation in the module docstring.)

## Review findings — all resolved

The automated review left 1 escalate + 3 propose items; all are now addressed (commit `5e45f4e`):

- **Escalate — calibration-gate docstring inconsistency**: docstring stated `[13.4%, 15.4%]`/`p ∈ [0.07, 0.17]`, code used `[13.0%, 16.0%]`/`[0.07, 0.20]` (the latter also pinned by the unit test). Docstring reconciled to the code's actual window.
- **F-0-1 (dz ddof)**: switched `dz` to sample std (`ddof=1`), the conventional Cohen's dz, since dz may be cited in the paper. Reported dz moves 0.284 → 0.282; no effect on the power curve or N* (the sims resample `d` directly).
- **F-0-2 (hardcoded 500/n=100)**: threaded `n_max`/`n_available` into `go_nogo_recommendation` so the null_branch message is correct under a non-default `--n-max`.
- **F-0-3 (duplicate wilcoxon)**: reuse `swebench.contrast_stats.wilcoxon_pvalue` instead of the local private copy.

## Tier / approach

Tier 2 — Planner → Coder A (power_analysis.py) + Tester (test_power_analysis.py)

## Acceptance criteria

- [x] Calibration gate passes (reproduces +14.4% / p≈0.12 from existing data): **+15.26% / p=0.118**
- [x] Power-vs-N curve + N*(0.90) reported — derived from empirical effect, not round-number default
- [x] Go/no-go recommendation for #299 included in JSON output (`full_pool`)
- [x] `runs/swebench/_analysis/power/ws-a.{csv,json}` written
- [x] Unit tests (21) in `tests/test_power_analysis.py` pass
- [x] Integration tests (43) in `tests/test_integration_power_analysis_*.py` pass
- [x] `pytest -m "not integration"` passes
- [x] All automated-review findings (escalate + 3 propose) resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
