### PR TITLE
feat(#305): parallelize image-runtime agent + grading passes, add resume

### DIFF
--- a/swebench/image_run.py
+++ b/swebench/image_run.py
@@ -20,10 +20,14 @@ here, and the agent never shares a container with the held-out test.
 ``grading_official.grade_predictions`` (official ``run_evaluation`` over the
 **unmodified** image). The verdict is merged back into each partial record.
 
-This is a **dedicated, serial** agent orchestrator — deliberately separate from
-the overlay path's serial/parallel loop in ``run.py`` (no surgery on that code).
-Instances are processed in repo+version-grouped order so the shared conda layer
-is reused before eviction (C3b). The grading pass parallelism is independent
+This is a **dedicated** agent orchestrator — deliberately separate from the
+overlay path's loop in ``run.py`` (no surgery on that code). The agent pass runs
+``agent_max_workers`` instances concurrently (``--parallel``); instances are
+disjoint (own image, snapshot, container, and output files), so the only shared
+state is the predictions dict (lock-guarded). Work is submitted in
+repo+version-grouped order so same-repo images are reused. The agent pass is
+API-bound (the agent turn blocks on the model API while the GIL is released), so
+threads give real parallelism. The grading pass parallelism is independent
 (``grading_max_workers``).
 """
 
@@ -33,7 +37,9 @@ import json
 import logging
 import os
 import tempfile
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from swebench import container, container_agent, grading_official, image_store, specs
@@ -43,6 +49,27 @@ from swebench.models import Problem
 #: SWE-bench image canonical paths.
 _TESTBED = "/testbed"
 _TESTBED_PY = "/opt/miniconda3/envs/testbed/bin/python"
+
+#: Terminal verdicts that --resume treats as "done" (matches the overlay path's
+#: ``run._is_triple_complete``). ``PENDING`` (agent ran, grading interrupted),
+#: ``ERROR`` (grader/patch error), and a missing record are all re-run.
+_RESUME_TERMINAL = {"PASS", "FAIL", "env_fail"}
+
+
+def _record_verdict(results_dir: str, instance_id: str, arm: str, run_idx: int) -> str | None:
+    """Terminal verdict already recorded for a triple, or ``None`` if the record
+    is absent/unreadable/PENDING. The image record stores the verdict in its meta
+    line (first line), rewritten in place by :func:`_finalize_record` at grade time."""
+    path = Path(results_dir) / f"{instance_id}_{arm}_run{run_idx}.jsonl"
+    if not path.is_file():
+        return None
+    try:
+        with path.open() as f:
+            meta = json.loads(f.readline())
+    except (OSError, ValueError):
+        return None
+    v = meta.get("verdict")
+    return v if v in _RESUME_TERMINAL else None
 
 
 def _build_prompt(problem: Problem, arm: str) -> str:
@@ -276,14 +303,18 @@ def run_image_arms(
     agent_surface: str = "claude_code",
     codex_model: str | None = None,
     wall_timeout: int = 1800,
+    agent_max_workers: int = 1,
     grading_max_workers: int = 1,
+    resume: bool = False,
     echo=print,
 ) -> list[tuple[str, str, str]]:
     """Run ``arms`` over ``problems`` on the image runtime in two passes.
 
     Pass 1 (agent): for each problem x arm x run, pull + prepare + run the agent,
     capturing each ``model_patch`` into a PENDING record. Predictions are grouped
-    by ``(arm, run_idx)``.
+    by ``(arm, run_idx)``. Runs ``agent_max_workers`` problems concurrently
+    (default 1 = serial); arms/runs within a problem stay serial (they share the
+    instance's prepared snapshot).
 
     Pass 2 (grading): per ``(arm, run_idx)`` group, grade the captured patches
     verbatim via :func:`grading_official.grade_predictions` (official
@@ -309,27 +340,79 @@ def run_image_arms(
     # --- Pass 1: agent. Collect predictions grouped by (arm, run_idx). ---
     # FAIL_TO_PASS / test_patch come from the official dataset at grade time, so
     # we no longer skip on missing grading data — only on un-promptable instances.
+    #
+    # Instances are independent (own image/snapshot/container/output files); the
+    # only shared state is ``predictions`` (lock-guarded). ``ensure_image`` raises
+    # ``DiskFullError`` when free space drops below the safety margin — on that we
+    # set ``stop_event`` so in-flight work drains and no new instance is started,
+    # then re-raise after the pool quiesces ("stop and add disk, then --resume").
     predictions: dict[tuple[str, int], list[dict]] = {}
-    for problem in problems:
+    pred_lock = threading.Lock()
+    stop_event = threading.Event()
+    disk_full: list[image_store.DiskFullError] = []
+
+    workers = max(1, agent_max_workers)
+    free = image_store.free_disk_gb()
+    echo(f"Agent pass: {len(problems)} instance(s) x {len(arms)} arm(s), "
+         f"parallel={workers}" + (f", {free:.0f} GB free" if free is not None else ""))
+
+    def _process_problem(problem: Problem) -> None:
+        if stop_event.is_set():
+            return
         if not problem.problem_statement:
             echo(f"  SKIP {problem.instance_id}: no problem_statement (cannot prompt the agent)")
-            continue
+            return
 
-        echo(f"--- Instance: {problem.instance_id} ({problem.repo_slug}@{problem.version}) ---")
-        digest_info = image_store.ensure_image(problem.instance_id)
-        prepared = container.prepare_instance(
-            problem.instance_id, post_strip_exec=container_agent.agent_user_setup_commands())
+        # --resume: only run (arm, run) triples without a terminal verdict, and
+        # skip the image pull + snapshot entirely when the whole instance is done.
+        if resume:
+            todo = [(arm, r) for arm in arms for r in range(num_runs)
+                    if _record_verdict(results_dir, problem.instance_id, arm, r) is None]
+            if not todo:
+                echo(f"  SKIP {problem.instance_id}: all triples already complete (--resume)")
+                return
+        else:
+            todo = [(arm, r) for arm in arms for r in range(num_runs)]
 
-        for arm in arms:
-            for run_idx in range(num_runs):
-                pred = run_one_arm(
-                    problem, arm=arm, run_idx=run_idx, prepared=prepared,
-                    digest_info=digest_info, results_dir=results_dir,
-                    wall_timeout=wall_timeout, agent_surface=agent_surface,
-                    codex_model=codex_model,
-                )
-                echo(f"  [{arm} run {run_idx}] agent done (PENDING grade)")
+        try:
+            echo(f"--- Instance: {problem.instance_id} ({problem.repo_slug}@{problem.version}) ---")
+            digest_info = image_store.ensure_image(problem.instance_id)
+            prepared = container.prepare_instance(
+                problem.instance_id,
+                post_strip_exec=container_agent.agent_user_setup_commands())
+        except image_store.DiskFullError as e:
+            disk_full.append(e)
+            stop_event.set()
+            echo(f"  DISK FULL at {problem.instance_id}: {e} "
+                 "— draining in-flight work, starting no new instances")
+            return
+
+        for arm, run_idx in todo:
+            pred = run_one_arm(
+                problem, arm=arm, run_idx=run_idx, prepared=prepared,
+                digest_info=digest_info, results_dir=results_dir,
+                wall_timeout=wall_timeout, agent_surface=agent_surface,
+                codex_model=codex_model,
+            )
+            echo(f"  [{problem.instance_id} {arm} run {run_idx}] agent done (PENDING grade)")
+            with pred_lock:
                 predictions.setdefault((arm, run_idx), []).append(pred)
+
+    if workers == 1:
+        for problem in problems:
+            if stop_event.is_set():
+                break
+            _process_problem(problem)
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = [ex.submit(_process_problem, p) for p in problems]
+            for fut in as_completed(futures):
+                fut.result()  # surface unexpected (non-DiskFull) worker exceptions
+
+    if disk_full:
+        # Agent work already captured is on disk as PENDING records; add disk and
+        # re-run with --resume. Re-raise so the operator sees the hard stop.
+        raise disk_full[0]
 
     # --- Pass 2: grade verbatim per (arm, run_idx), merge verdicts. ---
     results: list[tuple[str, str, str]] = []

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -893,9 +893,20 @@ def _run_image_runtime(
     max_wall_seconds: int,
     agent_surface: str = "claude_code",
     codex_model: str | None = None,
+    parallel: int = 1,
+    grading_parallel: int = 0,
+    resume: bool = True,
 ) -> None:
     """Handle ``--runtime image`` (C5 #319): Docker preflight, then dispatch to
-    the dedicated image-runtime orchestrator (``swebench.image_run``)."""
+    the dedicated image-runtime orchestrator (``swebench.image_run``).
+
+    ``parallel`` (= ``--parallel``) sets the agent-pass concurrency: that many
+    instances run their agent turns at once. Instances are disjoint, so this is a
+    near-linear speed-up for the API-bound agent pass until a rate-limit or disk
+    margin is hit. ``grading_parallel`` (= ``--grading-parallel``, 0 ⇒ follow
+    ``parallel``) sets the verbatim grading-pass concurrency — that pass runs the
+    official test suite per instance (CPU/IO-bound), so it is the other half of a
+    workable full-run wall-clock."""
     from swebench import container, image_run
 
     proc = container._docker(["version", "--format", "{{.Server.Version}}"], check=False)
@@ -913,13 +924,15 @@ def _run_image_runtime(
     # wall_timeout: max_wall_seconds==0 means unlimited; the orchestrator wants a
     # positive bound (in-container `timeout`), so fall back to 1800s when unset.
     wall = max_wall_seconds if max_wall_seconds and max_wall_seconds > 0 else 1800
+    grading_workers = grading_parallel if grading_parallel and grading_parallel > 0 else parallel
     results = image_run.run_image_arms(
         problems, arms=arm_list, num_runs=num_runs,
         results_dir=results_dir, agent_binary=agent_binary,
         agent_surface=agent_surface, codex_model=codex_model,
         wall_timeout=wall,
-        # TODO(#354): wire a CLI flag for the verbatim grading-pass concurrency.
-        grading_max_workers=1,
+        agent_max_workers=parallel,
+        grading_max_workers=grading_workers,
+        resume=resume,
         echo=click.echo,
     )
     n_pass = sum(1 for _, _, v in results if v == "PASS")
@@ -968,7 +981,16 @@ def _run_image_runtime(
     "parallel",
     type=int,
     default=1,
-    help="Max problems to run concurrently (default: 1 = serial).",
+    help="Max problems to run concurrently (default: 1 = serial). On the image "
+         "runtime this sets the agent-pass concurrency (API-bound).",
+)
+@click.option(
+    "--grading-parallel",
+    "grading_parallel",
+    type=int,
+    default=0,
+    help="Image runtime only: concurrency for the verbatim grading pass "
+         "(CPU/IO-bound test-suite runs). 0 (default) follows --parallel.",
 )
 @click.option(
     "--fail-fast",
@@ -1108,6 +1130,7 @@ def run_command(
     persistent_kernel: bool,
     num_runs: int,
     parallel: int,
+    grading_parallel: int,
     fail_fast: bool,
     use_cache: bool,
     shuffle_arms: bool,
@@ -1185,6 +1208,8 @@ def run_command(
             results_dir=str(results_dir), agent_binary=agent_binary,
             num_runs=num_runs, max_wall_seconds=max_wall_seconds,
             agent_surface=agent_surface, codex_model=codex_model,
+            parallel=parallel, grading_parallel=grading_parallel,
+            resume=resume,
         )
         return
 

--- a/tests/test_image_run.py
+++ b/tests/test_image_run.py
@@ -264,3 +264,158 @@ def test_run_image_arms_skips_unpromptable(monkeypatch, tmp_path) -> None:
                                    results_dir=str(tmp_path), agent_binary="claude", echo=lambda *a: None)
     iids = {iid for iid, _, _ in out}
     assert iids == {"psf__requests-1142", "psf__requests-2222"}  # no-f2p kept; unpromptable dropped
+
+
+# ---------------------------------------------------------------------------
+# Parallel agent pass (--parallel on the image runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_agent_pass_processes_all_instances(monkeypatch, tmp_path) -> None:
+    _stub_agent_pass(monkeypatch)
+    monkeypatch.setattr(image_run.grading_official, "grade_predictions",
+                        lambda preds, **kw: {p["instance_id"]: {"resolved": True} for p in preds})
+
+    problems = [_problem(instance_id=f"psf__requests-{i}") for i in range(8)]
+    out = image_run.run_image_arms(
+        problems, arms=["baseline"], num_runs=1,
+        results_dir=str(tmp_path), agent_binary="claude",
+        agent_max_workers=4, echo=lambda *a: None,
+    )
+    # All 8 instances graded exactly once despite concurrent agent pass.
+    assert sorted(iid for iid, _, _ in out) == sorted(p.instance_id for p in problems)
+    assert len(out) == 8
+    # Each wrote its PENDING-then-finalized record.
+    assert len(list(tmp_path.glob("*_baseline_run0.jsonl"))) == 8
+
+
+def test_parallel_agent_pass_runs_concurrently(monkeypatch, tmp_path) -> None:
+    # Prove real concurrency: with a barrier of width W, W agent turns must be
+    # in-flight simultaneously or the barrier (and the test) times out.
+    import threading
+
+    _stub_agent_pass(monkeypatch)
+    monkeypatch.setattr(image_run.grading_official, "grade_predictions",
+                        lambda preds, **kw: {p["instance_id"]: {"resolved": True} for p in preds})
+
+    width = 4
+    barrier = threading.Barrier(width, timeout=10)
+    peak = {"n": 0}
+    live_lock = threading.Lock()
+    live = {"n": 0}
+
+    def _concurrent_run_agent(h, **kw):
+        with live_lock:
+            live["n"] += 1
+            peak["n"] = max(peak["n"], live["n"])
+        barrier.wait()  # blocks until `width` turns are simultaneously here
+        with live_lock:
+            live["n"] -= 1
+        Path(kw["result_path"]).write_text('{"type":"result","total_cost_usd":0.1,"num_turns":1}\n')
+        return 0
+
+    monkeypatch.setattr(image_run.container_agent, "run_agent", _concurrent_run_agent)
+
+    problems = [_problem(instance_id=f"psf__requests-{i}") for i in range(width)]
+    image_run.run_image_arms(
+        problems, arms=["baseline"], num_runs=1,
+        results_dir=str(tmp_path), agent_binary="claude",
+        agent_max_workers=width, echo=lambda *a: None,
+    )
+    assert peak["n"] == width  # all `width` agent turns were in-flight at once
+
+
+def test_parallel_disk_full_stops_and_reraises(monkeypatch, tmp_path) -> None:
+    # ensure_image raises DiskFullError on the 3rd instance → stop event set,
+    # in-flight drains, DiskFullError re-raised. Not every instance is processed.
+    _stub_agent_pass(monkeypatch)
+    seen = []
+    seen_lock = __import__("threading").Lock()
+
+    real_calls = {"n": 0}
+
+    def _ensure(iid, **k):
+        with seen_lock:
+            real_calls["n"] += 1
+            n = real_calls["n"]
+        if n >= 3:
+            raise image_run.image_store.DiskFullError("only 2.0 GB free")
+        seen.append(iid)
+        return {"digest": "sha256:x", "arch": "amd64"}
+
+    monkeypatch.setattr(image_run.image_store, "ensure_image", _ensure)
+
+    problems = [_problem(instance_id=f"psf__requests-{i}") for i in range(10)]
+    with pytest.raises(image_run.image_store.DiskFullError):
+        image_run.run_image_arms(
+            problems, arms=["baseline"], num_runs=1,
+            results_dir=str(tmp_path), agent_binary="claude",
+            agent_max_workers=1, echo=lambda *a: None,
+        )
+    # Serial path stops at the disk-full instance; not all 10 are processed.
+    assert len(seen) < 10
+
+
+def test_resume_skips_completed_and_skips_pull(monkeypatch, tmp_path) -> None:
+    # A finished instance (terminal verdict in its record) must be skipped under
+    # --resume, including its image pull + prepare (no ensure_image call for it).
+    _stub_agent_pass(monkeypatch)
+    monkeypatch.setattr(image_run.grading_official, "grade_predictions",
+                        lambda preds, **kw: {p["instance_id"]: {"resolved": True} for p in preds})
+    ensured = []
+    monkeypatch.setattr(image_run.image_store, "ensure_image",
+                        lambda iid, **k: ensured.append(iid) or {"digest": "sha256:x", "arch": "amd64"})
+
+    done = _problem(instance_id="psf__requests-1")
+    todo = _problem(instance_id="psf__requests-2")
+    # Pre-write a finalized (PASS) record for the done instance.
+    (tmp_path / "psf__requests-1_baseline_run0.jsonl").write_text(
+        json.dumps({"type": "meta", "instance_id": "psf__requests-1", "arm": "baseline",
+                    "verdict": "PASS", "resolution": "RESOLVED_FULL"}) + "\n"
+        + json.dumps({"type": "verdict", "verdict": "PASS"}) + "\n")
+
+    out = image_run.run_image_arms(
+        [done, todo], arms=["baseline"], num_runs=1,
+        results_dir=str(tmp_path), agent_binary="claude",
+        resume=True, echo=lambda *a: None,
+    )
+    assert out == [("psf__requests-2", "baseline", "PASS")]  # only the todo instance graded
+    assert ensured == ["psf__requests-2"]  # done instance never pulled/prepared
+
+
+def test_resume_reruns_pending_record(monkeypatch, tmp_path) -> None:
+    # A PENDING record (agent ran, grading was interrupted) is NOT terminal → re-run.
+    _stub_agent_pass(monkeypatch)
+    monkeypatch.setattr(image_run.grading_official, "grade_predictions",
+                        lambda preds, **kw: {p["instance_id"]: {"resolved": True} for p in preds})
+    (tmp_path / "psf__requests-1142_baseline_run0.jsonl").write_text(
+        json.dumps({"type": "meta", "verdict": "PENDING"}) + "\n")
+    out = image_run.run_image_arms(
+        [_problem()], arms=["baseline"], num_runs=1,
+        results_dir=str(tmp_path), agent_binary="claude",
+        resume=True, echo=lambda *a: None,
+    )
+    assert out == [("psf__requests-1142", "baseline", "PASS")]  # re-run to completion
+
+
+def test_record_verdict_helper(tmp_path) -> None:
+    p = tmp_path / "x__x-1_baseline_run0.jsonl"
+    p.write_text(json.dumps({"type": "meta", "verdict": "FAIL"}) + "\n")
+    assert image_run._record_verdict(str(tmp_path), "x__x-1", "baseline", 0) == "FAIL"
+    # PENDING / missing → None (re-run).
+    p.write_text(json.dumps({"type": "meta", "verdict": "PENDING"}) + "\n")
+    assert image_run._record_verdict(str(tmp_path), "x__x-1", "baseline", 0) is None
+    assert image_run._record_verdict(str(tmp_path), "nope", "baseline", 0) is None
+
+
+def test_serial_path_unchanged_when_workers_one(monkeypatch, tmp_path) -> None:
+    _stub_agent_pass(monkeypatch)
+    monkeypatch.setattr(image_run.grading_official, "grade_predictions",
+                        lambda preds, **kw: {p["instance_id"]: {"resolved": True} for p in preds})
+    problems = [_problem(instance_id=f"psf__requests-{i}") for i in range(3)]
+    out = image_run.run_image_arms(
+        problems, arms=["baseline"], num_runs=1,
+        results_dir=str(tmp_path), agent_binary="claude",
+        agent_max_workers=1, echo=lambda *a: None,
+    )
+    assert sorted(iid for iid, _, _ in out) == sorted(p.instance_id for p in problems)


### PR DESCRIPTION
Refs #305 (WS-G). Makes the image runtime's full-run wall-clock **workable** for the ~494-instance baseline runs (#299) — the prerequisite the spine was gated on.

## The problem

The image runtime ([image_run.py](swebench/image_run.py)) was a **serial** agent orchestrator:
- The agent pass was a serial `for problem in problems` loop — **`--parallel` was silently ignored** (only the deprecated overlay path honored it). ~494 baseline instances ≈ 16–25 h *per agent*, serially.
- The verbatim grading pass was hardcoded `grading_max_workers=1`. Grading runs the official test suite per instance (CPU/IO-bound) — the other half of the wall-clock.
- The image path **ignored `--resume`**: it returns before the overlay resume logic and writes no `_test.txt`, so `_is_triple_complete` never matched. Any interruption (rate-limit, disk, crash) re-ran **every** instance from scratch, re-spending all agent cost.

## The fix

**Agent pass — `--parallel`.** `ThreadPoolExecutor(max_workers=--parallel)`. Instances are disjoint (own image, snapshot, container, output files); only the predictions dict is shared (lock-guarded). The pass is API-bound (the agent turn blocks on the model API with the GIL released), so threads give near-linear speed-up. A `DiskFullError` from `ensure_image` sets a stop event → in-flight work drains, no new instances start, then re-raise (“add disk, `--resume`”). `workers=1` keeps the previous serial behavior byte-for-byte.

**Grading pass — `--grading-parallel`** (0 ⇒ follow `--parallel`). Wired to the official `run_evaluation`'s `max_workers`. Separate knob because grading is CPU/IO-bound, not API-bound.

**Resume on the image path.** `_record_verdict` reads the terminal verdict from a record's meta line (`PASS`/`FAIL`/`env_fail` = done; `PENDING`/`ERROR`/missing = re-run). Completed `(arm, run)` triples are skipped, and an instance whose every triple is done **skips its image pull + snapshot entirely**.

## Validation

- **Live**, 4 fast instances at `--parallel 4 --grading-parallel 4`: agent + grading ran end-to-end to verdicts (flask/requests/seaborn PASS, pylint FAIL). A `--resume` re-run **skipped all 4 in 5s** (no pulls, no agent runs).
- Earlier serial vs parallel on a 12-instance repo-diverse slice: serial managed ~1 instance/150s; parallel started all 12 at once.
- **Unit tests** (`tests/test_image_run.py`, +9): a `threading.Barrier` proof that `--parallel` agent turns run simultaneously, the `DiskFullError` stop, resume skip/rerun, and the serial path unchanged.

## Notes

- Stragglers: the two-pass design grades only after *all* agent runs finish, so one slow agent (near `--max-wall-seconds`) delays the batch's grading start. Mitigate with a tighter `--max-wall-seconds` for baseline runs. (Not changed here.)
- Pairs with the run-health audit (#359): after a run, `audit_runs.py --quarantine` + a `--resume` pass re-runs only rate-limited/errored triples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)