### PR TITLE
fix(audit): don't flag overageStatus as a rate-limit (false positives)

### DIFF
--- a/swebench/run_audit.py
+++ b/swebench/run_audit.py
@@ -196,10 +196,15 @@ def _classify_claude(objs: list[dict], raw: str, arm: str | None) -> tuple[str, 
     fired: list[str] = []
     reasons: list[str] = []
 
-    # Rate-limit events: the request was served unless the status says otherwise.
-    # ``allowed`` and ``allowed_warning`` (allowed, but near the cap) both mean the
-    # call went through — only a non-``allowed*`` status (e.g. "rejected",
-    # "blocked", "exceeded") indicates the turn was actually throttled.
+    # Rate-limit events: the request was served unless the **primary** status says
+    # otherwise. ``allowed`` and ``allowed_warning`` (allowed, but near the cap)
+    # both mean the call went through — only a non-``allowed*`` status (e.g.
+    # "rejected", "blocked", "exceeded") means the turn was actually throttled.
+    #
+    # ``overageStatus`` is NOT checked: it reports whether *overage* (pay-as-you-go
+    # beyond the plan) is enabled, so ``overageStatus: rejected`` with
+    # ``status: allowed`` is a normal served request on a plan without overage —
+    # flagging it produced false-positive quarantines (django-13121/13964).
     def _is_served(val: object) -> bool:
         return val is None or str(val).startswith("allowed") or val == "disabled"
 
@@ -210,10 +215,6 @@ def _classify_claude(objs: list[dict], raw: str, arm: str | None) -> tuple[str, 
             if not _is_served(status):
                 fired.append(RATE_LIMITED)
                 reasons.append(f"rate_limit_event.status={status!r}")
-            over = info.get("overageStatus")
-            if not _is_served(over):
-                fired.append(RATE_LIMITED)
-                reasons.append(f"rate_limit_event.overageStatus={over!r}")
 
     # Wall-time kill (runner writes a system/wall_timeout line).
     for o in objs:

--- a/tests/test_run_audit.py
+++ b/tests/test_run_audit.py
@@ -90,11 +90,20 @@ def test_claude_rate_limited_rejected(tmp_path):
     assert a.needs_rerun
 
 
-def test_claude_overage_rejected(tmp_path):
+def test_claude_overage_rejected_but_served_is_ok(tmp_path):
+    # overageStatus reports whether pay-as-you-go overage is enabled; "rejected"
+    # with status "allowed" is a normal served request on a plan without overage,
+    # NOT a throttle (regression: this previously false-flagged as rate_limited).
     p = _claude_jsonl(tmp_path, "x__x-1_baseline_run0.jsonl",
                       [_claude_meta(), _rate_event("allowed", overage="rejected"),
                        _claude_result()])
-    assert classify_run(p).status == RATE_LIMITED
+    assert classify_run(p).status == OK
+
+    # But a genuine throttle — primary status rejected — is still caught.
+    p2 = _claude_jsonl(tmp_path, "x__x-2_baseline_run0.jsonl",
+                       [_claude_meta(), _rate_event("rejected", overage="rejected"),
+                        _claude_result(is_error=True, api_error_status=429)])
+    assert classify_run(p2).status == RATE_LIMITED
 
 
 def test_claude_is_error_is_api_error(tmp_path):


### PR DESCRIPTION
Found while investigating why the Claude baseline run was hard-blocked.

## The investigation

The active Claude credential is **valid** (Max 20x, not expired) — but the account **genuinely hit its 5-hour cap**: 306 runs show `status: rejected` + HTTP 429 + `is_error`, resetting at 19:20. The maxmanager rotation pool is stale (the `hongy`/`hongy2` profiles expired Apr 17, others have no creds), so there's no fresh account to rotate to — that's the real blocker, not the audit.

## The bug this fixes

While breaking down the 316 quarantined Claude runs, the audit's `overageStatus` check produced **2 false positives**: `django-13121` and `django-13964` had `overageStatus: rejected` with `status: allowed` and a clean result — i.e. **served requests**, wrongly quarantined.

`overageStatus` reports whether *overage* (pay-as-you-go beyond the plan) is enabled. `rejected` there just means overage is off; with `status: allowed` the request went through. Only the **primary `status`** (`allowed` / `allowed_warning` / `rejected`) indicates an actual throttle.

## Change

`run_audit`: stop flagging on `overageStatus`; key only on `status`. Genuine throttles (`status: rejected`, the 306 real ones) are still caught.

Reclaimed the 2 false-positives from quarantine locally (baseline_claude: 178 → 180 clean).

## Tests

`test_run_audit.py`: `overageStatus: rejected` + `status: allowed` → OK; `status: rejected` + 429 → still rate_limited. 44 audit/image_run tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)