### PR TITLE
feat(#305): back off and pause on account rate-limits (429)

### DIFF
--- a/swebench/image_run.py
+++ b/swebench/image_run.py
@@ -45,6 +45,23 @@ from pathlib import Path
 from swebench import container, container_agent, grading_official, image_store, specs
 from swebench.container_agent import runtime_volume_spec
 from swebench.models import Problem
+from swebench.run_audit import is_account_limited
+
+
+class AccountLimitHalt(Exception):
+    """Raised when the agent hits an account rate-limit / quota (HTTP 429) and the
+    run backs off. The clean agent work captured so far is graded and committed
+    first; rate-limited instances stay PENDING so a later ``--resume`` re-runs
+    only them. The run does **not** auto-retry — the operator approves the resume
+    once quota recovers (or maxmanager rotates credentials)."""
+
+    def __init__(self, n_limited: int, n_done: int):
+        self.n_limited = n_limited
+        self.n_done = n_done
+        super().__init__(
+            f"account rate-limit (429) hit: backed off after {n_done} clean run(s); "
+            f"{n_limited} rate-limited instance(s) left PENDING. "
+            f"Resume with --resume once quota recovers.")
 
 #: SWE-bench image canonical paths.
 _TESTBED = "/testbed"
@@ -306,6 +323,7 @@ def run_image_arms(
     agent_max_workers: int = 1,
     grading_max_workers: int = 1,
     resume: bool = False,
+    halt_on_rate_limit: bool = True,
     echo=print,
 ) -> list[tuple[str, str, str]]:
     """Run ``arms`` over ``problems`` on the image runtime in two passes.
@@ -350,6 +368,10 @@ def run_image_arms(
     pred_lock = threading.Lock()
     stop_event = threading.Event()
     disk_full: list[image_store.DiskFullError] = []
+    # Account rate-limit (429) back-off: when an agent turn comes back throttled we
+    # stop launching new instances, let in-flight drain, grade the clean work, and
+    # leave the rate-limited records PENDING for a later --resume.
+    rate_limited: list[str] = []
 
     workers = max(1, agent_max_workers)
     free = image_store.free_disk_gb()
@@ -388,12 +410,24 @@ def run_image_arms(
             return
 
         for arm, run_idx in todo:
+            if stop_event.is_set():
+                return
             pred = run_one_arm(
                 problem, arm=arm, run_idx=run_idx, prepared=prepared,
                 digest_info=digest_info, results_dir=results_dir,
                 wall_timeout=wall_timeout, agent_surface=agent_surface,
                 codex_model=codex_model,
             )
+            # Account-limit (429) back-off: a throttled turn is not a result. Leave
+            # its PENDING record for --resume, stop launching new work, and don't
+            # grade it. Distinct from a task FAIL or a non-quota api_error.
+            if halt_on_rate_limit and is_account_limited(pred["record_path"]):
+                with pred_lock:
+                    rate_limited.append(pred["instance_id"])
+                stop_event.set()
+                echo(f"  RATE LIMIT (429) at {problem.instance_id} {arm} run {run_idx} "
+                     "— backing off, draining in-flight, no new instances")
+                return
             echo(f"  [{problem.instance_id} {arm} run {run_idx}] agent done (PENDING grade)")
             with pred_lock:
                 predictions.setdefault((arm, run_idx), []).append(pred)
@@ -432,4 +466,9 @@ def run_image_arms(
             _finalize_record(pred["record_path"], verdict, resolution)
             echo(f"  [{arm} run {run_idx}] {iid}: {verdict}")
             results.append((iid, arm, verdict))
+
+    # Clean work is now graded + committed. If we backed off on an account limit,
+    # halt loudly so the operator approves the resume once quota recovers.
+    if rate_limited:
+        raise AccountLimitHalt(n_limited=len(set(rate_limited)), n_done=len(results))
     return results

--- a/swebench/run.py
+++ b/swebench/run.py
@@ -896,6 +896,7 @@ def _run_image_runtime(
     parallel: int = 1,
     grading_parallel: int = 0,
     resume: bool = True,
+    halt_on_rate_limit: bool = True,
 ) -> None:
     """Handle ``--runtime image`` (C5 #319): Docker preflight, then dispatch to
     the dedicated image-runtime orchestrator (``swebench.image_run``).
@@ -925,16 +926,30 @@ def _run_image_runtime(
     # positive bound (in-container `timeout`), so fall back to 1800s when unset.
     wall = max_wall_seconds if max_wall_seconds and max_wall_seconds > 0 else 1800
     grading_workers = grading_parallel if grading_parallel and grading_parallel > 0 else parallel
-    results = image_run.run_image_arms(
-        problems, arms=arm_list, num_runs=num_runs,
-        results_dir=results_dir, agent_binary=agent_binary,
-        agent_surface=agent_surface, codex_model=codex_model,
-        wall_timeout=wall,
-        agent_max_workers=parallel,
-        grading_max_workers=grading_workers,
-        resume=resume,
-        echo=click.echo,
-    )
+    try:
+        results = image_run.run_image_arms(
+            problems, arms=arm_list, num_runs=num_runs,
+            results_dir=results_dir, agent_binary=agent_binary,
+            agent_surface=agent_surface, codex_model=codex_model,
+            wall_timeout=wall,
+            agent_max_workers=parallel,
+            grading_max_workers=grading_workers,
+            resume=resume,
+            halt_on_rate_limit=halt_on_rate_limit,
+            echo=click.echo,
+        )
+    except image_run.AccountLimitHalt as e:
+        # Backed off on an account rate-limit (429). Clean work was graded before
+        # the raise; the rate-limited instances are PENDING and resume-able.
+        click.echo(
+            f"\n⏸  PAUSED on account rate-limit (429). {e.n_done} clean run(s) graded; "
+            f"{e.n_limited} rate-limited instance(s) left for re-run.\n"
+            f"   Approve the resume once quota recovers (or maxmanager rotates):\n"
+            f"     python -m swebench run --runtime image --resume "
+            f"--output-dir {results_dir} ...  (same flags)",
+            err=True,
+        )
+        raise SystemExit(3)
     n_pass = sum(1 for _, _, v in results if v == "PASS")
     click.echo(f"\nImage runtime: {n_pass}/{len(results)} PASS across "
                f"{len({i for i, _, _ in results})} instances.")
@@ -991,6 +1006,15 @@ def _run_image_runtime(
     default=0,
     help="Image runtime only: concurrency for the verbatim grading pass "
          "(CPU/IO-bound test-suite runs). 0 (default) follows --parallel.",
+)
+@click.option(
+    "--halt-on-rate-limit/--no-halt-on-rate-limit",
+    "halt_on_rate_limit",
+    default=True,
+    help="Image runtime only: when an agent turn hits an account rate-limit "
+         "(HTTP 429 / quota), back off — grade the clean work, leave throttled "
+         "instances PENDING, and stop (exit 3) instead of burning quota into 429 "
+         "garbage. Re-run with --resume once quota recovers. Default on.",
 )
 @click.option(
     "--fail-fast",
@@ -1131,6 +1155,7 @@ def run_command(
     num_runs: int,
     parallel: int,
     grading_parallel: int,
+    halt_on_rate_limit: bool,
     fail_fast: bool,
     use_cache: bool,
     shuffle_arms: bool,
@@ -1209,7 +1234,7 @@ def run_command(
             num_runs=num_runs, max_wall_seconds=max_wall_seconds,
             agent_surface=agent_surface, codex_model=codex_model,
             parallel=parallel, grading_parallel=grading_parallel,
-            resume=resume,
+            resume=resume, halt_on_rate_limit=halt_on_rate_limit,
         )
         return
 

--- a/swebench/run_audit.py
+++ b/swebench/run_audit.py
@@ -375,6 +375,15 @@ def classify_run(jsonl_path: Path) -> RunAudit:
     )
 
 
+def is_account_limited(jsonl_path: Path) -> bool:
+    """True if a transcript shows an **account rate-limit / quota rejection** — an
+    HTTP 429, a ``rate_limit_event`` whose status is not ``allowed*``, or a
+    usage-limit error event (codex). This is the signal to *back off and pause*
+    the run, distinct from a task FAIL or a one-off non-quota ``api_error`` (e.g.
+    a 401 or 500). Reuses the tested classifier so the rule stays single-sourced."""
+    return classify_run(jsonl_path).status == RATE_LIMITED
+
+
 def audit_dir(run_dir: Path) -> list[RunAudit]:
     """Classify every ``*_run<N>.jsonl`` transcript under ``run_dir`` (recursive),
     sorted by path for deterministic output.

--- a/tests/test_image_run.py
+++ b/tests/test_image_run.py
@@ -408,6 +408,73 @@ def test_record_verdict_helper(tmp_path) -> None:
     assert image_run._record_verdict(str(tmp_path), "nope", "baseline", 0) is None
 
 
+def _rate_limited_run_agent(transcript_path):
+    """Write a transcript carrying a rejected (429) rate-limit event."""
+    Path(transcript_path).write_text(
+        json.dumps({"type": "rate_limit_event",
+                    "rate_limit_info": {"status": "rejected"}}) + "\n"
+        + json.dumps({"type": "result", "subtype": "success", "is_error": True,
+                      "api_error_status": 429, "total_cost_usd": 0.0, "num_turns": 1}) + "\n")
+
+
+def test_halt_on_rate_limit_backs_off_grades_clean_and_raises(monkeypatch, tmp_path) -> None:
+    _stub_agent_pass(monkeypatch)
+    # First instance is clean; the second comes back rate-limited (429).
+    calls = {"n": 0}
+
+    def _run_agent_seq(h, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            Path(kw["result_path"]).write_text('{"type":"result","subtype":"success","is_error":false,"api_error_status":null}\n')
+        else:
+            _rate_limited_run_agent(kw["result_path"])
+        return 0
+
+    monkeypatch.setattr(image_run.container_agent, "run_agent", _run_agent_seq)
+    graded = {}
+    monkeypatch.setattr(image_run.grading_official, "grade_predictions",
+                        lambda preds, **kw: graded.update({"ids": [p["instance_id"] for p in preds]})
+                        or {p["instance_id"]: {"resolved": True} for p in preds})
+
+    problems = [_problem(instance_id=f"psf__requests-{i}") for i in range(2)]
+    with pytest.raises(image_run.AccountLimitHalt) as ei:
+        image_run.run_image_arms(
+            problems, arms=["baseline"], num_runs=1,
+            results_dir=str(tmp_path), agent_binary="claude",
+            agent_max_workers=1, halt_on_rate_limit=True, echo=lambda *a: None,
+        )
+    assert ei.value.n_limited == 1
+    # Only the clean instance was graded; the rate-limited one was NOT.
+    assert graded["ids"] == ["psf__requests-0"]
+    # The rate-limited record stays PENDING → --resume re-runs it.
+    rl = json.loads((tmp_path / "psf__requests-1_baseline_run0.jsonl").read_text().splitlines()[0])
+    assert rl["verdict"] == "PENDING"
+
+
+def test_no_halt_when_disabled(monkeypatch, tmp_path) -> None:
+    # With halt_on_rate_limit=False, a 429 run is recorded and graded like any other.
+    _stub_agent_pass(monkeypatch)
+    monkeypatch.setattr(image_run.container_agent, "run_agent",
+                        lambda h, **kw: (_rate_limited_run_agent(kw["result_path"]), 0)[1])
+    monkeypatch.setattr(image_run.grading_official, "grade_predictions",
+                        lambda preds, **kw: {p["instance_id"]: {"resolved": False} for p in preds})
+    out = image_run.run_image_arms(
+        [_problem()], arms=["baseline"], num_runs=1,
+        results_dir=str(tmp_path), agent_binary="claude",
+        halt_on_rate_limit=False, echo=lambda *a: None,
+    )
+    assert out == [("psf__requests-1142", "baseline", "FAIL")]  # graded, no halt
+
+
+def test_is_account_limited_helper(tmp_path) -> None:
+    from swebench.run_audit import is_account_limited
+    p = tmp_path / "x__x-1_baseline_run0.jsonl"
+    _rate_limited_run_agent(p)
+    assert is_account_limited(p) is True
+    p.write_text('{"type":"result","subtype":"success","is_error":false,"api_error_status":null}\n')
+    assert is_account_limited(p) is False
+
+
 def test_serial_path_unchanged_when_workers_one(monkeypatch, tmp_path) -> None:
     _stub_agent_pass(monkeypatch)
     monkeypatch.setattr(image_run.grading_official, "grade_predictions",


### PR DESCRIPTION
Refs #305. Adds the back-off-and-pause behavior so a single-account run stops cleanly on a quota hit instead of corrupting the whole grid.

## Why

The baseline runs (#299) exposed the real single-account failure mode (no maxmanager): the agent keeps getting **429 `rejected`** rate-limit events, each recorded as a degraded FAIL, so a full sweep burns into ~50–60% rate-limited garbage (observed: **claude 309/494, codex 248/494**) that then has to be quarantined and re-run.

## Behavior

When an agent turn comes back **account-limited** (HTTP 429 / `rejected` rate_limit_event / usage-limit), the image runtime:
1. **backs off** — stop event set, no new instances launched, in-flight drains;
2. **grades the clean work** already captured (not wasted);
3. **leaves the throttled instances PENDING** so `--resume` re-runs only them;
4. raises `AccountLimitHalt` → `run.py` prints `⏸ PAUSED on account rate-limit` with the resume command and exits **3** (clean, no traceback).

**No auto-retry** — the operator approves the resume once quota recovers (or maxmanager rotates credentials).

## Details

- `run_audit.is_account_limited()` reuses the tested classifier, so the 429-detection rule is single-sourced. A quota rejection is treated distinctly from a task FAIL or a non-quota `api_error` (401/500).
- `--halt-on-rate-limit/--no-halt-on-rate-limit` (default **on**). `--no-halt` keeps the old record-and-continue behavior.
- Asymmetry by design: **disk-full** raises *before* grading (grading needs disk); **rate-limit** raises *after* grading (grading is local Docker, unaffected by the API quota).

## Tests

`tests/test_image_run.py`: halt grades clean + leaves limited PENDING + raises `AccountLimitHalt`; `--no-halt` records 429s as before; `is_account_limited` helper. 65 image_run/run/audit tests pass.

Pairs with #359 (audit) and #360 (parallelism + resume): the run now self-pauses on quota, and the audit catches any stragglers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)